### PR TITLE
Add agent state snapshots and structured tool calling

### DIFF
--- a/adapters/tool_schema.py
+++ b/adapters/tool_schema.py
@@ -1,0 +1,186 @@
+"""
+Reflection-based tool schema generation for adapters.
+
+Builds JSON-schema descriptions of adapter actions from method signatures,
+type hints, and docstrings so agents can expose adapter functions to models
+as structured tools (native function calling for online providers, schema
+grounded prompts for local models).
+"""
+import inspect
+import json
+import typing
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union, get_args, get_origin, get_type_hints
+
+from adapters.base_adapter import BaseAdapter
+
+_PRIMITIVE_TYPE_MAP = {
+    str: {"type": "string"},
+    int: {"type": "integer"},
+    float: {"type": "number"},
+    bool: {"type": "boolean"},
+    dict: {"type": "object"},
+    list: {"type": "array"},
+    type(None): {"type": "null"},
+}
+
+# Separator used to namespace an action name with its adapter class for
+# providers that require flat tool names (OpenAI-compatible endpoints reject
+# dots in function names).
+QUALIFIED_NAME_SEPARATOR = "__"
+
+
+@dataclass
+class ToolSchema:
+    """JSON-schema description of a single adapter action."""
+    adapter: str
+    action: str
+    description: str
+    parameters: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.adapter}{QUALIFIED_NAME_SEPARATOR}{self.action}"
+
+    def to_openai_tool(self) -> Dict[str, Any]:
+        """Render as an OpenAI-compatible `tools` array entry."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.qualified_name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+    def to_prompt_dict(self) -> Dict[str, Any]:
+        """Render in the class/function shape used by prompt-based tool calling."""
+        return {
+            "class": self.adapter,
+            "function": self.action,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
+
+
+def _annotation_to_schema(annotation: Any) -> Dict[str, Any]:
+    """Map a Python type annotation to a JSON schema fragment."""
+    if annotation is inspect.Parameter.empty or annotation is Any:
+        return {}
+    if annotation in _PRIMITIVE_TYPE_MAP:
+        return dict(_PRIMITIVE_TYPE_MAP[annotation])
+
+    origin = get_origin(annotation)
+    if origin is Union:
+        non_null = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_null) == 1:
+            return _annotation_to_schema(non_null[0])
+        fragments = [_annotation_to_schema(arg) for arg in non_null]
+        fragments = [fragment for fragment in fragments if fragment]
+        return {"anyOf": fragments} if fragments else {}
+    if origin in (list, tuple, set, frozenset):
+        args = get_args(annotation)
+        schema: Dict[str, Any] = {"type": "array"}
+        if args:
+            items = _annotation_to_schema(args[0])
+            if items:
+                schema["items"] = items
+        return schema
+    if origin is dict:
+        return {"type": "object"}
+    return {}
+
+
+def _docstring_summary(func: Any, fallback: str) -> str:
+    """First paragraph of a callable's docstring, collapsed to one line."""
+    doc = inspect.getdoc(func)
+    if not doc:
+        return fallback
+    first_paragraph = doc.split("\n\n", 1)[0]
+    return " ".join(line.strip() for line in first_paragraph.splitlines()).strip()
+
+
+def build_action_schema(adapter_cls: type, action_name: str) -> ToolSchema:
+    """
+    Build a ToolSchema for a single adapter action via signature reflection.
+
+    Parameters without defaults are marked required. Unannotated parameters are
+    accepted with an unconstrained schema so legacy adapters remain callable.
+    """
+    method = getattr(adapter_cls, action_name, None)
+    if method is None or not callable(method):
+        raise ValueError(f"{adapter_cls.__name__} has no callable action '{action_name}'")
+
+    try:
+        hints = get_type_hints(method)
+    except Exception:
+        hints = getattr(method, "__annotations__", {}) or {}
+
+    signature = inspect.signature(method)
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for name, parameter in signature.parameters.items():
+        if name == "self":
+            continue
+        if parameter.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        annotation = hints.get(name, parameter.annotation)
+        properties[name] = _annotation_to_schema(annotation)
+        if parameter.default is inspect.Parameter.empty:
+            required.append(name)
+
+    parameters: Dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        parameters["required"] = required
+
+    return ToolSchema(
+        adapter=adapter_cls.__name__,
+        action=action_name,
+        description=_docstring_summary(method, fallback=f"{adapter_cls.__name__}.{action_name}"),
+        parameters=parameters,
+    )
+
+
+def _visible_actions(adapter: Union[BaseAdapter, type]) -> List[str]:
+    """
+    Determine which actions an adapter exposes.
+
+    Instances keep the existing `enumerate_actions()` visibility contract;
+    classes fall back to reflection over public methods.
+    """
+    if isinstance(adapter, BaseAdapter):
+        try:
+            actions = adapter.enumerate_actions()
+            if actions:
+                return list(actions)
+        except Exception:
+            pass
+        adapter = type(adapter)
+
+    return [
+        name
+        for name, member in inspect.getmembers(adapter, inspect.isfunction)
+        if not name.startswith("_") and name != "enumerate_actions"
+    ]
+
+
+def enumerate_tool_schemas(adapter: Union[BaseAdapter, type]) -> List[ToolSchema]:
+    """Build ToolSchemas for every visible action of an adapter instance or class."""
+    adapter_cls = adapter if inspect.isclass(adapter) else type(adapter)
+    schemas = []
+    for action in _visible_actions(adapter):
+        try:
+            schemas.append(build_action_schema(adapter_cls, action))
+        except ValueError:
+            # enumerate_actions may advertise names that don't resolve; skip them
+            continue
+    return schemas
+
+
+def render_tool_prompt(schemas: List[ToolSchema]) -> str:
+    """Render tool schemas as a compact JSON listing for prompt-based tool calling."""
+    return "\n".join(json.dumps(schema.to_prompt_dict(), separators=(", ", ": ")) for schema in schemas)

--- a/agents/agent_context.py
+++ b/agents/agent_context.py
@@ -14,6 +14,7 @@ from app.models.database.agent_snapshot import (
     create_snapshot,
     get_latest_snapshot,
     get_snapshot_by_id,
+    prune_snapshots_older_than,
 )
 
 logger = logging.getLogger(__name__)
@@ -119,10 +120,24 @@ class AgentContext():
             logger.info(
                 f"Saved snapshot step={snapshot.step} reason={reason} for agent_id={self.agent_id}"
             )
-            return snapshot
         except Exception as e:
             logger.error(f"Failed to snapshot agent context for agent_id={self.agent_id}: {e}")
             return None
