### PR TITLE
[codex] Add AI test loop and pre-commit checks

### DIFF
--- a/.agents/skills/geist-test-loop/SKILL.md
+++ b/.agents/skills/geist-test-loop/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: geist-test-loop
+description: This skill should be used when Codex is preparing to push, publish, open a PR, or verify Geist runtime behavior through Docker, native startup, browser UI, chat, or settings smoke tests.
+---
+
+# Geist Test Loop
+
+Use this skill to produce evidence that a Geist change works before pushing or publishing it. Treat this as an AI operator workflow, not a Git-enforced gate.
+
+## Core Rules
+
+1. Inspect `git status --short` before testing. Preserve unrelated user changes and report when uncommitted files are outside the current task.
+2. Prefer the smallest meaningful test set first, then expand to runtime smoke checks when preparing to push or publish.
+3. Keep Docker runtime validation separate from native `MLX_BACKEND=1` validation. A pass in one mode does not prove the other mode.
+4. Do not print secrets. Confirm only presence, absence, or variable names when environment configuration matters.
+5. Report exact commands run, pass/fail status, and any blocked checks in the final response.
+
+## Fast Checks
+
+Run relevant fast checks before runtime smoke tests:
+
+```bash
+pre-commit run --all-files
+```
+
+When pre-commit is unavailable or too broad for the task, run targeted checks:
+
+```bash
+ruff check .
+ruff format --check .
+mypy --config-file=pyproject.toml <changed-python-files>
+cd client/geist && CI=true npm test -- --watchAll=false --passWithNoTests
+```
+
+For backend behavior, prefer the containerized test command from `AGENTS.md` when Docker is available:
+
+```bash
+docker compose up -d db backend
+docker exec backend /bin/bash -lc 'cd /opt/geist && PYTHONPATH=/opt/geist pytest'
+```
+
+## Docker Smoke Loop
+
+Run this loop before pushing or publishing user-facing changes when feasible:
+
+```bash
+docker compose up -d --build
+docker compose ps
+docker compose logs --tail=120 backend
+docker compose logs --tail=120 frontend
+curl -fsS http://localhost:3000
+```
+
+Treat backend/frontend startup errors, repeated tracebacks, failed health checks, or a failed `curl` as blocking unless there is a clear unrelated local-environment cause.
+
+## Browser UI Smoke
+
+Use the browser-control skill or available browser tooling to verify the running app at:
+
+```text
+http://localhost:3000
+```
+
+Check for:
+
+- The app renders a nonblank UI.
+- The browser console has no obvious runtime errors from the current change.
+- A basic chat flow can be reached and exercised without crashing.
+- Settings can be opened, a reversible default/preference can be changed, saved, reloaded, and restored.
+
+Use existing UI labels and routes discovered from the current app. If the chat flow requires a model, token, or external service that is unavailable, verify the UI path up to that dependency and report the blocker explicitly.
+
+## Native MLX Smoke Loop
+
+Run the native loop when the change touches local agents, model defaults, MLX behavior, native bootstrap, or when explicitly requested:
+
+```bash
+make run MLX_BACKEND=1
+```
+
+In native mode:
+
+- Keep the terminal session open while testing.
+- Verify the frontend/backend route that the native process exposes.
+- Exercise the same basic chat and settings paths if the app reaches the UI.
+- Stop the native process cleanly after testing.
+
+If Conda, MLX, model weights, GPU capability, or local tokens are missing, report native validation as blocked rather than substituting Docker results.
+
+## Pre-Push Evidence
+
+Before pushing, summarize:
+
+- Git branch and dirty-worktree state.
+- Fast checks run.
+- Docker startup/log/curl result.
+- Browser chat/settings result.
+- Native `MLX_BACKEND=1` result, or why it was not applicable.
+- Any skipped checks and the reason.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,19 @@ repos:
         # Run mypy only on Python files that are tracked by git
         pass_filenames: true
         files: \.py$
+
+  # Repo-local checks that avoid adding runtime dependencies.
+  - repo: local
+    hooks:
+      - id: staged-secret-scan
+        name: staged secret scan
+        entry: python scripts/pre_commit_security_check.py
+        language: system
+        pass_filenames: false
+
+      - id: frontend-eslint
+        name: frontend eslint
+        entry: bash scripts/pre_commit_frontend_lint.sh
+        language: system
+        pass_filenames: false
+        files: ^client/geist/src/.*\.(js|jsx|ts|tsx)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ When installing packages, `conda env export >> linux_environment.yml` after inst
 #running tests
 `cd /opt/geist && PYTHONPATH=/opt/geist pytest` in the backend container
 
+#pre-push AI testing
+Before pushing, publishing, or opening a PR, use `.agents/skills/geist-test-loop/SKILL.md` when feasible. The loop should collect evidence from relevant fast checks, Docker startup/logs/curl, browser UI smoke testing, basic chat, settings defaults, and native `make run MLX_BACKEND=1` when the change touches native/local model behavior.
+
+#pre-commit hooks
+Use `pre-commit install` to enable local hooks. Keep hooks fast: linting, formatting, type checks, staged secret scanning, and basic frontend lint are appropriate here. Full Docker/native/browser smoke testing belongs in the AI pre-push test loop, not in pre-commit.
+
 
 
 
