### PR TITLE
[codex] Add injectable SQLAlchemy providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ flowchart LR
 ```
 
 # Versioning and Setup
-## Install Postgresql
-1. Version 16.2 on Mac or Windows
+## Install PostgreSQL
+PostgreSQL is the default database provider. Install version 16.2 on Mac or Windows when using the default provider.
 
 ## Install Miniconda
 1. Create a python 3.10 environment solve and install with windows_x64_environment.yml or mac_arm_environment.yml
@@ -63,6 +63,21 @@ flowchart LR
     - DB_HOST = localhost
     - HUGGING_FACE_HUB_TOKEN = TOKEN_VALUE
     - LOCAL_WEIGHTS_DIR = WHERE_YOUR_WEIGHTS_ARE (non docker mount)
+
+### Database provider configuration
+
+Select the SQLAlchemy provider with `GEIST_DATABASE_PROVIDER`. PostgreSQL remains the default and continues to use the existing `POSTGRES_*`, `DB_HOST`, and `DB_PORT` settings.
+
+To use a local SQLite database instead:
+
+```bash
+GEIST_DATABASE_PROVIDER=sqlite
+SQLITE_DATABASE_PATH=/absolute/path/to/geist.sqlite3
+```
+
+`SQLITE_DATABASE_URL` can be used instead of `SQLITE_DATABASE_PATH`. `SQLALCHEMY_DATABASE_URL` overrides provider-specific URL construction when its URL scheme matches the selected provider.
+
+Tests and alternate application entry points can inject `DatabaseConfig(provider=..., database_url=...)` directly into `configure_database()` without changing environment variables.
 
 2. Copy any model weights into app/models/weights/MODEL_NAME.
     - Currently supported Models: llama_3_1
@@ -94,7 +109,6 @@ client/geist/.env settings:
 ## Scripts 
 1. scripts/download_models.py - download models from huggingface.
 2. scripts/copy_weights.py - copy weights from desktop to /app/models/weights/. Used for weights that are not hosted on huggingface. 
-
 
 
 

--- a/app/models/database/agent_preset.py
+++ b/app/models/database/agent_preset.py
@@ -1,8 +1,10 @@
 import datetime
-from sqlalchemy import Column, Integer, String, ForeignKey, LargeBinary, DateTime, Boolean, ARRAY, DateTime
+from sqlalchemy import ARRAY, Boolean, Column, DateTime, ForeignKey, Integer, JSON, LargeBinary, String
 from sqlalchemy.orm import relationship, Session
 from app.models.database.database import Base, Session
 from sqlalchemy.dialects.postgresql import insert
+
+StringList = JSON().with_variant(ARRAY(String), "postgresql")
 
 class AgentPreset(Base):
     """
@@ -105,8 +107,7 @@ class Restriction(Base):
     spending_limit = Column(Integer)
     restriction_type = Column(String)
     #allowed plugins and methods that an agent can use
-    allowed_plugins = Column(ARRAY(String))
-    allowed_methods = Column(ARRAY(String))
+    allowed_plugins = Column(StringList)
+    allowed_methods = Column(StringList)
     create_date = Column(DateTime)
     update_date = Column(DateTime)
-

--- a/app/models/database/database.py
+++ b/app/models/database/database.py
@@ -1,24 +1,101 @@
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from dotenv import load_dotenv
 import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine as SqlAlchemyEngine
+from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 
 load_dotenv()
 
-# Use environment variables set in docker-compose.yml
-DB_NAME = os.getenv("POSTGRES_DB", "geist")
-DB_USER = os.getenv("POSTGRES_USER", "geist")
-DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "geist")
-DB_HOST = os.getenv("DB_HOST", "db")
-DB_PORT = os.getenv("DB_PORT", "5432")
+DEFAULT_SQLITE_DATABASE_PATH = "data/geist.sqlite3"
 
-# Construct the database URL
-SQLALCHEMY_DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
-# Instantiate database engine and session
-Engine = create_engine(SQLALCHEMY_DATABASE_URL)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=Engine)
-Session = SessionLocal()
+def _postgres_database_url() -> str:
+    # Use environment variables set in docker-compose.yml.
+    db_name = os.getenv("POSTGRES_DB", "geist")
+    db_user = os.getenv("POSTGRES_USER", "geist")
+    db_password = os.getenv("POSTGRES_PASSWORD", "geist")
+    db_host = os.getenv("DB_HOST", "db")
+    db_port = os.getenv("DB_PORT", "5432")
+    return f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+
+
+def _sqlite_database_url() -> str:
+    sqlite_url = os.getenv("SQLITE_DATABASE_URL")
+    if sqlite_url:
+        return sqlite_url
+
+    sqlite_path = Path(os.getenv("SQLITE_DATABASE_PATH", DEFAULT_SQLITE_DATABASE_PATH))
+    if not sqlite_path.is_absolute():
+        sqlite_path = Path.cwd() / sqlite_path
+    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite:///{sqlite_path}"
+
+
+def _database_config(
+    backend: Optional[str] = None,
+    database_url: Optional[str] = None,
+) -> Tuple[str, str]:
+    explicit_database_url = database_url or os.getenv("SQLALCHEMY_DATABASE_URL")
+    if explicit_database_url:
+        explicit_backend = explicit_database_url.split(":", 1)[0]
+        if explicit_backend.startswith("sqlite"):
+            explicit_backend = "sqlite"
+        return explicit_database_url, explicit_backend
+
+    selected_backend = (backend or os.getenv("GEIST_DATABASE_BACKEND") or os.getenv("DB_BACKEND") or "postgresql").lower()
+    if selected_backend in {"sqlite", "sqlite3"}:
+        return _sqlite_database_url(), "sqlite"
+
+    return _postgres_database_url(), "postgresql"
+
+
+def _create_engine(database_url: str, backend: str) -> SqlAlchemyEngine:
+    connect_args = {"check_same_thread": False} if backend == "sqlite" else {}
+    engine = create_engine(database_url, connect_args=connect_args)
+
+    if backend == "sqlite":
+        @event.listens_for(engine, "connect")
+        def set_sqlite_pragma(dbapi_connection, _connection_record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+    return engine
+
+
+SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND = _database_config()
+
+Engine = _create_engine(SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND)
+_session_factory = sessionmaker(autocommit=False, autoflush=False, bind=Engine)
+SessionLocal = _session_factory
+Session = scoped_session(_session_factory)
 
 Base = declarative_base()
+
+
+def configure_database(
+    database_url: Optional[str] = None,
+    backend: Optional[str] = None,
+) -> SqlAlchemyEngine:
+    """
+    Rebind the process-wide SQLAlchemy session factory.
+
+    This is primarily used by tests and alternate storage configurations. Keeping
+    the same session factory lets existing model modules continue using their
+    imported SessionLocal object after the engine changes.
+    """
+    global SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND, Engine
+
+    Session.remove()
+    Engine.dispose()
+
+    SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND = _database_config(
+        backend=backend,
+        database_url=database_url,
+    )
+    Engine = _create_engine(SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND)
+    _session_factory.configure(bind=Engine)
+    return Engine

--- a/app/models/database/database.py
+++ b/app/models/database/database.py
@@ -1,74 +1,23 @@
-import os
-from pathlib import Path
-from typing import Optional, Tuple
-
 from dotenv import load_dotenv
-from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine as SqlAlchemyEngine
 from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 
+from app.models.database.database_config import (
+    DEFAULT_DATABASE_PROVIDERS,
+    DatabaseConfig,
+    DatabaseProviderRegistry,
+    create_database_engine,
+    load_database_config,
+)
+
 load_dotenv()
 
-DEFAULT_SQLITE_DATABASE_PATH = "data/geist.sqlite3"
+DATABASE_CONFIG = load_database_config()
+SQLALCHEMY_DATABASE_URL = DATABASE_CONFIG.database_url
+DATABASE_PROVIDER = DATABASE_CONFIG.provider
+DATABASE_BACKEND = DATABASE_PROVIDER
 
-
-def _postgres_database_url() -> str:
-    # Use environment variables set in docker-compose.yml.
-    db_name = os.getenv("POSTGRES_DB", "geist")
-    db_user = os.getenv("POSTGRES_USER", "geist")
-    db_password = os.getenv("POSTGRES_PASSWORD", "geist")
-    db_host = os.getenv("DB_HOST", "db")
-    db_port = os.getenv("DB_PORT", "5432")
-    return f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
-
-
-def _sqlite_database_url() -> str:
-    sqlite_url = os.getenv("SQLITE_DATABASE_URL")
-    if sqlite_url:
-        return sqlite_url
-
-    sqlite_path = Path(os.getenv("SQLITE_DATABASE_PATH", DEFAULT_SQLITE_DATABASE_PATH))
-    if not sqlite_path.is_absolute():
-        sqlite_path = Path.cwd() / sqlite_path
-    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
-    return f"sqlite:///{sqlite_path}"
-
-
-def _database_config(
-    backend: Optional[str] = None,
-    database_url: Optional[str] = None,
-) -> Tuple[str, str]:
-    explicit_database_url = database_url or os.getenv("SQLALCHEMY_DATABASE_URL")
-    if explicit_database_url:
-        explicit_backend = explicit_database_url.split(":", 1)[0]
-        if explicit_backend.startswith("sqlite"):
-            explicit_backend = "sqlite"
-        return explicit_database_url, explicit_backend
-
-    selected_backend = (backend or os.getenv("GEIST_DATABASE_BACKEND") or os.getenv("DB_BACKEND") or "postgresql").lower()
-    if selected_backend in {"sqlite", "sqlite3"}:
-        return _sqlite_database_url(), "sqlite"
-
-    return _postgres_database_url(), "postgresql"
-
-
-def _create_engine(database_url: str, backend: str) -> SqlAlchemyEngine:
-    connect_args = {"check_same_thread": False} if backend == "sqlite" else {}
-    engine = create_engine(database_url, connect_args=connect_args)
-
-    if backend == "sqlite":
-        @event.listens_for(engine, "connect")
-        def set_sqlite_pragma(dbapi_connection, _connection_record):
-            cursor = dbapi_connection.cursor()
-            cursor.execute("PRAGMA foreign_keys=ON")
-            cursor.close()
-
-    return engine
-
-
-SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND = _database_config()
-
-Engine = _create_engine(SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND)
+Engine = create_database_engine(DATABASE_CONFIG)
 _session_factory = sessionmaker(autocommit=False, autoflush=False, bind=Engine)
 SessionLocal = _session_factory
 Session = scoped_session(_session_factory)
@@ -77,8 +26,8 @@ Base = declarative_base()
 
 
 def configure_database(
-    database_url: Optional[str] = None,
-    backend: Optional[str] = None,
+    config: DatabaseConfig,
+    registry: DatabaseProviderRegistry = DEFAULT_DATABASE_PROVIDERS,
 ) -> SqlAlchemyEngine:
     """
     Rebind the process-wide SQLAlchemy session factory.
@@ -87,15 +36,15 @@ def configure_database(
     the same session factory lets existing model modules continue using their
     imported SessionLocal object after the engine changes.
     """
-    global SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND, Engine
+    global DATABASE_CONFIG, SQLALCHEMY_DATABASE_URL, DATABASE_PROVIDER, DATABASE_BACKEND, Engine
 
     Session.remove()
     Engine.dispose()
 
-    SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND = _database_config(
-        backend=backend,
-        database_url=database_url,
-    )
-    Engine = _create_engine(SQLALCHEMY_DATABASE_URL, DATABASE_BACKEND)
+    DATABASE_CONFIG = config
+    SQLALCHEMY_DATABASE_URL = config.database_url
+    DATABASE_PROVIDER = config.provider
+    DATABASE_BACKEND = DATABASE_PROVIDER
+    Engine = create_database_engine(config, registry=registry)
     _session_factory.configure(bind=Engine)
     return Engine

--- a/app/models/database/database_config.py
+++ b/app/models/database/database_config.py
@@ -1,0 +1,187 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional, Protocol, Sequence
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine as SqlAlchemyEngine
+from sqlalchemy.engine import make_url
+
+
+DEFAULT_SQLITE_DATABASE_PATH = "data/geist.sqlite3"
+DEFAULT_DATABASE_PROVIDER = "postgresql"
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    provider: str
+    database_url: str
+
+
+class DatabaseProvider(Protocol):
+    name: str
+    aliases: Sequence[str]
+
+    def build_database_url(self, environ: Mapping[str, str]) -> str:
+        ...
+
+    def create_engine(self, config: DatabaseConfig) -> SqlAlchemyEngine:
+        ...
+
+    def initialize_database(self, config: DatabaseConfig) -> None:
+        ...
+
+
+class PostgreSQLProvider:
+    name = "postgresql"
+    aliases = ("postgres", "postgresql")
+
+    def build_database_url(self, environ: Mapping[str, str]) -> str:
+        db_name = environ.get("POSTGRES_DB", "geist")
+        db_user = environ.get("POSTGRES_USER", "geist")
+        db_password = environ.get("POSTGRES_PASSWORD", "geist")
+        db_host = environ.get("DB_HOST", "db")
+        db_port = environ.get("DB_PORT", "5432")
+        return f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
+
+    def create_engine(self, config: DatabaseConfig) -> SqlAlchemyEngine:
+        return create_engine(config.database_url)
+
+    def initialize_database(self, config: DatabaseConfig) -> None:
+        from psycopg2 import connect, sql
+        from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+        database_url = make_url(config.database_url)
+        database_name = database_url.database or "geist"
+        connection = connect(
+            dbname="postgres",
+            user=database_url.username,
+            host=database_url.host,
+            port=database_url.port,
+            password=database_url.password,
+        )
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        cursor = connection.cursor()
+        try:
+            cursor.execute("SELECT 1 FROM pg_database WHERE datname = %s", (database_name,))
+            if cursor.fetchone():
+                print(f"Database '{database_name}' already exists")
+                return
+
+            cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
+            print(f"Database '{database_name}' created successfully")
+        finally:
+            cursor.close()
+            connection.close()
+
+
+class SQLiteProvider:
+    name = "sqlite"
+    aliases = ("sqlite", "sqlite3")
+
+    def build_database_url(self, environ: Mapping[str, str]) -> str:
+        configured_url = environ.get("SQLITE_DATABASE_URL")
+        if configured_url:
+            return configured_url
+
+        database_path = Path(environ.get("SQLITE_DATABASE_PATH", DEFAULT_SQLITE_DATABASE_PATH))
+        if not database_path.is_absolute():
+            database_path = Path.cwd() / database_path
+        return f"sqlite:///{database_path}"
+
+    def create_engine(self, config: DatabaseConfig) -> SqlAlchemyEngine:
+        self._ensure_parent_directory(config)
+        engine = create_engine(config.database_url, connect_args={"check_same_thread": False})
+
+        @event.listens_for(engine, "connect")
+        def set_sqlite_pragma(dbapi_connection, _connection_record):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        return engine
+
+    def initialize_database(self, config: DatabaseConfig) -> None:
+        self._ensure_parent_directory(config)
+
+    @staticmethod
+    def _ensure_parent_directory(config: DatabaseConfig) -> None:
+        database_path = make_url(config.database_url).database
+        if not database_path or database_path == ":memory:":
+            return
+        Path(database_path).parent.mkdir(parents=True, exist_ok=True)
+
+
+class DatabaseProviderRegistry:
+    def __init__(self, providers: Sequence[DatabaseProvider]):
+        self._providers = {}
+        for provider in providers:
+            for name in (provider.name, *provider.aliases):
+                self._providers[name.lower()] = provider
+
+    def get(self, name: str) -> DatabaseProvider:
+        normalized_name = name.lower()
+        if normalized_name not in self._providers:
+            available = ", ".join(sorted({provider.name for provider in self._providers.values()}))
+            raise ValueError(
+                f"Unknown database provider '{name}'. Available providers: {available}"
+            )
+        return self._providers[normalized_name]
+
+    def infer_from_url(self, database_url: str) -> DatabaseProvider:
+        driver_name = make_url(database_url).drivername.split("+", 1)[0]
+        return self.get(driver_name)
+
+
+DEFAULT_DATABASE_PROVIDERS = DatabaseProviderRegistry(
+    providers=(PostgreSQLProvider(), SQLiteProvider()),
+)
+
+
+def load_database_config(
+    provider: Optional[str] = None,
+    database_url: Optional[str] = None,
+    environ: Optional[Mapping[str, str]] = None,
+    registry: DatabaseProviderRegistry = DEFAULT_DATABASE_PROVIDERS,
+) -> DatabaseConfig:
+    environment = os.environ if environ is None else environ
+    selected_provider_name = (
+        provider
+        or environment.get("GEIST_DATABASE_PROVIDER")
+        or environment.get("GEIST_DATABASE_BACKEND")
+        or environment.get("DB_BACKEND")
+    )
+    selected_database_url = database_url or environment.get("SQLALCHEMY_DATABASE_URL")
+
+    if selected_database_url:
+        inferred_provider = registry.infer_from_url(selected_database_url)
+        selected_provider = (
+            registry.get(selected_provider_name) if selected_provider_name else inferred_provider
+        )
+        if selected_provider.name != inferred_provider.name:
+            raise ValueError(
+                f"Database provider '{selected_provider.name}' does not match URL "
+                f"provider '{inferred_provider.name}'"
+            )
+    else:
+        selected_provider = registry.get(selected_provider_name or DEFAULT_DATABASE_PROVIDER)
+        selected_database_url = selected_provider.build_database_url(environment)
+
+    return DatabaseConfig(
+        provider=selected_provider.name,
+        database_url=selected_database_url,
+    )
+
+
+def create_database_engine(
+    config: DatabaseConfig,
+    registry: DatabaseProviderRegistry = DEFAULT_DATABASE_PROVIDERS,
+) -> SqlAlchemyEngine:
+    return registry.get(config.provider).create_engine(config)
+
+
+def initialize_database(
+    config: DatabaseConfig,
+    registry: DatabaseProviderRegistry = DEFAULT_DATABASE_PROVIDERS,
+) -> None:
+    registry.get(config.provider).initialize_database(config)

--- a/initdb.py
+++ b/initdb.py
@@ -1,68 +1,61 @@
-from psycopg2 import connect, extensions, sql
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-from psycopg2.errors import DuplicateDatabase
-from psycopg2.extras import execute_values
+import importlib
+
 from dotenv import load_dotenv
-import os
+
+from app.models.database.database import Base, DATABASE_BACKEND, Engine
+
 
 load_dotenv()
 
-# Use environment variables set in docker-compose.yml
-DB_NAME = os.getenv("POSTGRES_DB", "geist")
-DB_USER = os.getenv("POSTGRES_USER", "geist")
-DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "geist")
-DB_HOST = os.getenv("DB_HOST", "db")
-DB_PORT = os.getenv("DB_PORT", "5432")
 
-# Connect to the default 'postgres' database first
-conn = connect(
-    dbname="postgres",
-    user=DB_USER,
-    host=DB_HOST,
-    port=DB_PORT,
-    password=DB_PASSWORD,
-)
-conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-cur = conn.cursor()
+def ensure_postgres_database() -> None:
+    import os
 
-# Check if database exists
-cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (DB_NAME,))
-exists = cur.fetchone()
+    from psycopg2 import connect, sql
+    from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
-if not exists:
-    try:
-        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(DB_NAME)))
-        print(f"Database '{DB_NAME}' created successfully")
-    except Exception as e:
-        print(f"An error occurred while creating the database: {e}")
-else:
-    print(f"Database '{DB_NAME}' already exists")
+    db_name = os.getenv("POSTGRES_DB", "geist")
+    db_user = os.getenv("POSTGRES_USER", "geist")
+    db_password = os.getenv("POSTGRES_PASSWORD", "geist")
+    db_host = os.getenv("DB_HOST", "db")
+    db_port = os.getenv("DB_PORT", "5432")
 
-cur.close()
-conn.close()
+    conn = connect(
+        dbname="postgres",
+        user=db_user,
+        host=db_host,
+        port=db_port,
+        password=db_password,
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = conn.cursor()
 
-# Now connect to the new database to create tables
-conn = connect(
-    dbname=DB_NAME,
-    user=DB_USER,
-    host=DB_HOST,
-    port=DB_PORT,
-    password=DB_PASSWORD,
-)
+    cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (db_name,))
+    exists = cur.fetchone()
 
-# Rest of your code...
-#database imports
-from app.models.database.database import Base
-from app.models.database.database import Engine
-# Import all models to register them with Base.metadata
-import app.models.database
+    if not exists:
+        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
+        print(f"Database '{db_name}' created successfully")
+    else:
+        print(f"Database '{db_name}' already exists")
 
-#create models if they do not exist
-Base.metadata.create_all(bind=Engine)
+    cur.close()
+    conn.close()
 
-#now, run all other idempotent insertion scripts
-from scripts.insert_presets import main as insert_presets
-# Add the 'overwrite' argument here. You may want to set this to False if you don't want to overwrite existing data
-insert_presets(to_commit=True, overwrite=False)
 
-conn.close()
+def main() -> None:
+    if DATABASE_BACKEND != "sqlite":
+        ensure_postgres_database()
+
+    # Import all models to register them with Base.metadata.
+    importlib.import_module("app.models.database")
+
+    Base.metadata.create_all(bind=Engine)
+
+    from scripts.insert_presets import main as insert_presets
+
+    insert_presets(to_commit=True, overwrite=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/initdb.py
+++ b/initdb.py
@@ -1,51 +1,11 @@
 import importlib
 
-from dotenv import load_dotenv
-
-from app.models.database.database import Base, DATABASE_BACKEND, Engine
-
-
-load_dotenv()
-
-
-def ensure_postgres_database() -> None:
-    import os
-
-    from psycopg2 import connect, sql
-    from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-
-    db_name = os.getenv("POSTGRES_DB", "geist")
-    db_user = os.getenv("POSTGRES_USER", "geist")
-    db_password = os.getenv("POSTGRES_PASSWORD", "geist")
-    db_host = os.getenv("DB_HOST", "db")
-    db_port = os.getenv("DB_PORT", "5432")
-
-    conn = connect(
-        dbname="postgres",
-        user=db_user,
-        host=db_host,
-        port=db_port,
-        password=db_password,
-    )
-    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-    cur = conn.cursor()
-
-    cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (db_name,))
-    exists = cur.fetchone()
-
-    if not exists:
-        cur.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(db_name)))
-        print(f"Database '{db_name}' created successfully")
-    else:
-        print(f"Database '{db_name}' already exists")
-
-    cur.close()
-    conn.close()
+from app.models.database.database import Base, DATABASE_CONFIG, Engine
+from app.models.database.database_config import initialize_database
 
 
 def main() -> None:
-    if DATABASE_BACKEND != "sqlite":
-        ensure_postgres_database()
+    initialize_database(DATABASE_CONFIG)
 
     # Import all models to register them with Base.metadata.
     importlib.import_module("app.models.database")

--- a/plans/151-SQLITE_STORAGE_ENGINE.md
+++ b/plans/151-SQLITE_STORAGE_ENGINE.md
@@ -1,0 +1,42 @@
+# SQLite Storage Engine Plan
+
+## Goal
+
+Add an opt-in SQLite persistence implementation for the existing SQLAlchemy database layer while keeping PostgreSQL as the default runtime backend.
+
+## Approach
+
+1. Extend `app.models.database.database` so it can build either:
+   - the current PostgreSQL engine from `POSTGRES_*` variables, or
+   - a SQLite engine from `GEIST_DATABASE_BACKEND=sqlite` plus `SQLITE_DATABASE_PATH` or `SQLITE_DATABASE_URL`.
+2. Preserve the current public API used throughout the codebase:
+   - `Engine`
+   - `SessionLocal`
+   - `Session`
+   - `Base`
+   - `SQLALCHEMY_DATABASE_URL`
+3. Make model declarations portable where they currently depend on PostgreSQL-specific types.
+4. Update database initialization so SQLite creates its file-backed database and tables without requiring `psycopg2` setup.
+5. Add unit tests that bind the application models to a temporary SQLite file and validate persistence across the existing model helper functions.
+
+## Verification
+
+1. Run focused SQLite unit tests locally.
+2. Run the repository Python tests that do not require model downloads or external API credentials.
+3. Start Docker with `docker compose up -d`, inspect backend logs for startup errors, and smoke test the frontend endpoint with `curl http://localhost:3000`.
+
+## Configuration
+
+PostgreSQL remains the default. To opt into SQLite:
+
+```bash
+GEIST_DATABASE_BACKEND=sqlite
+SQLITE_DATABASE_PATH=/opt/geist/data/geist.sqlite3
+```
+
+or:
+
+```bash
+GEIST_DATABASE_BACKEND=sqlite
+SQLITE_DATABASE_URL=sqlite:////opt/geist/data/geist.sqlite3
+```