+
+        # Retention: expire old snapshots on write so history is bounded without
+        # a separate maintenance job. Prune failures are as harmless as snapshot
+        # failures — log and move on.
+        try:
+            retention_days = getattr(self.settings, "snapshot_retention_days", 7)
+            pruned = prune_snapshots_older_than(self.agent_id, retention_days)
+            if pruned:
+                logger.info(
+                    f"Pruned {pruned} snapshot(s) older than {retention_days} days for agent_id={self.agent_id}"
+                )
+        except Exception as e:
+            logger.warning(f"Failed to prune old snapshots for agent_id={self.agent_id}: {e}")
+
+        return snapshot
 
     def restore_snapshot(self, snapshot_id: int = None) -> bool:
         """

--- a/agents/agent_context.py
+++ b/agents/agent_context.py
@@ -7,7 +7,14 @@ import uuid
 import json
 import logging
 from adapters.adapter_registry import find_adapter_classes, init_adapter_class
+from adapters.tool_schema import ToolSchema, enumerate_tool_schemas
+from agents.tool_calling import ToolDispatcher
 from app.models.database.chat_session import get_chat_history, update_chat_history, ChatSession
+from app.models.database.agent_snapshot import (
+    create_snapshot,
+    get_latest_snapshot,
+    get_snapshot_by_id,
+)
 
 logger = logging.getLogger(__name__)
 class AgentContext():
@@ -31,15 +38,17 @@ class AgentContext():
         self.envs = envs
         self.include_world_processing = include_world_processing
 
+        self.initialized_classes = []
         if self.envs and len(self.envs.keys()) > 0:
             # Fix: avoid calling init_adapter_class twice by storing result first
-            self.initialized_classes = []
             for cls in self.execution_classes:
                 initialized = init_adapter_class(cls[0], self.envs)
                 if initialized is not None:
                     self.initialized_classes.append(initialized)
-            
-                
+
+        # Lazily-built caches for structured tool calling
+        self._tool_schemas = None
+        self._tool_dispatcher = None
 
     def _save(self):
         """Save agent context to database."""
@@ -63,6 +72,95 @@ class AgentContext():
         chat_history = get_chat_history(chat_id)
         chat_history.append({"user": user_message, "ai": ai_message})
         return update_chat_history(session_id = chat_id, new_user_message = user_message, new_ai_message = ai_message)
+
+    def get_tool_schemas(self) -> List[ToolSchema]:
+        """
+        Reflected JSON schemas for every action of the initialized adapters.
+
+        These give models full function visibility: adapter/action names, typed
+        parameters, required arguments, and docstring descriptions.
+        """
+        if self._tool_schemas is None:
+            schemas = []
+            for wrapper in self.initialized_classes:
+                try:
+                    schemas.extend(enumerate_tool_schemas(wrapper.instance))
+                except Exception as e:
+                    logger.warning(f"Failed to build tool schemas for adapter {wrapper.name}: {e}")
+            self._tool_schemas = schemas
+        return self._tool_schemas
+
+    def get_tool_dispatcher(self) -> ToolDispatcher:
+        """Dispatcher that validates and executes tool calls, journaling to function_log."""
+        if self._tool_dispatcher is None:
+            self._tool_dispatcher = ToolDispatcher(
+                self.initialized_classes,
+                schemas=self.get_tool_schemas(),
+                function_log=self.function_log,
+            )
+        return self._tool_dispatcher
+
+    def snapshot(self, reason: str = "manual"):
+        """
+        Persist an append-only snapshot of the current execution state.
+
+        Failures are logged rather than raised so snapshotting can never break
+        an agent loop. Returns the created AgentSnapshot or None on failure.
+        """
+        try:
+            snapshot = create_snapshot(
+                agent_identifier=self.agent_id,
+                world_context=self.world_context,
+                task_context=self.task_context,
+                execution_context=self.execution_context,
+                function_log=self.function_log,
+                reason=reason,
+            )
+            logger.info(
+                f"Saved snapshot step={snapshot.step} reason={reason} for agent_id={self.agent_id}"
+            )
+            return snapshot
+        except Exception as e:
+            logger.error(f"Failed to snapshot agent context for agent_id={self.agent_id}: {e}")
+            return None
+
+    def restore_snapshot(self, snapshot_id: int = None) -> bool:
+        """
+        Rehydrate execution state from a snapshot.
+
+        Restores the latest snapshot for this agent, or a specific snapshot_id
+        (which must belong to this agent). Returns True if state was restored.
+        """
+        try:
+            if snapshot_id is not None:
+                snapshot = get_snapshot_by_id(snapshot_id)
+                if snapshot is not None and snapshot.agent_identifier != self.agent_id:
+                    logger.warning(
+                        f"Snapshot {snapshot_id} belongs to agent {snapshot.agent_identifier}, "
+                        f"not {self.agent_id}; refusing to restore"
+                    )
+                    return False
+            else:
+                snapshot = get_latest_snapshot(self.agent_id)
+        except Exception as e:
+            logger.error(f"Failed to load snapshot for agent_id={self.agent_id}: {e}")
+            return False
+
+        if snapshot is None:
+            logger.info(f"No snapshot found for agent_id={self.agent_id}")
+            return False
+
+        state = snapshot.to_dict()
+        self.world_context = state["world_context"]
+        self.task_context = state["task_context"]
+        self.execution_context = state["execution_context"]
+        self.function_log = state["function_log"]
+        # function_log identity changed; rebuild the dispatcher so journaling follows it
+        self._tool_dispatcher = None
+        logger.info(
+            f"Restored snapshot step={state['step']} for agent_id={self.agent_id}"
+        )
+        return True
 
 
     

--- a/agents/agent_settings.py
+++ b/agents/agent_settings.py
@@ -17,3 +17,5 @@ class AgentSettings:
     interactive_only: bool = False
     #optional processiung for agents
     include_world_processing: bool = False
+    #days of state snapshots to retain; the latest snapshot is always kept. 0 disables pruning.
+    snapshot_retention_days: int = 7

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -85,6 +85,26 @@ class BaseAgent(ABC):
             "execution_context" : self._agent_context.execution_context
         }
 
+    def save_state_snapshot(self, reason: str = "manual"):
+        '''
+        Persist an append-only snapshot of the agent's execution state
+        (world/task/execution contexts and function log).
+        '''
+        return self._agent_context.snapshot(reason=reason)
+
+    def restore_state_snapshot(self, snapshot_id: Optional[int] = None) -> bool:
+        '''
+        Rehydrate the agent's execution state from its latest snapshot,
+        or from a specific snapshot_id. Returns True if state was restored.
+        '''
+        return self._agent_context.restore_snapshot(snapshot_id=snapshot_id)
+
+    def get_tool_schemas(self):
+        '''
+        Reflected JSON schemas for the adapter actions available to this agent.
+        '''
+        return self._agent_context.get_tool_schemas()
+
 
     @abstractmethod
     def tick_world(self):

--- a/agents/gpt4_agent.py
+++ b/agents/gpt4_agent.py
@@ -46,11 +46,13 @@ class GPT4Agent(BaseAgent):
         super().__init__(agent_context, as_subprocess)
 
     def phase_out(self):
+        self.save_state_snapshot(reason="phase_out")
         self._agent_context._save()
         self.terminate_subprocess()
 
     def phase_in(self):
         self.initialize()
+        self.restore_state_snapshot()
 
     def _is_valid_function_json(self, function_json:str):
         try:
@@ -281,6 +283,7 @@ class GPT4Agent(BaseAgent):
             self.tick_world()
         self._pop_and_add_execution_tasks()
         self._clear_execution_tasks()
+        self.save_state_snapshot(reason="tick")
 
     def is_subprocess_running(self):
         # Retrieve subprocess ID from agent context

--- a/agents/local_agent.py
+++ b/agents/local_agent.py
@@ -10,6 +10,14 @@ from agents.architectures.base_runner import GenerationConfig
 from agents.architectures.registry import ensure_runners_registered
 from agents.models.agent_completion import AgentCompletion
 from agents.models.llama_completion import LlamaCompletion
+from agents.tool_calling import (
+    ToolCallError,
+    ToolCompletion,
+    parse_tool_call,
+    run_prompt_tool_call,
+    validate_tool_call,
+)
+from adapters.tool_schema import render_tool_prompt
 import json
 import subprocess
 import os
@@ -161,6 +169,63 @@ class LocalAgent(BaseAgent):
         completion.chat_id = chat_history.chat_session_id
         return completion
 
+    def _complete_raw(self, prompt: str, system_prompt: Optional[str] = None,
+                      max_tokens: int = None, temperature: float = None) -> str:
+        """
+        Single completion returning plain text, without chat-history side effects.
+        Used for tool-call loops so intermediate attempts don't pollute history.
+        """
+        if not self.runner:
+            raise RuntimeError("Runner not initialized")
+        gen_config = self._create_generation_config(max_tokens=max_tokens, temperature=temperature)
+        completion_result = self.runner.complete(
+            system_prompt=system_prompt or SYSTEM_PROMPT,
+            user_prompt=prompt,
+            generation_config=gen_config
+        )
+        completion = LlamaCompletion.from_dict(completion_result)
+        return next((msg.content for msg in completion.messages if msg.role == 'assistant'), "")
+
+    def complete_with_tools(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = None,
+        temperature: float = None,
+        max_tool_iterations: int = 3,
+        chat_id: Optional[int] = None,
+    ) -> ToolCompletion:
+        """
+        Tool-augmented completion for local models via schema-grounded prompting.
+
+        Local models keep the reflection-based function visibility: adapter
+        actions are reflected into JSON schemas and rendered into the prompt.
+        Robustness comes from tolerant JSON extraction, schema validation with
+        type coercion, and validation-error feedback on retries.
+        """
+        result = run_prompt_tool_call(
+            complete_fn=lambda task, system: self._complete_raw(
+                task, system_prompt or system, max_tokens=max_tokens, temperature=temperature
+            ),
+            schemas=self._agent_context.get_tool_schemas(),
+            dispatcher=self._agent_context.get_tool_dispatcher(),
+            task_prompt=prompt,
+            max_attempts=max_tool_iterations,
+        )
+        if chat_id is not None:
+            try:
+                self._agent_context._add_to_chat_history(
+                    user_message=prompt, ai_message=result.to_content(), chat_id=chat_id
+                )
+            except Exception as e:
+                self.logger.warning(f"Failed to record tool completion in chat history: {e}")
+        return ToolCompletion(
+            content=result.to_content(),
+            tool_results=[result],
+            iterations=1,
+            used_native_tools=False,
+        )
+
     def stream_complete_text(
         self,
         prompt: str,
@@ -245,14 +310,16 @@ class LocalAgent(BaseAgent):
     
     def phase_out(self):
         """Phase out the agent and clean up resources."""
+        self.save_state_snapshot(reason="phase_out")
         self._agent_context._save()
         if self.runner:
             self.runner.cleanup()
         self.terminate_subprocess()
-    
+
     def phase_in(self):
-        """Phase in the agent and restore state."""
+        """Phase in the agent and restore state from the latest snapshot."""
         self.initialize()
+        self.restore_state_snapshot()
     
     def terminate_subprocess(self):
         """Terminate any running subprocess."""
@@ -268,12 +335,13 @@ class LocalAgent(BaseAgent):
                 self._agent_context.subprocess_id = None
     
     def tick(self):
-        """Execute one agent tick."""
+        """Execute one agent tick and snapshot the resulting state."""
         self.logger.info("LocalAgent Tick.")
         if self._agent_context.settings.include_world_processing:
             self.tick_world()
         self.tick_tasks()
         self.tick_execution()
+        self.save_state_snapshot(reason="tick")
     
     def tick_world(self):
         """Advance world state reasoning."""
@@ -294,13 +362,20 @@ class LocalAgent(BaseAgent):
         return split_result
     
     def tick_execution(self):
-        """Advance execution context reasoning."""
+        """Advance execution context reasoning with full tool visibility."""
         context_string = self._aggregated_context(world_context=True, task_context=True, execution_context=True)
-        result = self.complete_text(prompt=EXECUTION_TICK_PROMPT + context_string)
+        result = self.complete_text(prompt=EXECUTION_TICK_PROMPT + context_string + self._tool_visibility_prompt())
         result = self._transform_completions(result)
         split_result = result[0].split("\\n") if result else []
         self._agent_context.execution_context = split_result
         return split_result
+
+    def _tool_visibility_prompt(self) -> str:
+        """Rendered schemas of the available tools, for prompt-based execution."""
+        schemas = self._agent_context.get_tool_schemas()
+        if not schemas:
+            return ""
+        return "\nAVAILABLE_TOOLS (JSON schemas):\n" + render_tool_prompt(schemas)
     
     def _aggregated_context(self, world_context: bool, task_context: bool, execution_context: bool) -> str:
         """Get aggregated context string."""
@@ -330,35 +405,17 @@ class LocalAgent(BaseAgent):
             raise Exception(f"Completion failed to destructure: {completion}")
     
     def _is_valid_function_json(self, function_json: str) -> bool:
-        """Validate function call JSON format."""
+        """Validate that text contains a parseable, schema-valid tool call."""
         try:
-            function_json = function_json.replace('\\n', '')
-            parsed_json = json.loads(function_json)
-            required_keys = ["function", "parameters", "class"]
-            if all(key in parsed_json for key in required_keys):
-                if isinstance(parsed_json["parameters"], dict):
-                    return True
+            call = parse_tool_call(function_json)
+            validate_tool_call(call, self._agent_context.get_tool_schemas())
+            return True
+        except ToolCallError:
             return False
-        except json.JSONDecodeError:
-            return False
-    
+
     def _take_json_and_call_function(self, function_json: str):
-        """Execute function call from JSON specification."""
-        if not self._is_valid_function_json(function_json):
-            raise Exception(f"Invalid function call json: {function_json}")
-        
-        json_data = json.loads(function_json)
-        class_name = json_data["class"]
-        adapter_class = next(
-            (wrapper for wrapper in self._agent_context.initialized_classes if wrapper.name == class_name),
-            None
-        )
-        
-        if not adapter_class:
-            raise Exception(f"No adapter class matching {class_name}")
-        
-        adapter_class = adapter_class.instance
-        function_to_call = getattr(adapter_class, json_data["function"])
-        parameters = json_data["parameters"]
-        
-        return function_to_call(**parameters)
+        """Parse, validate, and execute a tool call from model output."""
+        result = self._agent_context.get_tool_dispatcher().dispatch_text(function_json)
+        if not result.success:
+            raise Exception(f"Tool call failed: {result.error}")
+        return result.result

--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -12,6 +12,16 @@ from agents.base_agent import BaseAgent
 from agents.agent_context import AgentContext
 from agents.models.generic_completion import GenericCompletion
 from agents.models.agent_completion import AgentCompletion
+from agents.tool_calling import (
+    ToolCall,
+    ToolCallError,
+    ToolCompletion,
+    ToolResult,
+    parse_tool_call,
+    run_prompt_tool_call,
+    validate_tool_call,
+)
+from adapters.tool_schema import render_tool_prompt
 from app.models.database.chat_session import get_chat_history
 
 logger = logging.getLogger(__name__)
@@ -366,6 +376,147 @@ class OnlineAgent(BaseAgent):
             self.logger.error(f"Streaming error: {e}")
             raise
     
+    def _complete_raw(self, prompt: str, system_prompt: Optional[str] = None,
+                      max_tokens: int = None, temperature: float = None) -> str:
+        """
+        Single completion returning plain text, without chat-history side effects.
+        Used for tool-call loops so intermediate attempts don't pollute history.
+        """
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        payload = {
+            "messages": messages,
+            "model": self.model,
+            "max_tokens": max_tokens or self._agent_context.settings.max_tokens or 16,
+            "temperature": temperature if temperature is not None else (self._agent_context.settings.temperature or 1.0),
+        }
+        response = self._make_request(payload)
+        choices = response.get("choices") or []
+        if not choices:
+            return ""
+        return (choices[0].get("message") or {}).get("content") or ""
+
+    def complete_with_tools(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = None,
+        temperature: float = None,
+        max_tool_iterations: int = 4,
+        chat_id: Optional[int] = None,
+    ) -> ToolCompletion:
+        """
+        Tool-augmented completion using the provider's native function calling.
+
+        Adapter actions are exposed via the OpenAI-compatible `tools` parameter;
+        returned tool_calls are validated against the reflected schemas and
+        dispatched, with results fed back as `tool` messages until the model
+        produces a final text answer or the iteration cap is reached. If the
+        endpoint rejects the tools payload, falls back to schema-grounded
+        prompt-based tool calling.
+        """
+        schemas = self._agent_context.get_tool_schemas()
+        dispatcher = self._agent_context.get_tool_dispatcher()
+
+        if not schemas:
+            content = self._complete_raw(prompt, system_prompt, max_tokens, temperature)
+            return ToolCompletion(content=content, tool_results=[], iterations=1)
+
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        tools_payload = [schema.to_openai_tool() for schema in schemas]
+
+        tool_results: List[ToolResult] = []
+        content: Optional[str] = None
+        iteration = 0
+
+        for iteration in range(1, max_tool_iterations + 1):
+            payload = {
+                "messages": messages,
+                "model": self.model,
+                "max_tokens": max_tokens or self._agent_context.settings.max_tokens or 16,
+                "temperature": temperature if temperature is not None else (self._agent_context.settings.temperature or 1.0),
+                "tools": tools_payload,
+            }
+            try:
+                response = self._make_request(payload)
+            except Exception as e:
+                if iteration == 1:
+                    self.logger.warning(
+                        f"Native tool calling failed ({e}); falling back to prompt-based tool calling"
+                    )
+                    return self._prompt_based_tool_completion(prompt, chat_id=chat_id)
+                raise
+
+            choices = response.get("choices") or []
+            if not choices:
+                break
+            message = choices[0].get("message") or {}
+            tool_calls = message.get("tool_calls")
+
+            if not tool_calls:
+                content = message.get("content")
+                break
+
+            messages.append(message)
+            for tool_call in tool_calls:
+                result = self._dispatch_native_tool_call(tool_call, dispatcher)
+                tool_results.append(result)
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call.get("id", ""),
+                    "content": result.to_content(),
+                })
+
+        if chat_id is not None:
+            try:
+                self._agent_context._add_to_chat_history(
+                    user_message=prompt, ai_message=content, chat_id=chat_id
+                )
+            except Exception as e:
+                self.logger.warning(f"Failed to record tool completion in chat history: {e}")
+
+        return ToolCompletion(
+            content=content,
+            tool_results=tool_results,
+            iterations=iteration,
+            used_native_tools=True,
+        )
+
+    def _dispatch_native_tool_call(self, tool_call: Dict[str, Any], dispatcher) -> ToolResult:
+        """Convert a provider tool_call entry into a validated, dispatched ToolCall."""
+        function = tool_call.get("function") or {}
+        name = function.get("name") or ""
+        raw_arguments = function.get("arguments") or "{}"
+        try:
+            arguments = json.loads(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
+            if not isinstance(arguments, dict):
+                raise ToolCallError("tool call arguments must decode to a JSON object")
+            call = ToolCall.from_qualified_name(name, arguments, raw=str(raw_arguments))
+        except (json.JSONDecodeError, ToolCallError) as e:
+            self.logger.warning(f"Malformed native tool call '{name}': {e}")
+            return ToolResult(call=None, success=False, error=f"Malformed tool call '{name}': {e}")
+        return dispatcher.dispatch(call)
+
+    def _prompt_based_tool_completion(self, prompt: str, chat_id: Optional[int] = None) -> ToolCompletion:
+        """Schema-grounded prompt fallback when native tool calling is unavailable."""
+        result = run_prompt_tool_call(
+            complete_fn=lambda task, system: self._complete_raw(task, system),
+            schemas=self._agent_context.get_tool_schemas(),
+            dispatcher=self._agent_context.get_tool_dispatcher(),
+            task_prompt=prompt,
+        )
+        return ToolCompletion(
+            content=result.to_content(),
+            tool_results=[result],
+            iterations=1,
+            used_native_tools=False,
+        )
+
     def complete_audio(
         self,
         audio_file,
@@ -464,14 +615,16 @@ class OnlineAgent(BaseAgent):
 
     def phase_out(self):
         """Phase out the agent and clean up resources."""
+        self.save_state_snapshot(reason="phase_out")
         self._agent_context._save()
         if hasattr(self, 'client'):
             self.client.close()
         self.terminate_subprocess()
-    
+
     def phase_in(self):
-        """Phase in the agent and restore state."""
+        """Phase in the agent and restore state from the latest snapshot."""
         self.initialize()
+        self.restore_state_snapshot()
     
     def terminate_subprocess(self):
         """Terminate any running subprocess."""
@@ -487,12 +640,13 @@ class OnlineAgent(BaseAgent):
                 self._agent_context.subprocess_id = None
     
     def tick(self):
-        """Execute one agent tick."""
+        """Execute one agent tick and snapshot the resulting state."""
         self.logger.info("OnlineAgent Tick.")
         if self._agent_context.settings.include_world_processing:
             self.tick_world()
         self.tick_tasks()
         self.tick_execution()
+        self.save_state_snapshot(reason="tick")
     
     def tick_world(self):
         """Advance world state reasoning."""
@@ -513,13 +667,20 @@ class OnlineAgent(BaseAgent):
         return split_result
     
     def tick_execution(self):
-        """Advance execution context reasoning."""
+        """Advance execution context reasoning with full tool visibility."""
         context_string = self._aggregated_context(world_context=True, task_context=True, execution_context=True)
-        result = self.complete_text(prompt=EXECUTION_TICK_PROMPT + context_string)
+        result = self.complete_text(prompt=EXECUTION_TICK_PROMPT + context_string + self._tool_visibility_prompt())
         result = self._transform_completions(result)
         split_result = result[0].split("\\n") if result else []
         self._agent_context.execution_context = split_result
         return split_result
+
+    def _tool_visibility_prompt(self) -> str:
+        """Rendered schemas of the available tools, for prompt-based execution."""
+        schemas = self._agent_context.get_tool_schemas()
+        if not schemas:
+            return ""
+        return "\nAVAILABLE_TOOLS (JSON schemas):\n" + render_tool_prompt(schemas)
     
     def _aggregated_context(self, world_context: bool, task_context: bool, execution_context: bool) -> str:
         """Get aggregated context string."""
@@ -546,35 +707,17 @@ class OnlineAgent(BaseAgent):
             raise Exception(f"Completion failed to destructure: {completion}")
     
     def _is_valid_function_json(self, function_json: str) -> bool:
-        """Validate function call JSON format."""
+        """Validate that text contains a parseable, schema-valid tool call."""
         try:
-            function_json = function_json.replace('\\n', '')
-            parsed_json = json.loads(function_json)
-            required_keys = ["function", "parameters", "class"]
-            if all(key in parsed_json for key in required_keys):
-                if isinstance(parsed_json["parameters"], dict):
-                    return True
+            call = parse_tool_call(function_json)
+            validate_tool_call(call, self._agent_context.get_tool_schemas())
+            return True
+        except ToolCallError:
             return False
-        except json.JSONDecodeError:
-            return False
-    
+
     def _take_json_and_call_function(self, function_json: str):
-        """Execute function call from JSON specification."""
-        if not self._is_valid_function_json(function_json):
-            raise Exception(f"Invalid function call json: {function_json}")
-        
-        json_data = json.loads(function_json)
-        class_name = json_data["class"]
-        adapter_class = next(
-            (wrapper for wrapper in self._agent_context.initialized_classes if wrapper.name == class_name),
-            None
-        )
-        
-        if not adapter_class:
-            raise Exception(f"No adapter class matching {class_name}")
-        
-        adapter_class = adapter_class.instance
-        function_to_call = getattr(adapter_class, json_data["function"])
-        parameters = json_data["parameters"]
-        
-        return function_to_call(**parameters)
+        """Parse, validate, and execute a tool call from model output."""
+        result = self._agent_context.get_tool_dispatcher().dispatch_text(function_json)
+        if not result.success:
+            raise Exception(f"Tool call failed: {result.error}")
+        return result.result

--- a/agents/tool_calling.py
+++ b/agents/tool_calling.py
@@ -1,0 +1,417 @@
+"""
+Structured tool calling shared by agents.
+
+Provides robust parsing of model-emitted tool calls (JSON embedded in prose,
+markdown fences, alias keys), schema validation with type coercion, and a
+dispatcher that executes adapter actions and journals results to the agent's
+function log. Used natively by OnlineAgent (provider `tools` API) and as the
+schema-grounded prompt path for LocalAgent.
+"""
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from adapters.tool_schema import (
+    QUALIFIED_NAME_SEPARATOR,
+    ToolSchema,
+    enumerate_tool_schemas,
+    render_tool_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+STRUCTURED_TOOL_SYSTEM_PROMPT = (
+    "You are an agent that completes tasks by calling tools. "
+    "Respond with ONLY a single JSON object of the form "
+    '{"class": "AdapterName", "function": "action_name", "parameters": {...}} '
+    "using one of the listed tools. Do not include any other text."
+)
+
+
+class ToolCallError(Exception):
+    """Raised when a tool call cannot be parsed or validated."""
+
+
+@dataclass
+class ToolCall:
+    """A parsed request to invoke one adapter action."""
+    adapter: str
+    function: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
+    raw: str = ""
+
+    @classmethod
+    def from_qualified_name(cls, name: str, arguments: Dict[str, Any], raw: str = "") -> "ToolCall":
+        adapter, separator, function = name.partition(QUALIFIED_NAME_SEPARATOR)
+        if not separator or not adapter or not function:
+            raise ToolCallError(
+                f"Tool name '{name}' is not namespaced as Adapter{QUALIFIED_NAME_SEPARATOR}action"
+            )
+        return cls(adapter=adapter, function=function, arguments=arguments, raw=raw)
+
+
+@dataclass
+class ToolResult:
+    """Outcome of dispatching a single tool call."""
+    call: Optional[ToolCall]
+    success: bool
+    result: Any = None
+    error: Optional[str] = None
+
+    def to_content(self) -> str:
+        """Serialize for feeding back to a model as a tool message."""
+        payload = {"success": self.success}
+        if self.success:
+            try:
+                json.dumps(self.result)
+                payload["result"] = self.result
+            except (TypeError, ValueError):
+                payload["result"] = str(self.result)
+        else:
+            payload["error"] = self.error
+        return json.dumps(payload)
+
+    def to_log_entry(self) -> Dict[str, Any]:
+        entry = {
+            "adapter": self.call.adapter if self.call else None,
+            "function": self.call.function if self.call else None,
+            "arguments": self.call.arguments if self.call else None,
+            "success": self.success,
+        }
+        if self.success:
+            entry["result"] = str(self.result)
+        else:
+            entry["error"] = self.error
+        return entry
+
+
+@dataclass
+class ToolCompletion:
+    """Result of a tool-augmented completion loop."""
+    content: Optional[str]
+    tool_results: List[ToolResult] = field(default_factory=list)
+    iterations: int = 0
+    used_native_tools: bool = False
+
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
+
+
+def extract_json_candidates(text: str) -> List[str]:
+    """
+    Extract candidate JSON object strings from model output.
+
+    Handles markdown fences and balanced top-level objects embedded in prose.
+    """
+    candidates: List[str] = []
+    for fenced in _JSON_FENCE_RE.findall(text):
+        if fenced.startswith("{"):
+            candidates.append(fenced)
+
+    depth = 0
+    start = None
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}" and depth > 0:
+            depth -= 1
+            if depth == 0 and start is not None:
+                candidates.append(text[start:index + 1])
+                start = None
+
+    # Preserve order but drop duplicates (a fenced block is also found by the scan)
+    seen = set()
+    unique = []
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def parse_tool_call(text: str) -> ToolCall:
+    """
+    Parse a tool call from model output.
+
+    Accepts the canonical {"class", "function", "parameters"} shape as well as
+    common aliases ("adapter", "action"/"name", "arguments") and qualified
+    names ("Adapter__action"). Raises ToolCallError with an actionable message
+    suitable for feeding back to the model on retry.
+    """
+    if not text or not text.strip():
+        raise ToolCallError("Empty completion; expected a JSON tool call object.")
+
+    errors: List[str] = []
+    for candidate in extract_json_candidates(text):
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            errors.append(f"Invalid JSON ({exc.msg})")
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        adapter = data.get("class") or data.get("adapter")
+        function = data.get("function") or data.get("action") or data.get("name")
+        arguments = data.get("parameters", data.get("arguments"))
+
+        if isinstance(function, str) and QUALIFIED_NAME_SEPARATOR in function and not adapter:
+            adapter, _, function = function.partition(QUALIFIED_NAME_SEPARATOR)
+
+        if not adapter or not function:
+            errors.append("JSON object is missing 'class' and/or 'function' keys")
+            continue
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            errors.append("'parameters' must be a JSON object of argument name/value pairs")
+            continue
+        return ToolCall(adapter=str(adapter), function=str(function), arguments=arguments, raw=candidate)
+
+    if errors:
+        raise ToolCallError("; ".join(errors))
+    raise ToolCallError("No JSON object found in completion; respond with only the tool call JSON.")
+
+
+_JSON_TYPE_CHECKS = {
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+_TRUE_STRINGS = {"true", "yes", "1"}
+_FALSE_STRINGS = {"false", "no", "0"}
+
+
+def _coerce_value(value: Any, expected_type: str) -> Any:
+    """Coerce a value to the expected JSON type, raising ValueError if impossible."""
+    expected = _JSON_TYPE_CHECKS[expected_type]
+    if isinstance(value, expected) and not (expected_type in ("integer", "number") and isinstance(value, bool)):
+        return float(value) if expected_type == "number" and isinstance(value, int) else value
+
+    if expected_type == "number" and isinstance(value, int) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if expected_type == "integer":
+            return int(stripped)
+        if expected_type == "number":
+            return float(stripped)
+        if expected_type == "boolean":
+            lowered = stripped.lower()
+            if lowered in _TRUE_STRINGS:
+                return True
+            if lowered in _FALSE_STRINGS:
+                return False
+            raise ValueError(f"cannot interpret '{value}' as boolean")
+        if expected_type in ("array", "object"):
+            parsed = json.loads(stripped)
+            if isinstance(parsed, expected):
+                return parsed
+            raise ValueError(f"parsed JSON is not of type {expected_type}")
+    if expected_type == "string" and isinstance(value, (int, float, bool)):
+        return json.dumps(value) if isinstance(value, bool) else str(value)
+    raise ValueError(f"expected {expected_type}, got {type(value).__name__}")
+
+
+def find_schema(call: ToolCall, schemas: List[ToolSchema]) -> Optional[ToolSchema]:
+    """Find the schema matching a call, tolerating case mismatches."""
+    for schema in schemas:
+        if schema.adapter == call.adapter and schema.action == call.function:
+            return schema
+    for schema in schemas:
+        if (schema.adapter.lower() == call.adapter.lower()
+                and schema.action.lower() == call.function.lower()):
+            return schema
+    return None
+
+
+def validate_tool_call(call: ToolCall, schemas: List[ToolSchema]) -> ToolCall:
+    """
+    Validate a parsed call against the available tool schemas.
+
+    Returns a normalized copy (canonical adapter/action casing, coerced argument
+    types, unknown arguments dropped). Raises ToolCallError describing every
+    problem found so the message can be fed back to the model.
+    """
+    schema = find_schema(call, schemas)
+    if schema is None:
+        available = ", ".join(s.qualified_name for s in schemas) or "none"
+        raise ToolCallError(
+            f"Unknown tool '{call.adapter}.{call.function}'. Available tools: {available}"
+        )
+
+    properties = schema.parameters.get("properties", {})
+    required = schema.parameters.get("required", [])
+    errors: List[str] = []
+    normalized: Dict[str, Any] = {}
+
+    for name, value in call.arguments.items():
+        if name not in properties:
+            logger.warning(
+                "Dropping unknown argument '%s' for tool %s", name, schema.qualified_name
+            )
+            continue
+        expected_type = properties[name].get("type")
+        if expected_type in _JSON_TYPE_CHECKS:
+            try:
+                normalized[name] = _coerce_value(value, expected_type)
+            except (ValueError, TypeError, json.JSONDecodeError):
+                errors.append(
+                    f"Argument '{name}' must be of type {expected_type}, got {value!r}"
+                )
+        else:
+            normalized[name] = value
+
+    for name in required:
+        if name not in normalized and not any(error.startswith(f"Argument '{name}'") for error in errors):
+            errors.append(f"Missing required argument '{name}'")
+
+    if errors:
+        raise ToolCallError("; ".join(errors))
+
+    return ToolCall(
+        adapter=schema.adapter,
+        function=schema.action,
+        arguments=normalized,
+        raw=call.raw,
+    )
+
+
+class ToolDispatcher:
+    """
+    Validates and executes tool calls against initialized adapter instances.
+
+    Execution failures are captured as unsuccessful ToolResults rather than
+    raised, so one bad call cannot crash an agent loop. Every dispatch is
+    journaled to the provided function log.
+    """
+
+    def __init__(self, adapter_wrappers: List[Any], schemas: Optional[List[ToolSchema]] = None,
+                 function_log: Optional[List[Any]] = None):
+        self._instances = {wrapper.name: wrapper.instance for wrapper in adapter_wrappers}
+        if schemas is None:
+            schemas = []
+            for wrapper in adapter_wrappers:
+                schemas.extend(enumerate_tool_schemas(wrapper.instance))
+        self.schemas = schemas
+        self.function_log = function_log if function_log is not None else []
+
+    def dispatch(self, call: ToolCall) -> ToolResult:
+        try:
+            call = validate_tool_call(call, self.schemas)
+        except ToolCallError as exc:
+            result = ToolResult(call=call, success=False, error=str(exc))
+            self._log(result)
+            return result
+
+        instance = self._instances.get(call.adapter)
+        if instance is None:
+            result = ToolResult(
+                call=call,
+                success=False,
+                error=f"Adapter '{call.adapter}' is not initialized for this agent",
+            )
+            self._log(result)
+            return result
+
+        try:
+            output = getattr(instance, call.function)(**call.arguments)
+            result = ToolResult(call=call, success=True, result=output)
+        except Exception as exc:
+            logger.exception("Tool %s.%s raised", call.adapter, call.function)
+            result = ToolResult(
+                call=call,
+                success=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        self._log(result)
+        return result
+
+    def dispatch_text(self, text: str) -> ToolResult:
+        """Parse model output and dispatch it, capturing parse failures as results."""
+        try:
+            call = parse_tool_call(text)
+        except ToolCallError as exc:
+            result = ToolResult(call=None, success=False, error=str(exc))
+            self._log(result)
+            return result
+        return self.dispatch(call)
+
+    def _log(self, result: ToolResult) -> None:
+        try:
+            self.function_log.append(json.dumps(result.to_log_entry(), default=str))
+        except Exception:
+            logger.warning("Failed to append tool result to function log", exc_info=True)
+
+
+def run_prompt_tool_call(
+    complete_fn: Callable[[str, str], str],
+    schemas: List[ToolSchema],
+    dispatcher: ToolDispatcher,
+    task_prompt: str,
+    max_attempts: int = 3,
+) -> ToolResult:
+    """
+    Prompt-based tool calling with schema visibility and validation feedback.
+
+    Used by local models (and as the fallback for online providers without
+    native tool support): the model sees the reflected tool schemas, its output
+    is parsed and validated, and validation errors are fed back on retry.
+
+    Args:
+        complete_fn: Callable of (prompt, system_prompt) returning model text.
+        schemas: Tool schemas visible to the model.
+        dispatcher: Dispatcher used to execute the validated call.
+        task_prompt: Description of the task the tool call should accomplish.
+        max_attempts: Attempts before giving up (validation feedback in between).
+    """
+    if not schemas:
+        return ToolResult(call=None, success=False, error="No tools are available to this agent")
+
+    base_prompt = (
+        f"{task_prompt}\n\nAVAILABLE_TOOLS (JSON schemas):\n{render_tool_prompt(schemas)}\n\n"
+        'Respond with ONLY one JSON object: {"class": ..., "function": ..., "parameters": {...}}'
+    )
+    prompt = base_prompt
+    last_error = "no attempts made"
+
+    for _ in range(max_attempts):
+        text = complete_fn(prompt, STRUCTURED_TOOL_SYSTEM_PROMPT)
+        try:
+            call = parse_tool_call(text or "")
+            call = validate_tool_call(call, schemas)
+        except ToolCallError as exc:
+            last_error = str(exc)
+            logger.info("Invalid tool call attempt, retrying with feedback: %s", last_error)
+            prompt = (
+                f"{base_prompt}\n\nYour previous response was invalid: {last_error}\n"
+                "Respond again with ONLY the corrected JSON object."
+            )
+            continue
+        return dispatcher.dispatch(call)
+
+    return ToolResult(
+        call=None,
+        success=False,
+        error=f"Failed to produce a valid tool call after {max_attempts} attempts: {last_error}",
+    )

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -5,3 +5,4 @@ from app.models.database.chat_session import ChatSession
 from app.models.database.file_upload import FileUpload
 from app.models.database.workflow import Workflow, WorkflowStep, WorkflowRun, WorkflowStepResult
 from app.models.database.user_settings import UserSettings
+from app.models.database.agent_snapshot import AgentSnapshot

--- a/app/models/database/agent_snapshot.py
+++ b/app/models/database/agent_snapshot.py
@@ -1,0 +1,142 @@
+import datetime
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import Column, DateTime, Integer, String, Text, func
+
+from app.models.database.database import Base, SessionLocal
+
+logger = logging.getLogger(__name__)
+
+
+class AgentSnapshot(Base):
+    '''
+    SqlAlchemy class persisting point-in-time snapshots of agent execution state.
+
+    Snapshots are append-only: one row per (agent, step), written after each
+    tick and on phase_out, so agent runs can be resumed after a crash,
+    inspected tick by tick, or rolled back to an earlier step.
+    '''
+    __tablename__ = "agent_snapshot"
+    snapshot_id = Column(Integer, primary_key=True, autoincrement=True)
+    agent_identifier = Column(String, nullable=False, index=True)
+    step = Column(Integer, nullable=False, default=0)
+    reason = Column(String, default="manual")
+    world_context = Column(Text)
+    task_context = Column(Text)
+    execution_context = Column(Text)
+    function_log = Column(Text)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+
+    @staticmethod
+    def _loads(serialized: Optional[str]) -> List[Any]:
+        if not serialized:
+            return []
+        try:
+            value = json.loads(serialized)
+            return value if isinstance(value, list) else []
+        except (TypeError, ValueError):
+            logger.warning("Failed to deserialize snapshot column; returning empty list")
+            return []
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_id": self.snapshot_id,
+            "agent_identifier": self.agent_identifier,
+            "step": self.step,
+            "reason": self.reason,
+            "world_context": self._loads(self.world_context),
+            "task_context": self._loads(self.task_context),
+            "execution_context": self._loads(self.execution_context),
+            "function_log": self._loads(self.function_log),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }
+
+
+def create_snapshot(
+    agent_identifier: str,
+    world_context: List[Any],
+    task_context: List[Any],
+    execution_context: List[Any],
+    function_log: Optional[List[Any]] = None,
+    reason: str = "manual",
+) -> AgentSnapshot:
+    """Persist a new snapshot with the next step number for the agent."""
+    with SessionLocal() as session:
+        max_step = (
+            session.query(func.max(AgentSnapshot.step))
+            .filter(AgentSnapshot.agent_identifier == agent_identifier)
+            .scalar()
+        )
+        snapshot = AgentSnapshot(
+            agent_identifier=agent_identifier,
+            step=(max_step or 0) + 1,
+            reason=reason,
+            world_context=json.dumps(world_context, default=str),
+            task_context=json.dumps(task_context, default=str),
+            execution_context=json.dumps(execution_context, default=str),
+            function_log=json.dumps(function_log or [], default=str),
+        )
+        session.add(snapshot)
+        session.commit()
+        session.refresh(snapshot)
+        session.expunge(snapshot)
+        return snapshot
+
+
+def get_snapshots(agent_identifier: str, limit: int = 50) -> List[AgentSnapshot]:
+    """Return snapshots for an agent, most recent step first."""
+    with SessionLocal() as session:
+        snapshots = (
+            session.query(AgentSnapshot)
+            .filter(AgentSnapshot.agent_identifier == agent_identifier)
+            .order_by(AgentSnapshot.step.desc())
+            .limit(limit)
+            .all()
+        )
+        for snapshot in snapshots:
+            session.expunge(snapshot)
+        return snapshots
+
+
+def get_latest_snapshot(agent_identifier: str) -> Optional[AgentSnapshot]:
+    snapshots = get_snapshots(agent_identifier, limit=1)
+    return snapshots[0] if snapshots else None
+
+
+def get_snapshot_by_id(snapshot_id: int) -> Optional[AgentSnapshot]:
+    with SessionLocal() as session:
+        snapshot = (
+            session.query(AgentSnapshot)
+            .filter(AgentSnapshot.snapshot_id == snapshot_id)
+            .first()
+        )
+        if snapshot is not None:
+            session.expunge(snapshot)
+        return snapshot
+
+
+def prune_snapshots(agent_identifier: str, keep_last: int = 100) -> int:
+    """Delete all but the most recent `keep_last` snapshots for an agent."""
+    with SessionLocal() as session:
+        steps = [
+            row[0]
+            for row in session.query(AgentSnapshot.step)
+            .filter(AgentSnapshot.agent_identifier == agent_identifier)
+            .order_by(AgentSnapshot.step.desc())
+            .limit(keep_last)
+            .all()
+        ]
+        if not steps:
+            return 0
+        deleted = (
+            session.query(AgentSnapshot)
+            .filter(
+                AgentSnapshot.agent_identifier == agent_identifier,
+                AgentSnapshot.step < min(steps),
+            )
+            .delete(synchronize_session=False)
+        )
+        session.commit()
+        return deleted

--- a/app/models/database/agent_snapshot.py
+++ b/app/models/database/agent_snapshot.py
@@ -117,6 +117,38 @@ def get_snapshot_by_id(snapshot_id: int) -> Optional[AgentSnapshot]:
         return snapshot
 
 
+def prune_snapshots_older_than(agent_identifier: str, retention_days: int = 7) -> int:
+    """
+    Delete an agent's snapshots older than the retention window.
+
+    The most recent snapshot is always kept regardless of age — it is the
+    agent's resume point for phase_in. A retention of 0 (or negative)
+    disables pruning.
+    """
+    if not retention_days or retention_days <= 0:
+        return 0
+    cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=retention_days)
+    with SessionLocal() as session:
+        max_step = (
+            session.query(func.max(AgentSnapshot.step))
+            .filter(AgentSnapshot.agent_identifier == agent_identifier)
+            .scalar()
+        )
+        if max_step is None:
+            return 0
+        deleted = (
+            session.query(AgentSnapshot)
+            .filter(
+                AgentSnapshot.agent_identifier == agent_identifier,
+                AgentSnapshot.created_at < cutoff,
+                AgentSnapshot.step < max_step,
+            )
+            .delete(synchronize_session=False)
+        )
+        session.commit()
+        return deleted
+
+
 def prune_snapshots(agent_identifier: str, keep_last: int = 100) -> int:
     """Delete all but the most recent `keep_last` snapshots for an agent."""
     with SessionLocal() as session:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -70,6 +70,79 @@ agent = AgentFactory.create_agent(
 )
 ```
 
+## State Snapshots
+
+Agents persist append-only snapshots of their execution state (world, task,
+and execution contexts plus the function log) to the `agent_snapshot` table:
+
+- After every `tick()` (reason `tick`)
+- On `phase_out()` (reason `phase_out`), and `phase_in()` restores the latest snapshot
+- On demand via `agent.save_state_snapshot(reason="manual")`
+
+Each snapshot gets a monotonic `step` number per agent, enabling crash
+recovery, tick-by-tick inspection, and rollback to an earlier step:
+
+```python
+# Roll back to a specific step
+from app.models.database.agent_snapshot import get_snapshots
+
+history = get_snapshots(agent_identifier=context.agent_id)
+agent.restore_state_snapshot(snapshot_id=history[2].snapshot_id)
+
+# Resume the latest state after a restart
+agent.restore_state_snapshot()
+```
+
+Snapshot writes never raise into the agent loop — failures are logged and the
+tick continues. Use `prune_snapshots(agent_identifier, keep_last=100)` to cap
+history for long-running agents.
+
+## Structured Tool Calling
+
+Adapter actions are reflected into JSON schemas (`adapters/tool_schema.py`)
+from method signatures, type hints, and docstrings, giving models full
+function visibility: adapter/action names, typed parameters, and required
+arguments. The shared pipeline (`agents/tool_calling.py`) then parses,
+validates, and dispatches model-emitted tool calls.
+
+### OnlineAgent (native function calling)
+
+`OnlineAgent.complete_with_tools()` exposes the schemas through the
+OpenAI-compatible `tools` parameter, dispatches returned `tool_calls`, and
+feeds results back as `tool` messages until the model produces a final
+answer. If the endpoint rejects the `tools` payload, it automatically falls
+back to the prompt-based path.
+
+```python
+completion = agent.complete_with_tools(
+    "Write today's notes to notes.md",
+    max_tool_iterations=4,
+)
+print(completion.content)        # final model answer
+print(completion.tool_results)   # every dispatched ToolResult
+```
+
+### LocalAgent (schema-grounded prompting)
+
+Local models keep reflection-based function visibility: schemas are rendered
+into the prompt, and robustness comes from tolerant JSON extraction (markdown
+fences, JSON embedded in prose, alias keys), schema validation with type
+coercion (`"7"` → `7`), and validation-error feedback on retries:
+
+```python
+completion = local_agent.complete_with_tools("What is 7 + 8?")
+```
+
+### Dispatch guarantees
+
+- Unknown tools, missing required arguments, and uncoercible types are
+  rejected with actionable error messages (fed back to the model on retry)
+- Hallucinated argument names are dropped with a warning
+- Adapter exceptions are captured as unsuccessful `ToolResult`s instead of
+  crashing the agent loop
+- Every dispatch is journaled to the agent context's `function_log`, which is
+  captured by state snapshots
+
 ## User Settings
 
 ### Configuration

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -94,8 +94,18 @@ agent.restore_state_snapshot()
 ```
 
 Snapshot writes never raise into the agent loop — failures are logged and the
-tick continues. Use `prune_snapshots(agent_identifier, keep_last=100)` to cap
-history for long-running agents.
+tick continues.
+
+### Retention
+
+Snapshot history is bounded by time-based retention applied on every write:
+snapshots older than `AgentSettings.snapshot_retention_days` (default 7) are
+deleted after each new snapshot is persisted. The most recent snapshot is
+always kept regardless of age — it is the agent's resume point for
+`phase_in()`. Set `snapshot_retention_days = 0` to disable pruning (e.g. for
+debugging). Count-based capping is also available via
+`prune_snapshots(agent_identifier, keep_last=100)`. Compaction of snapshot
+contents (e.g. summarizing old function logs) is future work.
 
 ## Structured Tool Calling
 

--- a/migrations/versions/b8c4d2e6f0a3_add_agent_snapshot_table.py
+++ b/migrations/versions/b8c4d2e6f0a3_add_agent_snapshot_table.py
@@ -1,0 +1,44 @@
+"""add agent snapshot table
+
+Revision ID: b8c4d2e6f0a3
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-05
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8c4d2e6f0a3'
+down_revision: Union[str, None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'agent_snapshot',
+        sa.Column('snapshot_id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('agent_identifier', sa.String(), nullable=False),
+        sa.Column('step', sa.Integer(), nullable=False),
+        sa.Column('reason', sa.String(), nullable=True),
+        sa.Column('world_context', sa.Text(), nullable=True),
+        sa.Column('task_context', sa.Text(), nullable=True),
+        sa.Column('execution_context', sa.Text(), nullable=True),
+        sa.Column('function_log', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('snapshot_id'),
+    )
+    op.create_index(
+        op.f('ix_agent_snapshot_agent_identifier'),
+        'agent_snapshot',
+        ['agent_identifier'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_agent_snapshot_agent_identifier'), table_name='agent_snapshot')
+    op.drop_table('agent_snapshot')

--- a/tests/adapters/test_tool_schema.py
+++ b/tests/adapters/test_tool_schema.py
@@ -1,0 +1,104 @@
+"""Tests for reflection-based tool schema generation."""
+from typing import Dict, List, Optional
+
+import pytest
+
+from adapters.base_adapter import BaseAdapter
+from adapters.markdown_file_adapter import MarkdownFileAdapter
+from adapters.tool_schema import (
+    ToolSchema,
+    build_action_schema,
+    enumerate_tool_schemas,
+    render_tool_prompt,
+)
+
+
+class TypedAdapter(BaseAdapter):
+    """Adapter with a variety of parameter annotations for schema tests."""
+
+    def enumerate_actions(self):
+        return ["typed_action", "untyped_action"]
+
+    def typed_action(self, name: str, count: int, ratio: float, enabled: bool,
+                     tags: List[str], config: Dict[str, str], limit: Optional[int] = None,
+                     **kwargs) -> str:
+        """Do a typed thing.
+
+        Longer explanation that should not appear in the summary.
+        """
+        return name
+
+    def untyped_action(self, anything, other=None):
+        return anything
+
+
+def test_build_action_schema_maps_types_and_required():
+    schema = build_action_schema(TypedAdapter, "typed_action")
+
+    assert schema.adapter == "TypedAdapter"
+    assert schema.action == "typed_action"
+    assert schema.description == "Do a typed thing."
+
+    properties = schema.parameters["properties"]
+    assert properties["name"] == {"type": "string"}
+    assert properties["count"] == {"type": "integer"}
+    assert properties["ratio"] == {"type": "number"}
+    assert properties["enabled"] == {"type": "boolean"}
+    assert properties["tags"] == {"type": "array", "items": {"type": "string"}}
+    assert properties["config"] == {"type": "object"}
+    # Optional[int] unwraps to integer and is not required
+    assert properties["limit"] == {"type": "integer"}
+    # **kwargs and self are excluded
+    assert "kwargs" not in properties
+    assert "self" not in properties
+
+    assert schema.parameters["required"] == ["name", "count", "ratio", "enabled", "tags", "config"]
+
+
+def test_build_action_schema_tolerates_untyped_parameters():
+    schema = build_action_schema(TypedAdapter, "untyped_action")
+
+    assert schema.parameters["properties"]["anything"] == {}
+    assert schema.parameters["required"] == ["anything"]
+    assert "other" not in schema.parameters["required"]
+
+
+def test_build_action_schema_rejects_missing_action():
+    with pytest.raises(ValueError):
+        build_action_schema(TypedAdapter, "does_not_exist")
+
+
+def test_enumerate_tool_schemas_uses_enumerate_actions(tmp_path):
+    adapter = MarkdownFileAdapter(file_root=str(tmp_path))
+    schemas = enumerate_tool_schemas(adapter)
+
+    names = {schema.action for schema in schemas}
+    assert names == {"read_file", "write_file", "get_files"}
+
+    read_file = next(schema for schema in schemas if schema.action == "read_file")
+    assert read_file.adapter == "MarkdownFileAdapter"
+    assert read_file.parameters["required"] == ["filename"]
+    assert read_file.description.startswith("Read content from a markdown file")
+
+
+def test_qualified_name_and_openai_tool_shape(tmp_path):
+    adapter = MarkdownFileAdapter(file_root=str(tmp_path))
+    schema = next(
+        schema for schema in enumerate_tool_schemas(adapter) if schema.action == "write_file"
+    )
+
+    assert schema.qualified_name == "MarkdownFileAdapter__write_file"
+
+    tool = schema.to_openai_tool()
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "MarkdownFileAdapter__write_file"
+    assert tool["function"]["parameters"]["properties"]["content"] == {"type": "string"}
+
+
+def test_render_tool_prompt_lists_every_tool(tmp_path):
+    adapter = MarkdownFileAdapter(file_root=str(tmp_path))
+    rendered = render_tool_prompt(enumerate_tool_schemas(adapter))
+
+    assert '"class": "MarkdownFileAdapter"' in rendered
+    assert '"function": "read_file"' in rendered
+    assert '"function": "write_file"' in rendered

--- a/tests/agents/test_agent_structured_tools.py
+++ b/tests/agents/test_agent_structured_tools.py
@@ -1,0 +1,259 @@
+"""Integration tests for structured tool calling in OnlineAgent and LocalAgent."""
+import json
+
+import pytest
+
+from adapters.adapter_registry import AdapterWrapper
+from adapters.base_adapter import BaseAdapter
+from agents.agent_context import AgentContext
+from agents.agent_settings import AgentSettings
+from agents.architectures import register_runner
+from agents.architectures.base_runner import BaseRunner, GenerationConfig
+from agents.local_agent import LocalAgent
+from agents.models.llama_completion import strings_to_message_dict
+from agents.online_agent import OnlineAgent
+
+
+class CalculatorAdapter(BaseAdapter):
+    """Test adapter recording its invocations."""
+
+    def __init__(self):
+        self.calls = []
+
+    def enumerate_actions(self):
+        return ["add"]
+
+    def add(self, a: int, b: int) -> int:
+        """Add two integers."""
+        self.calls.append((a, b))
+        return a + b
+
+
+def make_context(adapter):
+    settings = AgentSettings(name="test", version="1.0", description="test", max_tokens=64)
+    context = AgentContext(
+        settings=settings,
+        world_context=[],
+        task_context=[],
+        execution_context=[],
+        function_log=[],
+        execution_classes=[("CalculatorAdapter", ["add"])],
+    )
+    context.initialized_classes = [AdapterWrapper(name="CalculatorAdapter", instance=adapter)]
+    context._tool_schemas = None
+    context._tool_dispatcher = None
+    return context
+
+
+def make_online_agent(adapter):
+    context = make_context(adapter)
+    return OnlineAgent(context, base_url="https://example.test/v1", model="test-model", api_key="key")
+
+
+class TestOnlineAgentNativeTools:
+    def test_native_tool_loop(self, monkeypatch):
+        adapter = CalculatorAdapter()
+        agent = make_online_agent(adapter)
+        payloads = []
+
+        responses = iter([
+            {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "CalculatorAdapter__add",
+                                "arguments": '{"a": 2, "b": 3}',
+                            },
+                        }],
+                    }
+                }]
+            },
+            {"choices": [{"message": {"role": "assistant", "content": "The sum is 5."}}]},
+        ])
+
+        def fake_request(payload, **kwargs):
+            payloads.append(payload)
+            return next(responses)
+
+        monkeypatch.setattr(agent, "_make_request", fake_request)
+
+        completion = agent.complete_with_tools("What is 2 + 3?")
+
+        assert completion.content == "The sum is 5."
+        assert completion.used_native_tools
+        assert adapter.calls == [(2, 3)]
+        assert len(completion.tool_results) == 1
+        assert completion.tool_results[0].success
+        assert completion.tool_results[0].result == 5
+
+        # The provider saw the reflected schema in the tools payload
+        first_tools = payloads[0]["tools"]
+        assert first_tools[0]["function"]["name"] == "CalculatorAdapter__add"
+        assert first_tools[0]["function"]["parameters"]["required"] == ["a", "b"]
+
+        # The tool result was fed back as a tool message with the call id
+        second_messages = payloads[1]["messages"]
+        tool_messages = [message for message in second_messages if message.get("role") == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["tool_call_id"] == "call_1"
+        assert json.loads(tool_messages[0]["content"]) == {"success": True, "result": 5}
+
+        # Dispatch was journaled to the agent's function log
+        log_entry = json.loads(agent._agent_context.function_log[0])
+        assert log_entry["function"] == "add"
+        assert log_entry["success"] is True
+
+    def test_malformed_native_tool_call_is_captured(self, monkeypatch):
+        adapter = CalculatorAdapter()
+        agent = make_online_agent(adapter)
+
+        responses = iter([
+            {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "not_namespaced", "arguments": "{}"},
+                        }],
+                    }
+                }]
+            },
+            {"choices": [{"message": {"role": "assistant", "content": "giving up"}}]},
+        ])
+        monkeypatch.setattr(agent, "_make_request", lambda payload, **kwargs: next(responses))
+
+        completion = agent.complete_with_tools("What is 2 + 3?")
+
+        assert completion.content == "giving up"
+        assert not completion.tool_results[0].success
+        assert adapter.calls == []
+
+    def test_falls_back_to_prompt_tools_when_native_rejected(self, monkeypatch):
+        adapter = CalculatorAdapter()
+        agent = make_online_agent(adapter)
+
+        def fake_request(payload, **kwargs):
+            if "tools" in payload:
+                raise Exception("tools parameter not supported")
+            return {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": '{"class": "CalculatorAdapter", "function": "add", "parameters": {"a": 4, "b": 6}}',
+                    }
+                }]
+            }
+
+        monkeypatch.setattr(agent, "_make_request", fake_request)
+
+        completion = agent.complete_with_tools("What is 4 + 6?")
+
+        assert not completion.used_native_tools
+        assert adapter.calls == [(4, 6)]
+        assert completion.tool_results[0].success
+        assert completion.tool_results[0].result == 10
+
+    def test_no_tools_degrades_to_plain_completion(self, monkeypatch):
+        adapter = CalculatorAdapter()
+        agent = make_online_agent(adapter)
+        agent._agent_context.initialized_classes = []
+        agent._agent_context._tool_schemas = None
+        agent._agent_context._tool_dispatcher = None
+
+        monkeypatch.setattr(
+            agent,
+            "_make_request",
+            lambda payload, **kwargs: {
+                "choices": [{"message": {"role": "assistant", "content": "plain answer"}}]
+            },
+        )
+
+        completion = agent.complete_with_tools("Just answer")
+        assert completion.content == "plain answer"
+        assert completion.tool_results == []
+
+
+class ScriptedRunner(BaseRunner):
+    """Runner returning a scripted sequence of completions."""
+
+    script = []
+
+    def __init__(self):
+        self.prompts = []
+
+    def load(self, model_id, device_config=None):
+        pass
+
+    def generate(self, prompt, generation_config: GenerationConfig):
+        return {}
+
+    def complete(self, system_prompt, user_prompt, generation_config: GenerationConfig):
+        self.prompts.append(user_prompt)
+        response = self.script[min(len(self.prompts) - 1, len(self.script) - 1)]
+        return strings_to_message_dict(user_prompt, response)
+
+
+register_runner("scripted_test_runner", ScriptedRunner)
+
+
+class TestLocalAgentPromptTools:
+    def make_agent(self, adapter, script):
+        ScriptedRunner.script = script
+        context = make_context(adapter)
+        return LocalAgent(
+            context,
+            model_id="test-model",
+            runner_type="scripted_test_runner",
+        )
+
+    def test_schema_grounded_prompt_with_retry(self):
+        adapter = CalculatorAdapter()
+        agent = self.make_agent(adapter, [
+            "Let me think about which tool to use...",
+            'Here you go: {"class": "CalculatorAdapter", "function": "add", "parameters": {"a": "7", "b": 8}}',
+        ])
+
+        completion = agent.complete_with_tools("What is 7 + 8?")
+
+        assert completion.tool_results[0].success
+        # string "7" was coerced to the declared integer type
+        assert adapter.calls == [(7, 8)]
+        assert completion.tool_results[0].result == 15
+
+        runner = agent.runner
+        assert len(runner.prompts) == 2
+        # first prompt exposes the reflected schemas (function visibility)
+        assert "AVAILABLE_TOOLS" in runner.prompts[0]
+        assert "CalculatorAdapter" in runner.prompts[0]
+        # retry prompt carries the validation feedback
+        assert "previous response was invalid" in runner.prompts[1]
+
+    def test_gives_up_and_reports_after_max_attempts(self):
+        adapter = CalculatorAdapter()
+        agent = self.make_agent(adapter, ["never json"])
+
+        completion = agent.complete_with_tools("What is 7 + 8?", max_tool_iterations=2)
+
+        assert not completion.tool_results[0].success
+        assert "after 2 attempts" in completion.tool_results[0].error
+        assert adapter.calls == []
+
+    def test_legacy_helpers_use_robust_pipeline(self):
+        adapter = CalculatorAdapter()
+        agent = self.make_agent(adapter, ["unused"])
+
+        wrapped = 'prose before ```json\n{"class": "CalculatorAdapter", "function": "add", "parameters": {"a": 1, "b": 2}}\n``` prose after'
+        assert agent._is_valid_function_json(wrapped)
+        assert agent._take_json_and_call_function(wrapped) == 3
+
+        assert not agent._is_valid_function_json("not a call")
+        with pytest.raises(Exception):
+            agent._take_json_and_call_function("not a call")

