### PR TITLE
Speed up CI: parallel builds, conda env cache, Docker layer cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+**/node_modules
+**/__pycache__
+**/*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel superseded runs on PRs; let pushes to main run to completion
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -19,26 +25,32 @@ jobs:
           POSTGRES_PASSWORD: geist
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 2s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 20
         ports:
           - 5432:5432
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
     - name: Set up Conda
       uses: conda-incubator/setup-miniconda@v3.1.1
       with:
         python-version: '3.11'
         activate-environment: geist-linux-docker
-        environment-file: linux_environment_x86_x64.yml
+
+    - name: Cache Conda environment
+      uses: actions/cache@v4
+      id: conda-cache
+      with:
+        path: ${{ env.CONDA }}/envs/geist-linux-docker
+        key: conda-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('linux_environment_x86_x64.yml') }}
+
+    - name: Install Conda environment
+      if: steps.conda-cache.outputs.cache-hit != 'true'
+      shell: bash -l {0}
+      run: conda env update -n geist-linux-docker -f linux_environment_x86_x64.yml
 
     - name: Initialize database
       shell: bash -l {0}
@@ -63,12 +75,11 @@ jobs:
         POSTGRES_USER: geist
         POSTGRES_PASSWORD: geist
       run: |
-        conda info
-        conda list
         pytest tests/
 
   frontend-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v4
@@ -76,7 +87,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: client/geist/package-lock.json
 
@@ -92,16 +103,29 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [test, frontend-test]
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: backend
+            dockerfile: Dockerfile
+          - image: frontend
+            dockerfile: client/geist/Dockerfile
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
-    - name: Build Backend
-      run: docker build -t geist-backend -f Dockerfile .
-
-    - name: Build Frontend
-      run: docker build -t geist-frontend -f client/geist/Dockerfile .
+    - name: Build ${{ matrix.image }} image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ matrix.dockerfile }}
+        tags: geist-${{ matrix.image }}
+        push: false
+        cache-from: type=gha,scope=${{ matrix.image }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,25 +36,26 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN which conda && conda --version
-RUN conda init bash
-
-# Copy both environment files so the install script can choose the right one
-COPY linux_environment*.yml ./
-COPY . .
-
-RUN chmod +x *.sh
-
-VOLUME /rest
 
 # Set up conda environment activation
 RUN conda init bash && \
     echo "conda activate geist-linux-docker" >> ~/.bashrc
 SHELL ["/bin/bash", "--login", "-c"]
 
+# Copy only the files needed to build the conda environment, so source code
+# changes do not invalidate this expensive layer
+COPY linux_environment*.yml conda-install.sh ./
+RUN chmod +x conda-install.sh && ./conda-install.sh
+
+# Copy the rest of the source tree
+COPY . .
+
+RUN chmod +x *.sh
+
+VOLUME /rest
+
 EXPOSE 5000
 EXPOSE 5678
 EXPOSE 8000
-
-RUN ./conda-install.sh
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
- Run the docker build job in parallel with test jobs instead of after
  them (it doesn't publish images, so there's nothing to gate)
- Split backend/frontend image builds into a matrix and use
  docker/build-push-action with GitHub Actions layer caching
- Cache the conda environment keyed on the environment file hash;
  cold-cache path still uses the same conda env creation as before
- Reorder Dockerfile so the conda environment layer is built before
  copying source, so code changes no longer invalidate it
- Add .dockerignore to shrink the build context
- Drop the unused setup-python step and conda info/list debug output
- Cancel superseded runs on PRs, add job timeouts, tighten postgres
  health-check interval, align Node to 20 to match the frontend image

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G9Ccc6veikjTvjpzRfqWhN