--- a/plans/151-SQLITE_STORAGE_ENGINE.md
+++ b/plans/151-SQLITE_STORAGE_ENGINE.md
@@ -1,23 +1,26 @@
-# SQLite Storage Engine Plan
+# Injectable SQLAlchemy Provider Plan
 
 ## Goal
 
-Add an opt-in SQLite persistence implementation for the existing SQLAlchemy database layer while keeping PostgreSQL as the default runtime backend.
+Add a provider-neutral SQLAlchemy configuration layer that can select PostgreSQL or SQLite at runtime while keeping PostgreSQL as the default provider.
 
 ## Approach
 
-1. Extend `app.models.database.database` so it can build either:
-   - the current PostgreSQL engine from `POSTGRES_*` variables, or
-   - a SQLite engine from `GEIST_DATABASE_BACKEND=sqlite` plus `SQLITE_DATABASE_PATH` or `SQLITE_DATABASE_URL`.
-2. Preserve the current public API used throughout the codebase:
+1. Add an immutable `DatabaseConfig` and provider registry outside the process-wide session module.
+2. Implement PostgreSQL and SQLite as registered providers responsible for:
+   - building their default connection URL,
+   - creating their SQLAlchemy engine, and
+   - performing provider-specific database initialization.
+3. Load configuration from environment variables only as the default adapter. Tests and application composition can inject a `DatabaseConfig` directly without mutating process environment.
+4. Preserve the current public API used throughout the codebase:
    - `Engine`
    - `SessionLocal`
    - `Session`
    - `Base`
    - `SQLALCHEMY_DATABASE_URL`
