### PR TITLE
Fix: Align Python versions and update actions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Set up Conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v3.1.1
       with:
-        auto-activate-base: true
-        python-version: '3.10'
+        python-version: '3.11'
         activate-environment: geist-linux-docker
         environment-file: linux_environment_x86_x64.yml
 
@@ -40,7 +39,7 @@ jobs:
     needs: test
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
This commit addresses potential issues in the GitHub Actions CI workflow:

- Aligns Python version: Sets Python to 3.11 in both the 'Set up Python' step and the 'Set up Conda' step. This resolves a mismatch where the workflow was trying to use Python 3.10 with a Conda environment expecting Python 3.11.
- Updates GitHub Actions:
    - `actions/checkout` updated from `v3` to `v4`.
    - `actions/setup-python` updated from `v4` to `v5`.
    - `conda-incubator/setup-miniconda` updated from `v3` to `v3.1.1`.
- Simplifies Conda activation: Removed `auto-activate-base: true` to rely on `activate-environment` for more straightforward environment activation.

These changes are intended to resolve test failures in the CI pipeline.