--- a/tests/agents/test_tool_calling.py
+++ b/tests/agents/test_tool_calling.py
@@ -1,0 +1,227 @@
+"""Tests for robust tool-call parsing, validation, and dispatch."""
+import json
+
+import pytest
+
+from adapters.adapter_registry import AdapterWrapper
+from adapters.base_adapter import BaseAdapter
+from adapters.tool_schema import enumerate_tool_schemas
+from agents.tool_calling import (
+    ToolCall,
+    ToolCallError,
+    ToolDispatcher,
+    extract_json_candidates,
+    parse_tool_call,
+    run_prompt_tool_call,
+    validate_tool_call,
+)
+
+
+class EchoAdapter(BaseAdapter):
+    """Test adapter with typed actions and a failing action."""
+
+    def __init__(self):
+        self.calls = []
+
+    def enumerate_actions(self):
+        return ["echo", "add", "explode"]
+
+    def echo(self, message: str) -> str:
+        """Echo a message back."""
+        self.calls.append(("echo", message))
+        return f"echo: {message}"
+
+    def add(self, a: int, b: int) -> int:
+        """Add two integers."""
+        self.calls.append(("add", a, b))
+        return a + b
+
+    def explode(self) -> None:
+        """Always raises."""
+        raise RuntimeError("boom")
+
+
+@pytest.fixture()
+def adapter():
+    return EchoAdapter()
+
+
+@pytest.fixture()
+def schemas(adapter):
+    return enumerate_tool_schemas(adapter)
+
+
+@pytest.fixture()
+def dispatcher(adapter, schemas):
+    return ToolDispatcher(
+        [AdapterWrapper(name="EchoAdapter", instance=adapter)],
+        schemas=schemas,
+        function_log=[],
+    )
+
+
+class TestParseToolCall:
+    def test_parses_plain_json(self):
+        call = parse_tool_call('{"class": "EchoAdapter", "function": "echo", "parameters": {"message": "hi"}}')
+        assert call.adapter == "EchoAdapter"
+        assert call.function == "echo"
+        assert call.arguments == {"message": "hi"}
+
+    def test_parses_fenced_json(self):
+        text = 'Sure, here is the call:\n```json\n{"class": "EchoAdapter", "function": "echo", "parameters": {"message": "hi"}}\n```'
+        call = parse_tool_call(text)
+        assert call.function == "echo"
+
+    def test_parses_json_embedded_in_prose(self):
+        text = 'I will call the tool now. {"class": "EchoAdapter", "function": "add", "parameters": {"a": 1, "b": 2}} That should work.'
+        call = parse_tool_call(text)
+        assert call.function == "add"
+        assert call.arguments == {"a": 1, "b": 2}
+
+    def test_accepts_alias_keys(self):
+        call = parse_tool_call('{"adapter": "EchoAdapter", "action": "echo", "arguments": {"message": "hi"}}')
+        assert call.adapter == "EchoAdapter"
+        assert call.function == "echo"
+
+    def test_accepts_qualified_name(self):
+        call = parse_tool_call('{"name": "EchoAdapter__echo", "arguments": {"message": "hi"}}')
+        assert call.adapter == "EchoAdapter"
+        assert call.function == "echo"
+
+    def test_missing_parameters_defaults_to_empty(self):
+        call = parse_tool_call('{"class": "EchoAdapter", "function": "explode"}')
+        assert call.arguments == {}
+
+    def test_rejects_empty_text(self):
+        with pytest.raises(ToolCallError):
+            parse_tool_call("")
+
+    def test_rejects_text_without_json(self):
+        with pytest.raises(ToolCallError):
+            parse_tool_call("I could not decide which tool to use.")
+
+    def test_rejects_non_object_parameters(self):
+        with pytest.raises(ToolCallError):
+            parse_tool_call('{"class": "EchoAdapter", "function": "echo", "parameters": [1, 2]}')
+
+    def test_skips_invalid_json_and_finds_valid_object(self):
+        text = '{"broken": } then {"class": "EchoAdapter", "function": "echo", "parameters": {"message": "hi"}}'
+        call = parse_tool_call(text)
+        assert call.function == "echo"
+
+    def test_extract_candidates_handles_braces_in_strings(self):
+        candidates = extract_json_candidates('{"key": "value with } brace"}')
+        assert candidates == ['{"key": "value with } brace"}']
+
+
+class TestValidateToolCall:
+    def test_unknown_tool_lists_available(self, schemas):
+        call = ToolCall(adapter="EchoAdapter", function="nope", arguments={})
+        with pytest.raises(ToolCallError) as excinfo:
+            validate_tool_call(call, schemas)
+        assert "EchoAdapter__echo" in str(excinfo.value)
+
+    def test_missing_required_argument(self, schemas):
+        call = ToolCall(adapter="EchoAdapter", function="echo", arguments={})
+        with pytest.raises(ToolCallError) as excinfo:
+            validate_tool_call(call, schemas)
+        assert "message" in str(excinfo.value)
+
+    def test_coerces_string_numbers(self, schemas):
+        call = ToolCall(adapter="EchoAdapter", function="add", arguments={"a": "3", "b": 4})
+        normalized = validate_tool_call(call, schemas)
+        assert normalized.arguments == {"a": 3, "b": 4}
+
+    def test_case_insensitive_match_normalizes(self, schemas):
+        call = ToolCall(adapter="echoadapter", function="ECHO", arguments={"message": "hi"})
+        normalized = validate_tool_call(call, schemas)
+        assert normalized.adapter == "EchoAdapter"
+        assert normalized.function == "echo"
+
+    def test_drops_unknown_arguments(self, schemas):
+        call = ToolCall(
+            adapter="EchoAdapter",
+            function="echo",
+            arguments={"message": "hi", "hallucinated": True},
+        )
+        normalized = validate_tool_call(call, schemas)
+        assert normalized.arguments == {"message": "hi"}
+
+    def test_uncoercible_type_errors(self, schemas):
+        call = ToolCall(adapter="EchoAdapter", function="add", arguments={"a": "not-a-number", "b": 1})
+        with pytest.raises(ToolCallError) as excinfo:
+            validate_tool_call(call, schemas)
+        assert "'a'" in str(excinfo.value)
+
+
+class TestToolDispatcher:
+    def test_dispatch_success(self, dispatcher, adapter):
+        result = dispatcher.dispatch(
+            ToolCall(adapter="EchoAdapter", function="echo", arguments={"message": "hi"})
+        )
+        assert result.success
+        assert result.result == "echo: hi"
+        assert adapter.calls == [("echo", "hi")]
+
+    def test_dispatch_captures_adapter_exceptions(self, dispatcher):
+        result = dispatcher.dispatch(ToolCall(adapter="EchoAdapter", function="explode", arguments={}))
+        assert not result.success
+        assert "RuntimeError" in result.error
+
+    def test_dispatch_text_captures_parse_errors(self, dispatcher):
+        result = dispatcher.dispatch_text("no json here")
+        assert not result.success
+        assert result.call is None
+
+    def test_dispatch_journals_to_function_log(self, dispatcher):
+        dispatcher.dispatch(ToolCall(adapter="EchoAdapter", function="echo", arguments={"message": "hi"}))
+        assert len(dispatcher.function_log) == 1
+        entry = json.loads(dispatcher.function_log[0])
+        assert entry["adapter"] == "EchoAdapter"
+        assert entry["function"] == "echo"
+        assert entry["success"] is True
+
+    def test_result_to_content_is_json(self, dispatcher):
+        result = dispatcher.dispatch(
+            ToolCall(adapter="EchoAdapter", function="add", arguments={"a": 1, "b": 2})
+        )
+        assert json.loads(result.to_content()) == {"success": True, "result": 3}
+
+
+class TestRunPromptToolCall:
+    def test_retries_with_validation_feedback(self, schemas, dispatcher, adapter):
+        responses = iter([
+            "I think I should use the echo tool.",
+            '{"class": "EchoAdapter", "function": "echo", "parameters": {"message": "hello"}}',
+        ])
+        prompts_seen = []
+
+        def complete_fn(prompt, system_prompt):
+            prompts_seen.append(prompt)
+            return next(responses)
+
+        result = run_prompt_tool_call(complete_fn, schemas, dispatcher, "Say hello")
+
+        assert result.success
+        assert result.result == "echo: hello"
+        assert len(prompts_seen) == 2
+        assert "previous response was invalid" in prompts_seen[1]
+        # tool schemas are visible in every attempt prompt
+        assert "AVAILABLE_TOOLS" in prompts_seen[0]
+        assert "EchoAdapter" in prompts_seen[0]
+
+    def test_gives_up_after_max_attempts(self, schemas, dispatcher):
+        result = run_prompt_tool_call(
+            lambda prompt, system: "never valid",
+            schemas,
+            dispatcher,
+            "Say hello",
+            max_attempts=2,
+        )
+        assert not result.success
+        assert "after 2 attempts" in result.error
+
+    def test_no_tools_available(self, dispatcher):
+        result = run_prompt_tool_call(lambda p, s: "", [], dispatcher, "Say hello")
+        assert not result.success
+        assert "No tools" in result.error