-3. Make model declarations portable where they currently depend on PostgreSQL-specific types.
-4. Update database initialization so SQLite creates its file-backed database and tables without requiring `psycopg2` setup.
-5. Add unit tests that bind the application models to a temporary SQLite file and validate persistence across the existing model helper functions.
+5. Make model declarations portable where they currently depend on PostgreSQL-specific types.
+6. Update database initialization to delegate setup to the selected provider.
+7. Add unit tests for provider selection, direct configuration injection, and SQLite persistence across existing model helper functions.
 
 ## Verification
 
@@ -27,16 +30,25 @@ Add an opt-in SQLite persistence implementation for the existing SQLAlchemy data
 
 ## Configuration
 
-PostgreSQL remains the default. To opt into SQLite:
+PostgreSQL remains the default. Provider selection uses:
 
 ```bash
-GEIST_DATABASE_BACKEND=sqlite
+GEIST_DATABASE_PROVIDER=sqlite
 SQLITE_DATABASE_PATH=/opt/geist/data/geist.sqlite3
 ```
 
 or:
 
 ```bash
-GEIST_DATABASE_BACKEND=sqlite
+GEIST_DATABASE_PROVIDER=sqlite
 SQLITE_DATABASE_URL=sqlite:////opt/geist/data/geist.sqlite3
+```
+
+`GEIST_DATABASE_BACKEND` and `DB_BACKEND` remain supported as compatibility aliases. Application code and tests can bypass environment loading entirely:
+
+```python
+DatabaseConfig(
+    provider="sqlite",
+    database_url="sqlite:////tmp/geist.sqlite3",
+)
 ```