@@ -69,5 +75,4 @@ prefer minimal inline implementations over extra dependency imports. Core librar
 ## first, create a plan for your feature in /plans
 ## next, implement the plan, adding the backend data models, middle data models, service layer, routes, backend tests, 
 ## finally, test the solution by running `docker compose up -d`, then verifying no error logs in the docker container, then doing a curl command to localhost:3000
-
 

--- a/client/geist/package.json
+++ b/client/geist/package.json
@@ -24,6 +24,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/plans/151-AI-TEST-LOOP-AND-HOOKS.md
+++ b/plans/151-AI-TEST-LOOP-AND-HOOKS.md
@@ -1,0 +1,40 @@
+# AI Test Loop and Hook Plan
+
+## Goal
+
+Make Codex default to a real Geist smoke-test loop before pushing or publishing changes, while keeping Git hooks focused on fast linting and basic security checks.
+
+## Scope
+
+- Add a repo-local skill that tells Codex how to run Docker, native, UI, chat, and settings smoke checks before push/PR work.
+- Keep the AI smoke loop advisory and evidence-driven, not enforced by Git.
+- Extend pre-commit coverage with deterministic local checks that do not require standing up the whole application.
+
+## Implementation
+
+1. Add `.agents/skills/geist-test-loop/SKILL.md`.
+   - Trigger when preparing to push, publish, create a PR, or verify Geist runtime behavior.
+   - Prefer changed-file targeted tests first.
+   - Run Docker smoke checks and browser UI checks before push when feasible.
+   - Run native `MLX_BACKEND=1` checks when the change touches native/local model behavior or when explicitly requested.
+   - Report exact commands, pass/fail state, and blockers.
+
+2. Add a staged secret scanner script.
+   - Scan staged file contents through Git.
+   - Detect narrow high-signal token/private-key patterns.
+   - Avoid printing secret values.
+
+3. Add frontend lint wiring.
+   - Add an npm `lint` script for `client/geist/src`.
+   - Add a pre-commit local hook that runs frontend lint only when frontend source files are staged.
+
+4. Update `.pre-commit-config.yaml`.
+   - Keep existing Ruff, Ruff format, mypy, and generic safety hooks.
+   - Add repo-local hooks for staged secret scanning and frontend lint.
+
+## Verification
+
+- Compile the staged secret scanner.
+- Run the staged secret scanner.
+- Validate JSON syntax for `client/geist/package.json`.
+- Do not run network-dependent pre-commit installation or full Docker smoke unless requested.

--- a/scripts/pre_commit_frontend_lint.sh
+++ b/scripts/pre_commit_frontend_lint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd client/geist
+
+if [ ! -x node_modules/.bin/eslint ]; then
+  echo "client/geist/node_modules is missing eslint. Run 'cd client/geist && npm ci' before committing frontend source changes." >&2
+  exit 1
+fi
+
+npm run lint -- --max-warnings=0

--- a/scripts/pre_commit_security_check.py
+++ b/scripts/pre_commit_security_check.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Scan staged files for high-signal secret patterns without printing values."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    label: str
+
+
+SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("private key", re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")),
+    ("aws access key", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("github token", re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{36,255}\b")),
+    ("openai api key", re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b")),
+    ("anthropic api key", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
+    ("slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+    ("stripe live key", re.compile(r"\b(?:sk|pk)_live_[A-Za-z0-9]{16,}\b")),
+)
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(["git", *args], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def staged_paths() -> list[str]:
+    result = run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+        sys.exit(result.returncode)
+    return [line for line in result.stdout.decode("utf-8", errors="replace").splitlines() if line]
+
+
+def staged_text(path: str) -> Optional[str]:
+    result = run_git(["show", f":{path}"])
+    if result.returncode != 0:
+        return None
+    if b"\0" in result.stdout:
+        return None
+    return result.stdout.decode("utf-8", errors="ignore")
+
+
+def scan_file(path: str, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for label, pattern in SECRET_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding(path=path, line=line_number, label=label))
+    return findings
+
+
+def main() -> int:
+    findings: list[Finding] = []
+    for path in staged_paths():
+        text = staged_text(path)
+        if text is None:
+            continue
+        findings.extend(scan_file(path, text))
+
+    if not findings:
+        return 0
+
+    print("Potential secrets found in staged files:")
+    for finding in findings:
+        print(f"- {finding.path}:{finding.line} matched {finding.label}")
+    print("Remove the secret from the commit or explicitly rotate and document the exception.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a repo-local `geist-test-loop` skill so Codex defaults to Docker/native/UI smoke evidence before push or PR work when feasible.
- Document the pre-push AI workflow and keep full Docker/native/browser smoke testing out of Git hooks.
- Add lightweight pre-commit coverage for staged secret scanning and frontend ESLint, plus an npm `lint` script.

## Validation

- `git diff --cached --check`
- `PYTHONPYCACHEPREFIX=/tmp/geist-pycache python3 -m py_compile scripts/pre_commit_security_check.py`
- `python3 scripts/pre_commit_security_check.py`
- `python3 -m json.tool client/geist/package.json`
- `ruby -e "require 'yaml'; YAML.load_file('.pre-commit-config.yaml'); puts 'pre-commit yaml ok'"`
- `bash -n scripts/pre_commit_frontend_lint.sh`

## Notes

Docker, native MLX, and browser UI smoke were not run because this PR only changes repo workflow/hook wiring and `client/geist/node_modules` is not installed in the current worktree.