--- a/tests/database/test_agent_snapshots.py
+++ b/tests/database/test_agent_snapshots.py
@@ -7,11 +7,13 @@ from agents.agent_context import AgentContext
 from agents.agent_settings import AgentSettings
 from agents.online_agent import OnlineAgent
 from app.models.database.agent_snapshot import (
+    AgentSnapshot,
     create_snapshot,
     get_latest_snapshot,
     get_snapshot_by_id,
     get_snapshots,
     prune_snapshots,
+    prune_snapshots_older_than,
 )
 from app.models.database.database import (
     Base,
@@ -102,6 +104,71 @@ class TestSnapshotModel:
 
         assert deleted == 3
         assert [snapshot.step for snapshot in get_snapshots("agent-a")] == [5, 4]
+
+
+def backdate_snapshot(snapshot_id: int, days: int) -> None:
+    import datetime
+
+    from app.models.database.database import SessionLocal
+
+    with SessionLocal() as session:
+        session.query(AgentSnapshot).filter(
+            AgentSnapshot.snapshot_id == snapshot_id
+        ).update({
+            AgentSnapshot.created_at: datetime.datetime.utcnow() - datetime.timedelta(days=days)
+        })
+        session.commit()
+
+
+class TestSnapshotRetention:
+    def test_prunes_snapshots_past_retention(self, sqlite_database):
+        expired_one = create_snapshot("agent-a", ["old1"], [], [], reason="tick")
+        expired_two = create_snapshot("agent-a", ["old2"], [], [], reason="tick")
+        create_snapshot("agent-a", ["fresh"], [], [], reason="tick")
+        backdate_snapshot(expired_one.snapshot_id, days=8)
+        backdate_snapshot(expired_two.snapshot_id, days=30)
+
+        deleted = prune_snapshots_older_than("agent-a", retention_days=7)
+
+        assert deleted == 2
+        assert [snapshot.to_dict()["world_context"] for snapshot in get_snapshots("agent-a")] == [["fresh"]]
+
+    def test_latest_snapshot_survives_regardless_of_age(self, sqlite_database):
+        only = create_snapshot("agent-a", ["ancient"], [], [], reason="phase_out")
+        backdate_snapshot(only.snapshot_id, days=365)
+
+        assert prune_snapshots_older_than("agent-a", retention_days=7) == 0
+        assert get_latest_snapshot("agent-a").snapshot_id == only.snapshot_id
+
+    def test_zero_retention_disables_pruning(self, sqlite_database):
+        old = create_snapshot("agent-a", ["old"], [], [], reason="tick")
+        create_snapshot("agent-a", ["new"], [], [], reason="tick")
+        backdate_snapshot(old.snapshot_id, days=100)
+
+        assert prune_snapshots_older_than("agent-a", retention_days=0) == 0
+        assert len(get_snapshots("agent-a")) == 2
+
+    def test_context_snapshot_prunes_on_write(self, sqlite_database):
+        context = make_context(agent_id="retained-agent")
+        context.task_context = ["stale"]
+        stale = context.snapshot(reason="tick")
+        backdate_snapshot(stale.snapshot_id, days=8)
+
+        context.task_context = ["current"]
+        context.snapshot(reason="tick")
+
+        remaining = get_snapshots("retained-agent")
+        assert [snapshot.to_dict()["task_context"] for snapshot in remaining] == [["current"]]
+
+    def test_context_snapshot_respects_disabled_retention(self, sqlite_database):
+        context = make_context(agent_id="unbounded-agent")
+        context.settings.snapshot_retention_days = 0
+        stale = context.snapshot(reason="tick")
+        backdate_snapshot(stale.snapshot_id, days=100)
+
+        context.snapshot(reason="tick")
+
+        assert len(get_snapshots("unbounded-agent")) == 2
 
 
 class TestAgentContextSnapshots:

--- a/tests/database/test_agent_snapshots.py
+++ b/tests/database/test_agent_snapshots.py
@@ -1,0 +1,197 @@
+"""Tests for agent execution state snapshots."""
+import importlib
+
+import pytest
+
+from agents.agent_context import AgentContext
+from agents.agent_settings import AgentSettings
+from agents.online_agent import OnlineAgent
+from app.models.database.agent_snapshot import (
+    create_snapshot,
+    get_latest_snapshot,
+    get_snapshot_by_id,
+    get_snapshots,
+    prune_snapshots,
+)
+from app.models.database.database import (
+    Base,
+    DATABASE_CONFIG,
+    Session,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+
+
+@pytest.fixture()
+def sqlite_database(tmp_path):
+    original_config = DATABASE_CONFIG
+    sqlite_config = DatabaseConfig(
+        provider="sqlite",
+        database_url=f"sqlite:///{tmp_path / 'geist.sqlite3'}",
+    )
+
+    engine = configure_database(sqlite_config)
+
+    importlib.import_module("app.models.database")
+
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Session.remove()
+        Base.metadata.drop_all(bind=engine)
+        configure_database(original_config)
+
+
+def make_context(agent_id=None):
+    settings = AgentSettings(name="snap", version="1.0", description="snapshot test")
+    return AgentContext(
+        settings=settings,
+        agent_id=agent_id,
+        world_context=[],
+        task_context=[],
+        execution_context=[],
+        function_log=[],
+        execution_classes=[("InertAdapter", [])],
+    )
+
+
+class TestSnapshotModel:
+    def test_steps_are_monotonic_per_agent(self, sqlite_database):
+        first = create_snapshot("agent-a", ["w"], ["t"], ["e"], reason="tick")
+        second = create_snapshot("agent-a", ["w2"], ["t2"], ["e2"], reason="tick")
+        other = create_snapshot("agent-b", [], [], [], reason="manual")
+
+        assert first.step == 1
+        assert second.step == 2
+        assert other.step == 1
+
+    def test_get_snapshots_orders_most_recent_first(self, sqlite_database):
+        create_snapshot("agent-a", ["w1"], [], [], reason="tick")
+        create_snapshot("agent-a", ["w2"], [], [], reason="tick")
+
+        snapshots = get_snapshots("agent-a")
+        assert [snapshot.step for snapshot in snapshots] == [2, 1]
+
+        latest = get_latest_snapshot("agent-a")
+        assert latest.step == 2
+        assert latest.to_dict()["world_context"] == ["w2"]
+
+    def test_to_dict_round_trips_contexts(self, sqlite_database):
+        snapshot = create_snapshot(
+            "agent-a",
+            ["world fact"],
+            ["task one", "task two"],
+            ["execute this"],
+            function_log=['{"function": "add"}'],
+            reason="phase_out",
+        )
+        state = get_snapshot_by_id(snapshot.snapshot_id).to_dict()
+
+        assert state["world_context"] == ["world fact"]
+        assert state["task_context"] == ["task one", "task two"]
+        assert state["execution_context"] == ["execute this"]
+        assert state["function_log"] == ['{"function": "add"}']
+        assert state["reason"] == "phase_out"
+
+    def test_prune_keeps_most_recent(self, sqlite_database):
+        for index in range(5):
+            create_snapshot("agent-a", [f"w{index}"], [], [], reason="tick")
+
+        deleted = prune_snapshots("agent-a", keep_last=2)
+
+        assert deleted == 3
+        assert [snapshot.step for snapshot in get_snapshots("agent-a")] == [5, 4]
+
+
+class TestAgentContextSnapshots:
+    def test_snapshot_and_restore_round_trip(self, sqlite_database):
+        context = make_context(agent_id="ctx-agent")
+        context.world_context = ["the sky is blue"]
+        context.task_context = ["write tests"]
+        context.execution_context = ["call the tool"]
+        context.function_log = ["logged call"]
+
+        snapshot = context.snapshot(reason="tick")
+        assert snapshot is not None
+        assert snapshot.step == 1
+
+        rehydrated = make_context(agent_id="ctx-agent")
+        assert rehydrated.restore_snapshot()
+
+        assert rehydrated.world_context == ["the sky is blue"]
+        assert rehydrated.task_context == ["write tests"]
+        assert rehydrated.execution_context == ["call the tool"]
+        assert rehydrated.function_log == ["logged call"]
+
+    def test_restore_specific_snapshot(self, sqlite_database):
+        context = make_context(agent_id="ctx-agent")
+        context.task_context = ["version one"]
+        first = context.snapshot(reason="tick")
+        context.task_context = ["version two"]
+        context.snapshot(reason="tick")
+
+        assert context.restore_snapshot(snapshot_id=first.snapshot_id)
+        assert context.task_context == ["version one"]
+
+    def test_restore_refuses_foreign_snapshot(self, sqlite_database):
+        other = make_context(agent_id="other-agent")
+        other.task_context = ["not yours"]
+        foreign = other.snapshot()
+
+        context = make_context(agent_id="ctx-agent")
+        context.task_context = ["mine"]
+        assert not context.restore_snapshot(snapshot_id=foreign.snapshot_id)
+        assert context.task_context == ["mine"]
+
+    def test_restore_without_snapshots_returns_false(self, sqlite_database):
+        context = make_context(agent_id="never-snapshotted")
+        assert not context.restore_snapshot()
+
+    def test_snapshot_failure_does_not_raise(self):
+        # No reachable database outside the sqlite fixture; snapshot must
+        # swallow the error and return None rather than break the agent loop.
+        context = make_context(agent_id="no-db-agent")
+        context.world_context = ["irrelevant"]
+        assert context.snapshot(reason="tick") is None
+
+
+class TestAgentSnapshotIntegration:
+    def make_agent(self, agent_id="online-agent"):
+        context = make_context(agent_id=agent_id)
+        return OnlineAgent(
+            context, base_url="https://example.test/v1", model="test-model", api_key="key"
+        )
+
+    def test_tick_writes_snapshot(self, sqlite_database, monkeypatch):
+        agent = self.make_agent()
+        monkeypatch.setattr(agent, "tick_world", lambda: None)
+        monkeypatch.setattr(agent, "tick_tasks", lambda: agent._agent_context.task_context.append("task"))
+        monkeypatch.setattr(agent, "tick_execution", lambda: agent._agent_context.execution_context.append("run"))
+
+        agent.tick()
+        agent.tick()
+
+        snapshots = get_snapshots(agent._agent_context.agent_id)
+        assert [snapshot.step for snapshot in snapshots] == [2, 1]
+        assert all(snapshot.reason == "tick" for snapshot in snapshots)
+        assert get_latest_snapshot(agent._agent_context.agent_id).to_dict()["task_context"] == ["task", "task"]
+
+    def test_phase_out_then_phase_in_restores_state(self, sqlite_database):
+        agent = self.make_agent(agent_id="phased-agent")
+        agent._agent_context.task_context = ["finish the report"]
+        agent._agent_context.world_context = ["deadline is friday"]
+
+        agent.phase_out()
+
+        resumed_context = make_context(agent_id="phased-agent")
+        resumed = OnlineAgent(
+            resumed_context, base_url="https://example.test/v1", model="test-model", api_key="key"
+        )
+        resumed.phase_in()
+
+        assert resumed._agent_context.task_context == ["finish the report"]
+        assert resumed._agent_context.world_context == ["deadline is friday"]
+
+        latest = get_latest_snapshot("phased-agent")
+        assert latest.reason == "phase_out"

--- a/tests/database/test_agent_snapshots.py
+++ b/tests/database/test_agent_snapshots.py
@@ -148,9 +148,15 @@ class TestAgentContextSnapshots:
         context = make_context(agent_id="never-snapshotted")
         assert not context.restore_snapshot()
 
-    def test_snapshot_failure_does_not_raise(self):
-        # No reachable database outside the sqlite fixture; snapshot must
-        # swallow the error and return None rather than break the agent loop.
+    def test_snapshot_failure_does_not_raise(self, monkeypatch):
+        # Persistence failures must be swallowed and reported as None rather
+        # than break the agent loop.
+        import agents.agent_context as agent_context_module
+
+        def failing_create_snapshot(*args, **kwargs):
+            raise RuntimeError("database unavailable")
+
+        monkeypatch.setattr(agent_context_module, "create_snapshot", failing_create_snapshot)
         context = make_context(agent_id="no-db-agent")
         context.world_context = ["irrelevant"]
         assert context.snapshot(reason="tick") is None


### PR DESCRIPTION
## Summary

Two core agent-framework features, closing the reliability gap with LangGraph/Hermes-style harnesses:

### State execution snapshots
- New `agent_snapshot` table (alembic `b8c4d2e6f0a3`) storing append-only, per-tick snapshots of world/task/execution contexts and the function log, with a monotonic `step` counter per agent
- `AgentContext.snapshot()` / `restore_snapshot(snapshot_id=None)` with never-raise semantics — persistence failures log a warning instead of breaking the agent loop; restore refuses snapshots belonging to a different agent
- All agents snapshot after `tick()` and on `phase_out()`; `phase_in()` rehydrates from the latest snapshot, enabling crash recovery, tick-by-tick inspection, and rollback to an earlier step
- `prune_snapshots()` caps history for long-running agents

### Structured tool calling
- `adapters/tool_schema.py`: reflects adapter actions into JSON schemas from method signatures, type hints, and docstrings — models now get full function visibility (typed parameters, required arguments, descriptions) while keeping the existing `enumerate_actions()` contract
- `agents/tool_calling.py`: tolerant tool-call parsing (markdown fences, JSON embedded in prose, alias keys), schema validation with type coercion (`"7"` → `7`), and a `ToolDispatcher` that captures adapter exceptions as failed results and journals every dispatch to `function_log` (which snapshots then capture)
- `OnlineAgent.complete_with_tools()`: native OpenAI-compatible `tools` API loop with tool-result feedback until a final answer, falling back to schema-grounded prompting if an endpoint rejects the tools payload
- `LocalAgent.complete_with_tools()`: keeps reflection-based function visibility with schemas rendered into the prompt; robustness via validation-error feedback on retries
- Legacy `_is_valid_function_json` / `_take_json_and_call_function` now route through the robust pipeline; execution tick prompts include the actual tool schemas instead of referencing an unlisted "adapter list"
- Fixes a latent `AttributeError`: `AgentContext.initialized_classes` is now always initialized

## Testing
- 49 new tests: schema reflection, parse/validate/dispatch robustness, OnlineAgent native tool loop + fallback (mocked HTTP), LocalAgent retry-with-feedback (scripted runner), and snapshot round-trips against SQLite
- Full backend suite run against a real PostgreSQL 16 instance: **219 passed, 3 failed** — the 3 `test_voice_session` failures are pre-existing and fail identically on a clean baseline (verified by stash/rerun with byte-identical failure sets)
- New alembic migration validated in both directions (upgrade + downgrade)
- Not run here: containerized Docker backend tests (container-registry pulls are blocked by this sandbox's network policy) and native MLX validation (no Apple Silicon). No runner, model-loading, tokenizer, or generation code was modified — LocalAgent changes sit above the `BaseRunner` interface — but a local `pytest tests/agents/test_llama_mlx.py` run on Mac is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194cRTMwT3v4TYzLEtADjZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_0194cRTMwT3v4TYzLEtADjZ8)_