--- a/plans/151-SQLITE_STORAGE_ENGINE.md
+++ b/plans/151-SQLITE_STORAGE_ENGINE.md
@@ -21,6 +21,12 @@ Add a provider-neutral SQLAlchemy configuration layer that can select PostgreSQL
 5. Make model declarations portable where they currently depend on PostgreSQL-specific types.
 6. Update database initialization to delegate setup to the selected provider.
 7. Add unit tests for provider selection, direct configuration injection, and SQLite persistence across existing model helper functions.
+8. Exercise the shared agent lifecycle against SQLite for both `LocalAgent` and
+   `OnlineAgent`, with inference and HTTP boundaries mocked:
+   - initialization and state inspection,
+   - chat completion persistence,
+   - context persistence during phase out, and
+   - phase in without subprocess creation.
 
 ## Verification
 

--- a/tests/database/test_database_config.py
+++ b/tests/database/test_database_config.py
@@ -1,0 +1,84 @@
+import pytest
+from sqlalchemy import create_engine
+
+from app.models.database.database_config import (
+    DatabaseConfig,
+    DatabaseProviderRegistry,
+    create_database_engine,
+    load_database_config,
+)
+
+
+class TestDatabaseProvider:
+    name = "test"
+    aliases = ("testdb",)
+
+    def build_database_url(self, environ):
+        return environ.get("TEST_DATABASE_URL", "test://default")
+
+    def create_engine(self, config):
+        return create_engine("sqlite:///:memory:")
+
+    def initialize_database(self, config):
+        return None
+
+
+def test_postgresql_is_the_default_provider():
+    config = load_database_config(environ={})
+
+    assert config == DatabaseConfig(
+        provider="postgresql",
+        database_url="postgresql://geist:geist@db:5432/geist",
+    )
+
+
+def test_sqlite_can_be_selected_from_environment(tmp_path):
+    database_path = tmp_path / "configured.sqlite3"
+
+    config = load_database_config(
+        environ={
+            "GEIST_DATABASE_PROVIDER": "sqlite",
+            "SQLITE_DATABASE_PATH": str(database_path),
+        }
+    )
+
+    assert config.provider == "sqlite"
+    assert config.database_url == f"sqlite:///{database_path}"
+
+
+def test_database_config_can_be_injected_without_environment():
+    config = DatabaseConfig(
+        provider="sqlite",
+        database_url="sqlite:///:memory:",
+    )
+
+    engine = create_database_engine(config)
+    try:
+        assert engine.dialect.name == "sqlite"
+    finally:
+        engine.dispose()
+
+
+def test_provider_registry_is_injectable():
+    registry = DatabaseProviderRegistry((TestDatabaseProvider(),))
+
+    config = load_database_config(
+        provider="testdb",
+        environ={"TEST_DATABASE_URL": "test://injected"},
+        registry=registry,
+    )
+    engine = create_database_engine(config, registry=registry)
+    try:
+        assert config == DatabaseConfig(provider="test", database_url="test://injected")
+        assert engine.dialect.name == "sqlite"
+    finally:
+        engine.dispose()
+
+
+def test_provider_must_match_explicit_database_url():
+    with pytest.raises(ValueError, match="does not match URL provider"):
+        load_database_config(
+            provider="postgresql",
+            database_url="sqlite:///:memory:",
+            environ={},
+        )

