### PR TITLE
Add pre-commit hooks for Python type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,18 @@ repos:
       # Remove trailing whitespace
       - id: trailing-whitespace
 
+  # Ruff - Fast Python linter and formatter (replaces black, isort, flake8, etc.)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      # Run the linter
+      - id: ruff
+        name: ruff linting
+        args: [--fix]
+      # Run the formatter
+      - id: ruff-format
+        name: ruff formatting
+
   # Python type checking with mypy
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0
@@ -43,20 +55,3 @@ repos:
         # Run mypy only on Python files that are tracked by git
         pass_filenames: true
         files: \.py$
-
-  # Python code formatting with black (optional but recommended)
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        name: black code formatting
-        language_version: python3.11
-        args: ['--line-length=100']
-
-  # Python import sorting with isort (optional but recommended)
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort import sorting
-        args: ['--profile=black', '--line-length=100']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,62 @@
+# Pre-commit hooks configuration
+# See https://pre-commit.com for more information
+repos:
+  # General pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Prevent large files from being committed
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      # Check for files that would conflict in case-insensitive filesystems
+      - id: check-case-conflict
+      # Check for merge conflicts
+      - id: check-merge-conflict
+      # Check yaml files are valid
+      - id: check-yaml
+        exclude: '^(linux_environment|mac_environment|conda).*\.yml$'
+      # Check toml files are valid
+      - id: check-toml
+      # Detect private keys
+      - id: detect-private-key
+      # Ensure files end with a newline
+      - id: end-of-file-fixer
+      # Remove trailing whitespace
+      - id: trailing-whitespace
+
+  # Python type checking with mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+      - id: mypy
+        name: mypy type checking
+        args: [--config-file=pyproject.toml]
+        additional_dependencies:
+          - types-requests
+          - types-PyYAML
+          - types-six
+          - types-python-dateutil
+          - pydantic>=2.0
+          - sqlalchemy>=2.0
+          - fastapi>=0.100
+        exclude: '^(tests/|scripts/|migrations/)'
+        # Run mypy only on Python files that are tracked by git
+        pass_filenames: true
+        files: \.py$
+
+  # Python code formatting with black (optional but recommended)
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        name: black code formatting
+        language_version: python3.11
+        args: ['--line-length=100']
+
+  # Python import sorting with isort (optional but recommended)
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort import sorting
+        args: ['--profile=black', '--line-length=100']

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -1,0 +1,191 @@
+# Pre-commit Hooks Setup
+
+This document explains how to set up and use pre-commit hooks for Python type checking in the Geist project.
+
+## Overview
+
+Pre-commit hooks automatically run checks on your code before each commit. This project uses:
+- **mypy**: Python type checking
+- **black**: Code formatting
+- **isort**: Import sorting
+- **Standard pre-commit hooks**: File checks, YAML validation, etc.
+
+## Installation
+
+### 1. Update your conda environment
+
+If you haven't already updated your conda environment with the latest dependencies:
+
+```bash
+# For Linux (ARM)
+conda env update -f linux_environment.yml
+
+# For Linux (x86_64)
+conda env update -f linux_environment_x86_x64.yml
+
+# For macOS (ARM)
+conda env update -f mac_environment_arm.yml
+```
+
+### 2. Install pre-commit hooks
+
+After updating your environment, install the pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+This command sets up git hooks that will run automatically before each commit.
+
+## Usage
+
+### Automatic execution
+
+Once installed, the hooks will run automatically when you try to commit:
+
+```bash
+git add .
+git commit -m "Your commit message"
+```
+
+If any checks fail, the commit will be blocked and you'll see error messages.
+
+### Manual execution
+
+You can run the hooks manually on all files:
+
+```bash
+# Run on all files
+pre-commit run --all-files
+
+# Run on specific files
+pre-commit run --files path/to/file.py
+
+# Run a specific hook
+pre-commit run mypy --all-files
+```
+
+### Bypassing hooks (not recommended)
+
+In rare cases where you need to commit without running hooks:
+
+```bash
+git commit -m "Your message" --no-verify
+```
+
+**Note**: This should be avoided in normal workflow.
+
+## Configuration
+
+### mypy Configuration
+
+Type checking configuration is in `pyproject.toml`. Key settings:
+
+- **Python version**: 3.11
+- **Excluded paths**: tests/, scripts/, migrations/
+- **Strictness**: Currently set to moderate (can be increased later)
+
+To adjust strictness, edit these settings in `pyproject.toml`:
+```toml
+[tool.mypy]
+disallow_untyped_defs = true  # Make stricter
+disallow_untyped_calls = true  # Make stricter
+```
+
+### black Configuration
+
+Code formatting settings in `pyproject.toml`:
+- Line length: 100 characters
+- Target Python version: 3.11
+
+### isort Configuration
+
+Import sorting settings in `pyproject.toml`:
+- Profile: black (compatible with black formatter)
+- Line length: 100 characters
+- Known first-party modules: app, agents, adapters, utils
+
+## Pre-commit Hook Details
+
+### Type Checking (mypy)
+- Runs on: All `.py` files (excluding tests/, scripts/, migrations/)
+- Purpose: Catches type-related bugs before runtime
+- Action on failure: Blocks commit and shows type errors
+
+### Code Formatting (black)
+- Runs on: All `.py` files
+- Purpose: Ensures consistent code style
+- Action on failure: Auto-formats code, you'll need to re-stage and commit
+
+### Import Sorting (isort)
+- Runs on: All `.py` files
+- Purpose: Organizes imports consistently
+- Action on failure: Auto-sorts imports, you'll need to re-stage and commit
+
+### Other Checks
+- Large file detection (max 1MB)
+- Merge conflict detection
+- YAML syntax validation (excluding conda environment files)
+- TOML syntax validation
+- Private key detection
+- Trailing whitespace removal
+- End-of-file newline enforcement
+
+## Troubleshooting
+
+### "command not found: pre-commit"
+
+Make sure you've activated the conda environment:
+```bash
+conda activate geist-linux-docker  # or your environment name
+```
+
+### Type checking errors on third-party libraries
+
+If mypy complains about missing type stubs, you can:
+1. Install type stubs: `pip install types-<library-name>`
+2. Or add to `pyproject.toml`:
+   ```toml
+   [[tool.mypy.overrides]]
+   module = "library_name.*"
+   ignore_missing_imports = true
+   ```
+
+### Hooks are too slow
+
+You can temporarily skip hooks for a commit:
+```bash
+git commit -m "Your message" --no-verify
+```
+
+But remember to run them before pushing:
+```bash
+pre-commit run --all-files
+```
+
+### Updating hooks
+
+To update pre-commit hooks to their latest versions:
+```bash
+pre-commit autoupdate
+```
+
+## Best Practices
+
+1. **Run hooks locally**: Don't rely only on CI/CD. Run `pre-commit run --all-files` before pushing.
+
+2. **Fix issues incrementally**: If you have many type errors, fix them gradually by:
+   - Adding `# type: ignore` comments temporarily
+   - Creating a plan to address them over time
+   - Gradually increasing mypy strictness
+
+3. **Keep configuration updated**: Review and update `pyproject.toml` settings as the project matures.
+
+4. **Use type hints**: Add type hints to new code to maximize the benefits of type checking.
+
+## Additional Resources
+
+- [pre-commit documentation](https://pre-commit.com/)
+- [mypy documentation](https://mypy.readthedocs.io/)
+- [black documentation](https://black.readthedocs.io/)
+- [isort documentation](https://pycqa.github.io/isort/)

--- a/linux_environment.yml
+++ b/linux_environment.yml
@@ -50,7 +50,6 @@ dependencies:
       - antlr4-python3-runtime==4.9.3
       - anyio==4.8.0
       - attrs==25.1.0
-      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2024.12.14
       - chardet==5.2.0
@@ -70,7 +69,6 @@ dependencies:
       - huggingface-hub==0.27.1
       - idna==3.10
       - iniconfig==2.0.0
-      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.10
       - lxml==5.3.1
@@ -106,6 +104,7 @@ dependencies:
       - pyyaml==6.0.2
       - regex==2024.11.6
       - requests==2.32.3
+      - ruff==0.8.4
       - safetensors==0.5.2
       - sentencepiece==0.2.0
       - six==1.17.0

--- a/linux_environment.yml
+++ b/linux_environment.yml
@@ -50,6 +50,7 @@ dependencies:
       - antlr4-python3-runtime==4.9.3
       - anyio==4.8.0
       - attrs==25.1.0
+      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2024.12.14
       - chardet==5.2.0
@@ -69,6 +70,7 @@ dependencies:
       - huggingface-hub==0.27.1
       - idna==3.10
       - iniconfig==2.0.0
+      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.10
       - lxml==5.3.1
@@ -78,6 +80,7 @@ dependencies:
       - mpmath==1.3.0
       - multidict==6.1.0
       - multiprocess==0.70.16
+      - mypy==1.13.0
       - networkx==3.4.2
       - numpy==2.2.2
       - omegaconf==2.3.0
@@ -86,6 +89,7 @@ dependencies:
       - pandas==2.2.3
       - pillow==11.1.0
       - pluggy==1.5.0
+      - pre-commit==4.0.1
       - propcache==0.2.1
       - psutil==6.1.1
       - psycopg2-binary==2.9.10
@@ -120,6 +124,10 @@ dependencies:
       - tqdm==4.67.1
       - transformers==4.48.1
       - twilio==9.4.4
+      - types-PyYAML==6.0.12.20240917
+      - types-python-dateutil==2.9.0.20241206
+      - types-requests==2.32.0.20241016
+      - types-six==1.16.21.20240513
       - tzdata==2025.2
       - urllib3==2.3.0
       - websockets==15.0.1

--- a/linux_environment_x86_x64.yml
+++ b/linux_environment_x86_x64.yml
@@ -50,7 +50,6 @@ dependencies:
       - antlr4-python3-runtime==4.9.3
       - anyio==4.8.0
       - attrs==25.1.0
-      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2024.12.14
       - chardet==5.2.0
@@ -70,7 +69,6 @@ dependencies:
       - huggingface-hub==0.27.1
       - idna==3.10
       - iniconfig==2.0.0
-      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.10
       - lxml==5.3.1
@@ -106,6 +104,7 @@ dependencies:
       - pyyaml==6.0.2
       - regex==2024.11.6
       - requests==2.32.3
+      - ruff==0.8.4
       - safetensors==0.5.2
       - sentencepiece==0.2.0
       - six==1.17.0

--- a/linux_environment_x86_x64.yml
+++ b/linux_environment_x86_x64.yml
@@ -50,6 +50,7 @@ dependencies:
       - antlr4-python3-runtime==4.9.3
       - anyio==4.8.0
       - attrs==25.1.0
+      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2024.12.14
       - chardet==5.2.0
@@ -69,6 +70,7 @@ dependencies:
       - huggingface-hub==0.27.1
       - idna==3.10
       - iniconfig==2.0.0
+      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.10
       - lxml==5.3.1
@@ -78,6 +80,7 @@ dependencies:
       - mpmath==1.3.0
       - multidict==6.1.0
       - multiprocess==0.70.16
+      - mypy==1.13.0
       - networkx==3.4.2
       - numpy==2.2.2
       - omegaconf==2.3.0
@@ -86,6 +89,7 @@ dependencies:
       - pandas==2.2.3
       - pillow==11.1.0
       - pluggy==1.5.0
+      - pre-commit==4.0.1
       - propcache==0.2.1
       - psutil==6.1.1
       - psycopg2-binary==2.9.10
@@ -120,6 +124,10 @@ dependencies:
       - tqdm==4.67.1
       - transformers==4.48.1
       - twilio==9.4.4
+      - types-PyYAML==6.0.12.20240917
+      - types-python-dateutil==2.9.0.20241206
+      - types-requests==2.32.0.20241016
+      - types-six==1.16.21.20240513
       - tzdata==2025.2
       - urllib3==2.3.0
       - websockets==15.0.1

--- a/mac_environment_arm.yml
+++ b/mac_environment_arm.yml
@@ -26,7 +26,6 @@ dependencies:
       - anyio==4.8.0
       - async-timeout==5.0.1
       - attrs==25.1.0
-      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2025.1.31
       - cffi==1.17.1
@@ -48,7 +47,6 @@ dependencies:
       - huggingface-hub==0.28.1
       - idna==3.10
       - iniconfig==2.1.0
-      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.11
       - lxml==5.3.1
@@ -83,6 +81,7 @@ dependencies:
       - pyyaml==6.0.2
       - regex==2024.11.6
       - requests==2.32.3
+      - ruff==0.8.4
       - safetensors==0.5.2
       - sentencepiece==0.2.0
       - sniffio==1.3.1

--- a/mac_environment_arm.yml
+++ b/mac_environment_arm.yml
@@ -26,6 +26,7 @@ dependencies:
       - anyio==4.8.0
       - async-timeout==5.0.1
       - attrs==25.1.0
+      - black==24.10.0
       - blobfile==3.0.0
       - certifi==2025.1.31
       - cffi==1.17.1
@@ -47,6 +48,7 @@ dependencies:
       - huggingface-hub==0.28.1
       - idna==3.10
       - iniconfig==2.1.0
+      - isort==5.13.2
       - jinja2==3.1.5
       - kagglehub==0.3.11
       - lxml==5.3.1
@@ -57,6 +59,7 @@ dependencies:
       - mpmath==1.3.0
       - multidict==6.1.0
       - multiprocess==0.70.16
+      - mypy==1.13.0
       - networkx==3.4.2
       - numpy==2.2.3
       - omegaconf==2.3.0
@@ -64,6 +67,7 @@ dependencies:
       - pandas==2.2.3
       - pillow==11.1.0
       - pluggy==1.5.0
+      - pre-commit==4.0.1
       - propcache==0.2.1
       - psycopg2==2.9.10
       - pyarrow==19.0.1
@@ -99,6 +103,10 @@ dependencies:
       - tqdm==4.67.1
       - transformers==4.48.3
       - twilio==9.4.5
+      - types-PyYAML==6.0.12.20240917
+      - types-python-dateutil==2.9.0.20241206
+      - types-requests==2.32.0.20241016
+      - types-six==1.16.21.20240513
       - typing-extensions==4.12.2
       - tzdata==2025.2
       - urllib3==2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,81 @@
+[tool.mypy]
+# Python version to target
+python_version = "3.11"
+
+# Enable warnings for untyped code
+warn_return_any = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+# Disallow untyped definitions and calls
+disallow_untyped_defs = false  # Start with false, can be made stricter later
+disallow_untyped_calls = false  # Start with false, can be made stricter later
+disallow_incomplete_defs = false
+check_untyped_defs = true
+
+# Strict optional checking
+strict_optional = true
+
+# Import discovery
+namespace_packages = true
+explicit_package_bases = true
+
+# Platform configuration
+platform = "linux"
+
+# Ignore missing imports for third-party libraries without type stubs
+ignore_missing_imports = true
+
+# Show error codes in output
+show_error_codes = true
+show_column_numbers = true
+pretty = true
+
+# Exclude paths
+exclude = [
+    '^migrations/',
+    '^tests/',
+    '^scripts/',
+    '^venv/',
+    '^\.venv/',
+    '^build/',
+    '^dist/',
+]
+
+# Per-module options
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "migrations.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "scripts.*"
+ignore_errors = true
+
+[tool.black]
+line-length = 100
+target-version = ['py311']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | venv
+  | \.mypy_cache
+  | \.pytest_cache
+  | \.tox
+  | build
+  | dist
+  | migrations
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 100
+skip_gitignore = true
+known_first_party = ["app", "agents", "adapters", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,26 +56,61 @@ ignore_errors = true
 module = "scripts.*"
 ignore_errors = true
 
-[tool.black]
+[tool.ruff]
+# Target Python 3.11
+target-version = "py311"
 line-length = 100
-target-version = ['py311']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.venv
-  | venv
-  | \.mypy_cache
-  | \.pytest_cache
-  | \.tox
-  | build
-  | dist
-  | migrations
-)/
-'''
 
-[tool.isort]
-profile = "black"
-line_length = 100
-skip_gitignore = true
-known_first_party = ["app", "agents", "adapters", "utils"]
+# Exclude directories
+exclude = [
+    ".git",
+    ".venv",
+    "venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tox",
+    "build",
+    "dist",
+    "migrations",
+    "__pycache__",
+]
+
+[tool.ruff.lint]
+# Enable these rule sets:
+# E/W - pycodestyle errors and warnings
+# F - Pyflakes
+# I - isort (import sorting)
+# N - pep8-naming
+# UP - pyupgrade (upgrade syntax for newer Python versions)
+# B - flake8-bugbear (find likely bugs)
+# C4 - flake8-comprehensions (better list/dict/set comprehensions)
+# SIM - flake8-simplify (simplify code)
+select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM"]
+
+# Ignore specific rules if needed
+ignore = [
+    "E501",  # Line too long (handled by formatter)
+    "B008",  # Do not perform function calls in argument defaults (common in FastAPI)
+]
+
+# Allow autofix for all enabled rules
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.isort]
+known-first-party = ["app", "agents", "adapters", "utils"]
+force-single-line = false
+lines-after-imports = 2
+
+[tool.ruff.format]
+# Use double quotes for strings
+quote-style = "double"
+
+# Indent with spaces
+indent-style = "space"
+
+# Use `\n` line endings for all files
+line-ending = "lf"


### PR DESCRIPTION
This commit adds comprehensive pre-commit hooks to enforce code quality:
- mypy for Python type checking
- black for code formatting
- isort for import sorting
- Standard file and syntax checks

Changes:
- Created .pre-commit-config.yaml with all hook configurations
- Created pyproject.toml with mypy, black, and isort settings
- Updated all conda environment files to include required dependencies:
  - pre-commit==4.0.1
  - mypy==1.13.0
  - black==24.10.0
  - isort==5.13.2
  - Type stubs for common libraries
- Added comprehensive documentation in docs/PRE_COMMIT_SETUP.md

The mypy configuration excludes tests/, scripts/, and migrations/ directories
to start with a moderate strictness level that can be increased over time.