### PR TITLE
[codex] Remove generic API key fallback

### DIFF
--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -88,7 +88,7 @@ class OnlineAgent(BaseAgent):
             self.headers["Authorization"] = f"Bearer {self.api_key}"
     
     def _get_api_key_from_env(self) -> Optional[str]:
-        """Get API key from environment variables based on the endpoint."""
+        """Get provider-specific API key from environment variables based on the endpoint."""
         if "openai.com" in self.base_url:
             return os.getenv("OPENAI_API_KEY")
         elif "anthropic" in self.base_url:
@@ -97,9 +97,7 @@ class OnlineAgent(BaseAgent):
             return os.getenv("GROQ_API_KEY")
         elif "x.ai" in self.base_url:  # Grok
             return os.getenv("GROK_API_KEY")
-        else:
-            # Fallback to generic API key
-            return os.getenv("API_KEY")
+        return None
     
     def _make_request(
         self,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -112,7 +112,6 @@ User settings control default agent behavior and can be configured via API:
 - `ANTHROPIC_API_KEY` - Anthropic API key
 - `GROQ_API_KEY` - Groq API key
 - `GROK_API_KEY` - Grok (X.AI) API key
-- `API_KEY` - Generic fallback API key
 
 ## Usage Examples
 
@@ -375,6 +374,7 @@ All scripts should maintain consistent parameter naming and conventions across c
    - Verify API keys are correctly set
    - Check API key permissions
    - Ensure endpoint URLs are correct
+   - Pass an explicit API key for custom endpoints
 
 3. **Runner Not Found**
    - Verify runner is registered: `register_runner("name", Class)`

--- a/tests/agents/test_online_agent.py
+++ b/tests/agents/test_online_agent.py
@@ -790,8 +790,8 @@ class TestOnlineAgentAPIKeyRetrieval:
             
             assert agent.api_key == "env-grok-key"
 
-    def test_fallback_to_generic_api_key(self):
-        """Test fallback to generic API_KEY environment variable."""
+    def test_custom_provider_requires_explicit_api_key(self):
+        """Test custom endpoints do not use a generic API_KEY fallback."""
         context = create_mock_agent_context()
         
         with patch.dict('os.environ', {'API_KEY': 'generic-api-key'}, clear=True):
@@ -801,5 +801,18 @@ class TestOnlineAgentAPIKeyRetrieval:
                 model="custom-model"
             )
             
-            assert agent.api_key == "generic-api-key"
+            assert agent.api_key is None
 
+    def test_custom_provider_uses_explicit_api_key(self):
+        """Test custom endpoints can still receive an explicit API key."""
+        context = create_mock_agent_context()
+
+        with patch.dict('os.environ', {'API_KEY': 'generic-api-key'}, clear=True):
+            agent = OnlineAgent(
+                agent_context=context,
+                base_url="https://api.custom-provider.com/v1",
+                model="custom-model",
+                api_key="explicit-key"
+            )
+
+            assert agent.api_key == "explicit-key"


### PR DESCRIPTION
## Summary
- remove the implicit generic `API_KEY` fallback from `OnlineAgent`
- keep provider-specific environment variable lookup for OpenAI, Anthropic, Groq, and Grok
- document that custom endpoints should pass an explicit API key
- update tests to cover the explicit-key behavior for custom providers

## Validation
- `git diff --check origin/main...HEAD`
- `PYTHONPYCACHEPREFIX=/private/tmp/geist-pycache python3 -m py_compile agents/online_agent.py tests/agents/test_online_agent.py`

Docker pytest was not run because the Docker daemon was not reachable in this environment. Local pytest was not run because `pytest` is not installed locally.