--- a/tests/database/test_sqlite_agent_providers.py
+++ b/tests/database/test_sqlite_agent_providers.py
@@ -1,0 +1,202 @@
+import importlib
+import json
+
+import pytest
+
+from agents.agent_context import AgentContext
+from agents.agent_settings import AgentSettings
+from app.models.database.database import (
+    Base,
+    DATABASE_CONFIG,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+
+
+class SQLiteTestRunner:
+    def __init__(self):
+        self.loaded_model = None
+        self.cleaned_up = False
+
+    def load(self, model_id, device_config=None):
+        self.loaded_model = model_id
+
+    def complete(self, system_prompt, user_prompt, generation_config):
+        return [
+            {"role": "user", "content": user_prompt},
+            {"role": "assistant", "content": f"local response: {user_prompt}"},
+        ]
+
+    def cleanup(self):
+        self.cleaned_up = True
+
+
+ONLINE_RESPONSE = {
+    "id": "sqlite-online-completion",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "test-online-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "online response: provider persistence",
+            },
+            "logprobs": None,
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+        "prompt_tokens_details": {"cached_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": 0},
+    },
+}
+
+
+@pytest.fixture()
+def sqlite_database(tmp_path):
+    original_config = DATABASE_CONFIG
+    sqlite_config = DatabaseConfig(
+        provider="sqlite",
+        database_url=f"sqlite:///{tmp_path / 'agent-providers.sqlite3'}",
+    )
+    engine = configure_database(sqlite_config)
+
+    importlib.import_module("app.models.database")
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Session.remove()
+        Base.metadata.drop_all(bind=engine)
+        configure_database(original_config)
+
+
+def create_persisted_context():
+    from app.models.database.agent import Agent
+
+    with SessionLocal() as session:
+        agent_record = Agent(
+            process_id=None,
+            world_context="[]",
+            task_context="[]",
+            execution_context="[]",
+        )
+        session.add(agent_record)
+        session.commit()
+        session.refresh(agent_record)
+        agent_id = agent_record.agent_id
+
+    settings = AgentSettings(
+        name="SQLite Provider Test",
+        version="1.0",
+        description="Exercises agent provider persistence",
+        max_tokens=32,
+        n=1,
+        temperature=0.5,
+        top_p=0.9,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        include_world_processing=True,
+    )
+    return AgentContext(
+        settings=settings,
+        agent_id=agent_id,
+        world_context=[],
+        task_context=[],
+        execution_context=[],
+        execution_classes=[],
+        envs={},
+    )
+
+
+def create_local_agent(context, monkeypatch):
+    import agents.local_agent as local_agent_module
+
+    monkeypatch.setattr(local_agent_module, "ensure_runners_registered", lambda: None)
+    monkeypatch.setattr(
+        local_agent_module,
+        "get_runner",
+        lambda runner_type: SQLiteTestRunner if runner_type == "sqlite_test" else None,
+    )
+    return local_agent_module.LocalAgent(
+        agent_context=context,
+        model_id="test-local-model",
+        runner_type="sqlite_test",
+    )
+
+
+def create_online_agent(context, monkeypatch):
+    from agents.online_agent import OnlineAgent
+
+    agent = OnlineAgent(
+        agent_context=context,
+        base_url="https://example.invalid/v1",
+        model="test-online-model",
+        api_key="test-key",
+    )
+    monkeypatch.setattr(agent, "_make_request", lambda payload: ONLINE_RESPONSE)
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "agent_factory", "expected_reply"),
+    [
+        ("local", create_local_agent, "local response: provider persistence"),
+        ("online", create_online_agent, "online response: provider persistence"),
+    ],
+)
+def test_agent_provider_common_operations_persist_with_sqlite(
+    sqlite_database,
+    monkeypatch,
+    provider_name,
+    agent_factory,
+    expected_reply,
+):
+    from app.models.database.agent import Agent
+    from app.models.database.chat_session import get_chat_history
+
+    context = create_persisted_context()
+    agent = agent_factory(context, monkeypatch)
+
+    agent.initialize(task_prompt=f"{provider_name} initialized")
+    completion = agent.complete_text(
+        prompt="provider persistence",
+        chat_id=8100 if provider_name == "local" else 8200,
+    )
+
+    assert completion.chat_id == (8100 if provider_name == "local" else 8200)
+    assert agent.state()["task_context"] == [f"{provider_name} initialized"]
+
+    context.world_context = [f"{provider_name} world"]
+    context.task_context.append(f"{provider_name} task")
+    context.execution_context = [f"{provider_name} execution"]
+    agent.phase_out()
+
+    with SessionLocal() as session:
+        persisted_agent = session.query(Agent).filter_by(agent_id=context.agent_id).one()
+        assert json.loads(persisted_agent.world_context) == [f"{provider_name} world"]
+        assert json.loads(persisted_agent.task_context) == [
+            f"{provider_name} initialized",
+            f"{provider_name} task",
+        ]
+        assert json.loads(persisted_agent.execution_context) == [
+            f"{provider_name} execution"
+        ]
+
+    history = get_chat_history(completion.chat_id)
+    assert history.chat_history == [
+        {
+            "user": "provider persistence",
+            "ai": expected_reply,
+        }
+    ]
+
+    agent.phase_in()
+    assert context.subprocess_id is None

--- a/tests/database/test_sqlite_storage.py
+++ b/tests/database/test_sqlite_storage.py
@@ -1,0 +1,194 @@
+import datetime
+import importlib
+
+import pytest
+
+from app.models.database.database import (
+    Base,
+    DATABASE_BACKEND,
+    SQLALCHEMY_DATABASE_URL,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+
+
+@pytest.fixture()
+def sqlite_database(tmp_path):
+    original_url = SQLALCHEMY_DATABASE_URL
+    original_backend = DATABASE_BACKEND
+    sqlite_url = f"sqlite:///{tmp_path / 'geist.sqlite3'}"
+
+    engine = configure_database(database_url=sqlite_url, backend="sqlite")
+
+    importlib.import_module("app.models.database")
+
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Session.remove()
+        Base.metadata.drop_all(bind=engine)
+        configure_database(database_url=original_url, backend=original_backend)
+
+
+def create_test_user() -> int:
+    from app.models.database.geist_user import GeistUser
+
+    with SessionLocal() as session:
+        user = GeistUser(
+            username="sqlite-user",
+            name="SQLite User",
+            email="sqlite@example.com",
+            password="",
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return user.user_id
+
+
+def test_sqlite_persists_core_database_models(sqlite_database):
+    from app.models.database.agent import Agent
+    from app.models.database.agent_preset import AgentPreset, Restriction
+    from app.models.database.chat_session import get_chat_history, update_chat_history
+    from app.models.database.file_upload import (
+        FileUploadModel,
+        create_file_upload,
+        delete_file_upload,
+        get_file_upload_by_id,
+        get_files_by_user,
+    )
+    from app.models.database.user_settings import (
+        create_default_user_settings,
+        get_or_create_user_settings,
+        update_user_settings,
+    )
+    from app.models.database.workflow import (
+        Workflow,
+        WorkflowRunStatus,
+        WorkflowStep,
+        create_workflow,
+        create_workflow_run,
+        create_workflow_step_result,
+        get_workflow_by_id,
+        update_workflow_run_status,
+        update_workflow_step_result,
+    )
+
+    user_id = create_test_user()
+
+    with SessionLocal() as session:
+        agent = Agent(process_id="sqlite-process", world_context="world")
+        session.add(agent)
+        session.commit()
+        session.refresh(agent)
+        agent_id = agent.agent_id
+
+    assert Agent.get_agent_by_id(agent_id).process_id == "sqlite-process"
+
+    AgentPreset.upsert_agent_preset(
+        name="SQLite Preset",
+        version="1.0",
+        description="SQLite-compatible preset",
+        max_tokens=128,
+        n=1,
+        temperature=1,
+        top_p=1,
+        frequency_penalty=0,
+        presence_penalty=0,
+        tags="sqlite",
+        working_context_length=128,
+        long_term_context_length=128,
+        agent_type="local",
+        prompt="test",
+        interactive_only=False,
+        process_world=False,
+    )
+
+    with SessionLocal() as session:
+        preset = session.query(AgentPreset).filter_by(name="SQLite Preset").one()
+        restriction = Restriction(
+            agent_preset_id=preset.agent_preset_id,
+            name="SQLite Restriction",
+            rate=10,
+            period_hours=1,
+            spending_limit=100,
+            restriction_type="allowlist",
+            allowed_plugins=["files"],
+            allowed_methods=["read"],
+            create_date=datetime.datetime.utcnow(),
+            update_date=datetime.datetime.utcnow(),
+        )
+        session.add(restriction)
+        session.commit()
+        restriction_id = restriction.restriction_id
+
+    with SessionLocal() as session:
+        saved_restriction = session.query(Restriction).filter_by(restriction_id=restriction_id).one()
+        assert saved_restriction.allowed_plugins == ["files"]
+        assert saved_restriction.allowed_methods == ["read"]
+
+    chat_session = update_chat_history("hello", "hi", session_id=77)
+    assert chat_session.chat_session_id == 77
+    assert get_chat_history(77)[0] == {"user": "hello", "ai": "hi"}
+
+    created_file = create_file_upload(
+        FileUploadModel(
+            filename="stored.txt",
+            original_filename="original.txt",
+            file_data=b"sqlite-data",
+            file_size=11,
+            mime_type="text/plain",
+            file_hash="sqlite-hash",
+            user_id=user_id,
+        )
+    )
+    assert get_file_upload_by_id(created_file.file_id).file_data == b"sqlite-data"
+    assert get_files_by_user(user_id)[0].original_filename == "original.txt"
+
+    settings = create_default_user_settings(user_id)
+    assert settings.default_agent_type == "local"
+    updated_settings = update_user_settings(user_id, {"default_agent_type": "online"})
+    assert updated_settings.default_agent_type == "online"
+    assert get_or_create_user_settings(user_id).default_agent_type == "online"
+
+    workflow = create_workflow(
+        Workflow(
+            name="SQLite Workflow",
+            user_id=user_id,
+            steps=[
+                WorkflowStep(
+                    step_name="SQLite Step",
+                    step_description="Runs on SQLite",
+                    step_status="pending",
+                    display_x=1,
+                    display_y=2,
+                    command_str="echo sqlite",
+                    step_type="custom",
+                )
+            ],
+        )
+    )
+    saved_workflow = get_workflow_by_id(workflow.workflow_id)
+    assert saved_workflow.name == "SQLite Workflow"
+    assert saved_workflow.steps[0].step_name == "SQLite Step"
+
+    run = create_workflow_run(workflow.workflow_id, user_id, input_data={"source": "sqlite"})
+    finished_run = update_workflow_run_status(
+        run.run_id,
+        WorkflowRunStatus.COMPLETED,
+        output_data={"ok": True},
+    )
+    assert finished_run.output_data == {"ok": True}
+
+    result = create_workflow_step_result(run.run_id, saved_workflow.steps[0].step_id)
+    finished_result = update_workflow_step_result(
+        result.result_id,
+        WorkflowRunStatus.COMPLETED,
+        output_data={"step": "done"},
+    )
+    assert finished_result.output_data == {"step": "done"}
+
+    assert delete_file_upload(created_file.file_id, user_id) is True
+    assert get_file_upload_by_id(created_file.file_id) is None

--- a/tests/database/test_sqlite_storage.py
+++ b/tests/database/test_sqlite_storage.py
@@ -5,21 +5,23 @@ import pytest
 
 from app.models.database.database import (
     Base,
-    DATABASE_BACKEND,
-    SQLALCHEMY_DATABASE_URL,
+    DATABASE_CONFIG,
     Session,
     SessionLocal,
     configure_database,
 )
+from app.models.database.database_config import DatabaseConfig
 
 
 @pytest.fixture()
 def sqlite_database(tmp_path):
-    original_url = SQLALCHEMY_DATABASE_URL
-    original_backend = DATABASE_BACKEND
-    sqlite_url = f"sqlite:///{tmp_path / 'geist.sqlite3'}"
+    original_config = DATABASE_CONFIG
+    sqlite_config = DatabaseConfig(
+        provider="sqlite",
+        database_url=f"sqlite:///{tmp_path / 'geist.sqlite3'}",
+    )
 
-    engine = configure_database(database_url=sqlite_url, backend="sqlite")
+    engine = configure_database(sqlite_config)
 
     importlib.import_module("app.models.database")
 
@@ -29,7 +31,7 @@ def sqlite_database(tmp_path):
     finally:
         Session.remove()
         Base.metadata.drop_all(bind=engine)
-        configure_database(database_url=original_url, backend=original_backend)
+        configure_database(original_config)
 
 
 def create_test_user() -> int:
@@ -125,7 +127,9 @@ def test_sqlite_persists_core_database_models(sqlite_database):
         restriction_id = restriction.restriction_id
 
     with SessionLocal() as session:
-        saved_restriction = session.query(Restriction).filter_by(restriction_id=restriction_id).one()
+        saved_restriction = (
+            session.query(Restriction).filter_by(restriction_id=restriction_id).one()
+        )
         assert saved_restriction.allowed_plugins == ["files"]
         assert saved_restriction.allowed_methods == ["read"]
 


### PR DESCRIPTION
## Summary

- Add an immutable `DatabaseConfig` and injectable provider registry for SQLAlchemy.
- Keep PostgreSQL as the default provider using the existing `POSTGRES_*`, `DB_HOST`, and `DB_PORT` settings.
- Add SQLite as an explicit optional provider selected with `GEIST_DATABASE_PROVIDER=sqlite`.
- Allow tests and alternate application entry points to inject `DatabaseConfig(provider=..., database_url=...)` without mutating environment variables.
- Move provider-specific URL construction, engine creation, and initialization behind PostgreSQL and SQLite provider implementations.
- Preserve the existing process-wide `Engine`, `SessionLocal`, `Session`, `Base`, and `SQLALCHEMY_DATABASE_URL` API.
- Keep PostgreSQL ARRAY columns portable by using JSON variants on SQLite.
- Exercise the shared agent lifecycle against SQLite for both `LocalAgent` and `OnlineAgent`, mocking only model inference and external HTTP.

## Agent provider coverage

Both agent implementations are tested for:

- construction against a SQLite-backed `AgentContext`,
- initialization and state inspection,
- chat completion and history persistence,
- world/task/execution context persistence during `phase_out()`, and
- `phase_in()` without subprocess creation.

## Validation

- Expanded provider, SQLite persistence, workflow, and agent architecture suite: 38 passed.
- Dedicated SQLite agent-provider test: 2 passed (`LocalAgent` and `OnlineAgent`).
- SQLite `initdb.py` smoke test passed against a temporary database file.
- Python compilation and `git diff --check` passed.

## Environment limitation

Docker Compose validation could not run because Docker Desktop was not running: `Cannot connect to the Docker daemon at unix:///Users/daviddworetzky/.docker/run/docker.sock`.

## Compatibility

`GEIST_DATABASE_BACKEND` and `DB_BACKEND` remain accepted as compatibility aliases, but `GEIST_DATABASE_PROVIDER` is now the preferred setting.