### PR TITLE
Add database-backed sync job queue with worker, API, and workflow integration

### DIFF
--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -3,31 +3,15 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.utils import get_current_user
 from app.models.database.job import get_job, get_jobs
-from app.schemas.job import JobEnqueueRequest, JobResponse
-from app.services.job_queue import enqueue, registered_kinds
+from app.schemas.job import JobResponse
 
 
 router = APIRouter()
 
-
-@router.post("/", response_model=JobResponse, status_code=status.HTTP_202_ACCEPTED)
-async def enqueue_job_endpoint(
-    request: JobEnqueueRequest,
-    current_user: dict = Depends(get_current_user),
-) -> JobResponse:
-    """Queue a background job for the worker to execute."""
-    if request.kind not in registered_kinds():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unknown job kind '{request.kind}'. Registered kinds: {registered_kinds()}",
-        )
-    job = enqueue(
-        request.kind,
-        payload=request.payload,
-        max_attempts=request.max_attempts,
-        delay_seconds=request.delay_seconds,
-    )
-    return JobResponse(**job.to_dict())
+# Read-only observability endpoints. Enqueueing is intentionally not exposed
+# over HTTP: jobs are queued internally via app.services.job_queue.enqueue by
+# feature code that enforces its own authorization (e.g. the workflow run
+# endpoint's background=true path), never directly by API callers.
 
 
 @router.get("/{job_id}", response_model=JobResponse)
@@ -35,7 +19,7 @@ async def get_job_endpoint(
     job_id: int,
     current_user: dict = Depends(get_current_user),
 ) -> JobResponse:
-    """Get the status and result of a job."""
+    """Get the status and result of a background job."""
     job = get_job(job_id)
     if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
@@ -48,6 +32,6 @@ async def list_jobs_endpoint(
     limit: int = 50,
     current_user: dict = Depends(get_current_user),
 ) -> list[JobResponse]:
-    """List jobs, newest first, optionally filtered by status."""
+    """List background jobs, newest first, optionally filtered by status."""
     jobs = get_jobs(status=status_filter, limit=min(limit, 200))
     return [JobResponse(**job.to_dict()) for job in jobs]

--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -1,0 +1,53 @@
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.utils import get_current_user
+from app.models.database.job import get_job, get_jobs
+from app.schemas.job import JobEnqueueRequest, JobResponse
+from app.services.job_queue import enqueue, registered_kinds
+
+
+router = APIRouter()
+
+
+@router.post("/", response_model=JobResponse, status_code=status.HTTP_202_ACCEPTED)
+async def enqueue_job_endpoint(
+    request: JobEnqueueRequest,
+    current_user: dict = Depends(get_current_user),
+) -> JobResponse:
+    """Queue a background job for the worker to execute."""
+    if request.kind not in registered_kinds():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown job kind '{request.kind}'. Registered kinds: {registered_kinds()}",
+        )
+    job = enqueue(
+        request.kind,
+        payload=request.payload,
+        max_attempts=request.max_attempts,
+        delay_seconds=request.delay_seconds,
+    )
+    return JobResponse(**job.to_dict())
+
+
+@router.get("/{job_id}", response_model=JobResponse)
+async def get_job_endpoint(
+    job_id: int,
+    current_user: dict = Depends(get_current_user),
+) -> JobResponse:
+    """Get the status and result of a job."""
+    job = get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return JobResponse(**job.to_dict())
+
+
+@router.get("/", response_model=list[JobResponse])
+async def list_jobs_endpoint(
+    status_filter: str | None = None,
+    limit: int = 50,
+    current_user: dict = Depends(get_current_user),
+) -> list[JobResponse]:
+    """List jobs, newest first, optionally filtered by status."""
+    jobs = get_jobs(status=status_filter, limit=min(limit, 200))
+    return [JobResponse(**job.to_dict()) for job in jobs]

--- a/app/api/v1/endpoints/workflows.py
+++ b/app/api/v1/endpoints/workflows.py
@@ -155,28 +155,45 @@ async def delete_workflow(
 async def run_workflow(
     workflow_id: int,
     input_data: Dict[str, Any] = None,
+    background: bool = False,
     db: Session = Depends(get_db),
     current_user: Dict = Depends(get_current_user)
 ) -> Dict[str, Any]:
-    """Execute a workflow synchronously."""
+    """Execute a workflow synchronously, or queue it with background=true."""
     # First check if the user owns this workflow
     workflow = db.query(Workflow).options(selectinload(Workflow.steps)).filter(
         Workflow.workflow_id == workflow_id,
         Workflow.user_id == current_user["user_id"]
     ).first()
-    
+
     if not workflow:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found"
         )
-    
+
     if not workflow.steps:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Workflow has no steps to execute"
         )
-    
+
+    if background:
+        from app.services.job_queue import enqueue
+        job = enqueue(
+            "workflow.run",
+            payload={
+                "workflow_id": workflow_id,
+                "user_id": current_user["user_id"],
+                "input_data": input_data or {},
+            },
+        )
+        return {
+            "job_id": job.job_id,
+            "workflow_id": workflow_id,
+            "status": "queued",
+        }
+
     try:
         # Initialize the workflow executor
         executor = WorkflowExecutor()

--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,8 @@ from app.api.v1.endpoints.files import router as files_router
 from app.api.v1.endpoints.user_settings import router as user_settings_router
 from app.api.v1.endpoints.voice import router as voice_router
 from app.api.v1.endpoints.models import router as models_router
+from app.api.v1.endpoints.jobs import router as jobs_router
+from app.services.job_queue import start_worker, stop_worker
 from agents.local_agent import LocalAgent
 from app.services.user_settings_service import UserSettingsService
 from app.models.user_settings import AgentFactoryConfig
@@ -248,6 +250,15 @@ def create_app():
     app.include_router(user_settings_router, prefix="/api/v1/user-settings", tags=["user-settings"])
     app.include_router(voice_router, prefix="/api/v1/voice", tags=["voice"])
     app.include_router(models_router, prefix="/api/v1/models", tags=["models"])
+    app.include_router(jobs_router, prefix="/api/v1/jobs", tags=["jobs"])
+
+    @app.on_event("startup")
+    def start_job_worker():
+        start_worker()
+
+    @app.on_event("shutdown")
+    def stop_job_worker():
+        stop_worker()
 
     @app.get('/')
     def version():

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -6,3 +6,4 @@ from app.models.database.file_upload import FileUpload
 from app.models.database.workflow import Workflow, WorkflowStep, WorkflowRun, WorkflowStepResult
 from app.models.database.user_settings import UserSettings
 from app.models.database.agent_snapshot import AgentSnapshot
+from app.models.database.job import Job

--- a/app/models/database/job.py
+++ b/app/models/database/job.py
@@ -1,0 +1,186 @@
+import datetime
+import json
+import logging
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import Column, DateTime, Integer, String, Text
+
+from app.models.database.database import Base, SessionLocal
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_RETRY_BACKOFF_SECONDS = 30
+
+
+class JobStatus(Enum):
+    """Lifecycle states of a queued job."""
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class Job(Base):
+    '''
+    SqlAlchemy class persisting queued background jobs.
+
+    The job table is the whole queue: enqueue is an INSERT, claiming is a
+    single transaction that flips the oldest visible queued row to running,
+    and retries requeue the row with a later run_after. This works on both
+    SQLite (single writer, so a plain transaction is safe) and PostgreSQL
+    (claiming adds FOR UPDATE SKIP LOCKED so concurrent workers never
+    double-claim).
+    '''
+    __tablename__ = "job"
+    job_id = Column(Integer, primary_key=True, autoincrement=True)
+    kind = Column(String, nullable=False, index=True)
+    payload = Column(Text)
+    status = Column(String, nullable=False, default=JobStatus.QUEUED.value, index=True)
+    attempts = Column(Integer, nullable=False, default=0)
+    max_attempts = Column(Integer, nullable=False, default=DEFAULT_MAX_ATTEMPTS)
+    run_after = Column(DateTime, nullable=False, default=datetime.datetime.utcnow, index=True)
+    result = Column(Text)
+    error = Column(Text)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+
+    @staticmethod
+    def _loads(serialized: str | None) -> Any:
+        if not serialized:
+            return None
+        try:
+            return json.loads(serialized)
+        except (TypeError, ValueError):
+            logger.warning("Failed to deserialize job column; returning raw value")
+            return serialized
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "kind": self.kind,
+            "payload": self._loads(self.payload) or {},
+            "status": self.status,
+            "attempts": self.attempts,
+            "max_attempts": self.max_attempts,
+            "run_after": self.run_after.isoformat() if self.run_after else None,
+            "result": self._loads(self.result),
+            "error": self.error,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+def enqueue_job(
+    kind: str,
+    payload: dict[str, Any] | None = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    delay_seconds: int = 0,
+) -> Job:
+    """Insert a queued job; delay_seconds hides it from workers until then."""
+    run_after = datetime.datetime.utcnow() + datetime.timedelta(seconds=delay_seconds)
+    with SessionLocal() as session:
+        job = Job(
+            kind=kind,
+            payload=json.dumps(payload or {}),
+            status=JobStatus.QUEUED.value,
+            max_attempts=max_attempts,
+            run_after=run_after,
+        )
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        session.expunge(job)
+        return job
+
+
+def claim_next_job() -> Job | None:
+    """
+    Atomically claim the oldest visible queued job, or None if the queue is
+    empty. The claimed row is flipped to running with attempts incremented.
+    """
+    now = datetime.datetime.utcnow()
+    with SessionLocal() as session:
+        query = (
+            session.query(Job)
+            .filter(Job.status == JobStatus.QUEUED.value, Job.run_after <= now)
+            .order_by(Job.job_id)
+        )
+        # PostgreSQL: lock the claimed row and skip rows other workers hold,
+        # so multiple workers can share one queue. SQLite has a single writer,
+        # so the plain transaction below is already race-free.
+        if session.get_bind().dialect.name == "postgresql":
+            query = query.with_for_update(skip_locked=True)
+        job = query.first()
+        if job is None:
+            return None
+        job.status = JobStatus.RUNNING.value
+        job.attempts += 1
+        session.commit()
+        session.refresh(job)
+        session.expunge(job)
+        return job
+
+
+def mark_job_succeeded(job_id: int, result: Any = None) -> Job | None:
+    """Record a successful run and its JSON-serializable result."""
+    with SessionLocal() as session:
+        job = session.query(Job).filter_by(job_id=job_id).first()
+        if job is None:
+            return None
+        job.status = JobStatus.SUCCEEDED.value
+        job.result = json.dumps(result) if result is not None else None
+        job.error = None
+        session.commit()
+        session.refresh(job)
+        session.expunge(job)
+        return job
+
+
+def mark_job_failed(
+    job_id: int,
+    error: str,
+    retry_backoff_seconds: int = DEFAULT_RETRY_BACKOFF_SECONDS,
+) -> Job | None:
+    """
+    Record a failed run. The job is requeued with exponential backoff until
+    attempts reach max_attempts, then left in the terminal failed state.
+    """
+    with SessionLocal() as session:
+        job = session.query(Job).filter_by(job_id=job_id).first()
+        if job is None:
+            return None
+        job.error = error
+        if job.attempts >= job.max_attempts:
+            job.status = JobStatus.FAILED.value
+        else:
+            backoff = retry_backoff_seconds * (2 ** (job.attempts - 1))
+            job.status = JobStatus.QUEUED.value
+            job.run_after = datetime.datetime.utcnow() + datetime.timedelta(seconds=backoff)
+        session.commit()
+        session.refresh(job)
+        session.expunge(job)
+        return job
+
+
+def get_job(job_id: int) -> Job | None:
+    """Fetch a single job by id."""
+    with SessionLocal() as session:
+        job = session.query(Job).filter_by(job_id=job_id).first()
+        if job is not None:
+            session.expunge(job)
+        return job
+
+
+def get_jobs(status: str | None = None, limit: int = 50) -> list[Job]:
+    """List jobs, newest first, optionally filtered by status."""
+    with SessionLocal() as session:
+        query = session.query(Job)
+        if status:
+            query = query.filter(Job.status == status)
+        jobs = query.order_by(Job.job_id.desc()).limit(limit).all()
+        for job in jobs:
+            session.expunge(job)
+        return jobs

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class JobEnqueueRequest(BaseModel):
+    """Schema for enqueueing a background job."""
+    kind: str = Field(..., description="Registered handler kind that will execute this job")
+    payload: dict[str, Any] = Field(default_factory=dict, description="JSON payload passed to the handler")
+    max_attempts: int = Field(3, ge=1, le=10, description="Attempts before the job is marked failed")
+    delay_seconds: int = Field(0, ge=0, description="Seconds to delay the job before it becomes visible")
+
+
+class JobResponse(BaseModel):
+    """Schema for job status responses."""
+    job_id: int
+    kind: str
+    payload: dict[str, Any]
+    status: str
+    attempts: int
+    max_attempts: int
+    run_after: str | None = None
+    result: Any | None = None
+    error: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -1,14 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field
-
-
-class JobEnqueueRequest(BaseModel):
-    """Schema for enqueueing a background job."""
-    kind: str = Field(..., description="Registered handler kind that will execute this job")
-    payload: dict[str, Any] = Field(default_factory=dict, description="JSON payload passed to the handler")
-    max_attempts: int = Field(3, ge=1, le=10, description="Attempts before the job is marked failed")
-    delay_seconds: int = Field(0, ge=0, description="Seconds to delay the job before it becomes visible")
+from pydantic import BaseModel
 
 
 class JobResponse(BaseModel):

--- a/app/services/job_queue.py
+++ b/app/services/job_queue.py
@@ -1,0 +1,197 @@
+"""
+Compact, durable job queue on the application database.
+
+Jobs are rows in the `job` table (see app.models.database.job). A single
+worker thread claims one job at a time and dispatches it to a handler looked
+up by the job's `kind`. Handlers take the payload dict and return a
+JSON-serializable result. Failures requeue with exponential backoff until
+max_attempts, then land in the terminal failed state.
+
+No broker, no new dependencies: SQLite gets a safe single-writer queue, and
+PostgreSQL claiming uses FOR UPDATE SKIP LOCKED so several workers can share
+one queue if ever needed.
+"""
+import logging
+import os
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from app.models.database.job import (
+    Job,
+    claim_next_job,
+    enqueue_job,
+    mark_job_failed,
+    mark_job_succeeded,
+)
+
+
+logger = logging.getLogger(__name__)
+
+JobHandler = Callable[[dict[str, Any]], Any]
+
+_handlers: dict[str, JobHandler] = {}
+
+
+def register_job_handler(kind: str, handler: JobHandler) -> None:
+    """Register the callable that executes jobs of the given kind."""
+    if kind in _handlers:
+        logger.warning(f"Job handler for kind '{kind}' is being replaced")
+    _handlers[kind] = handler
+
+
+def job_handler(kind: str) -> Callable[[JobHandler], JobHandler]:
+    """Decorator form of register_job_handler."""
+    def decorator(handler: JobHandler) -> JobHandler:
+        register_job_handler(kind, handler)
+        return handler
+    return decorator
+
+
+def registered_kinds() -> list:
+    """Kinds that currently have a handler."""
+    return sorted(_handlers.keys())
+
+
+def enqueue(
+    kind: str,
+    payload: dict[str, Any] | None = None,
+    max_attempts: int = 3,
+    delay_seconds: int = 0,
+) -> Job:
+    """Queue one job for background execution."""
+    return enqueue_job(kind, payload=payload, max_attempts=max_attempts, delay_seconds=delay_seconds)
+
+
+class JobWorker:
+    """Single-threaded queue consumer."""
+
+    def __init__(self, poll_interval: float = 1.0, retry_backoff_seconds: int = 30):
+        self.poll_interval = poll_interval
+        self.retry_backoff_seconds = retry_backoff_seconds
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def run_once(self) -> bool:
+        """Claim and execute at most one job. Returns True if one was processed."""
+        job = claim_next_job()
+        if job is None:
+            return False
+
+        handler = _handlers.get(job.kind)
+        if handler is None:
+            logger.error(f"No handler registered for job kind '{job.kind}' (job_id={job.job_id})")
+            mark_job_failed(
+                job.job_id,
+                f"No handler registered for kind '{job.kind}'",
+                retry_backoff_seconds=self.retry_backoff_seconds,
+            )
+            return True
+
+        try:
+            result = handler(job.to_dict()["payload"])
+        except Exception as e:
+            logger.exception(f"Job {job.job_id} ({job.kind}) failed on attempt {job.attempts}")
+            mark_job_failed(job.job_id, str(e), retry_backoff_seconds=self.retry_backoff_seconds)
+            return True
+
+        mark_job_succeeded(job.job_id, result)
+        logger.info(f"Job {job.job_id} ({job.kind}) succeeded on attempt {job.attempts}")
+        return True
+
+    def _run_loop(self) -> None:
+        logger.info("Job worker started")
+        while not self._stop_event.is_set():
+            try:
+                processed = self.run_once()
+            except Exception:
+                # Claiming itself failed (e.g. transient DB error); back off.
+                logger.exception("Job worker loop error")
+                processed = False
+            if not processed:
+                self._stop_event.wait(self.poll_interval)
+        logger.info("Job worker stopped")
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, name="geist-job-worker", daemon=True)
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+
+_worker: JobWorker | None = None
+
+
+def start_worker() -> JobWorker | None:
+    """
+    Start the process-wide worker thread unless disabled via
+    GEIST_JOB_WORKER_ENABLED=false. Poll cadence comes from
+    GEIST_JOB_POLL_INTERVAL (seconds, default 1.0).
+    """
+    global _worker
+    enabled = os.getenv("GEIST_JOB_WORKER_ENABLED", "true").strip().lower() not in ("false", "0", "no")
+    if not enabled:
+        logger.info("Job worker disabled via GEIST_JOB_WORKER_ENABLED")
+        return None
+    if _worker is None:
+        try:
+            poll_interval = float(os.getenv("GEIST_JOB_POLL_INTERVAL", "1.0"))
+        except ValueError:
+            poll_interval = 1.0
+        _worker = JobWorker(poll_interval=poll_interval)
+    _worker.start()
+    return _worker
+
+
+def stop_worker() -> None:
+    """Stop the process-wide worker thread if it is running."""
+    global _worker
+    if _worker is not None:
+        _worker.stop()
+        _worker = None
+
+
+@job_handler("workflow.run")
+def _run_workflow_job(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Execute a stored workflow in the background.
+
+    Payload: {"workflow_id": int, "user_id": int, "input_data": dict}.
+    Returns the WorkflowRun summary so the job row carries the run outcome.
+    """
+    # Imported here to keep module import light and avoid circular imports.
+    from sqlalchemy.orm import selectinload
+
+    from app.models.database.database import SessionLocal
+    from app.models.database.workflow import Workflow
+    from app.services.workflow_execution import WorkflowExecutor
+
+    workflow_id = payload["workflow_id"]
+    user_id = payload["user_id"]
+    input_data = payload.get("input_data") or {}
+
+    with SessionLocal() as session:
+        workflow = (
+            session.query(Workflow)
+            .options(selectinload(Workflow.steps))
+            .filter(Workflow.workflow_id == workflow_id, Workflow.user_id == user_id)
+            .first()
+        )
+        if workflow is None:
+            raise ValueError(f"Workflow {workflow_id} not found for user {user_id}")
+        session.expunge_all()
+
+    run = WorkflowExecutor().execute_workflow(workflow=workflow, user_id=user_id, input_data=input_data)
+    return {
+        "run_id": run.run_id,
+        "workflow_id": workflow_id,
+        "status": run.status,
+        "error_message": run.error_message,
+    }

--- a/migrations/versions/c3a1f5e7d9b2_add_job_table.py
+++ b/migrations/versions/c3a1f5e7d9b2_add_job_table.py
@@ -1,0 +1,45 @@
+"""add job table
+
+Revision ID: c3a1f5e7d9b2
+Revises: b8c4d2e6f0a3
+Create Date: 2026-07-11
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3a1f5e7d9b2'
+down_revision: str | None = 'b8c4d2e6f0a3'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'job',
+        sa.Column('job_id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('kind', sa.String(), nullable=False),
+        sa.Column('payload', sa.Text(), nullable=True),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('attempts', sa.Integer(), nullable=False),
+        sa.Column('max_attempts', sa.Integer(), nullable=False),
+        sa.Column('run_after', sa.DateTime(), nullable=False),
+        sa.Column('result', sa.Text(), nullable=True),
+        sa.Column('error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('job_id'),
+    )
+    op.create_index(op.f('ix_job_kind'), 'job', ['kind'], unique=False)
+    op.create_index(op.f('ix_job_status'), 'job', ['status'], unique=False)
+    op.create_index(op.f('ix_job_run_after'), 'job', ['run_after'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_job_run_after'), table_name='job')
+    op.drop_index(op.f('ix_job_status'), table_name='job')
+    op.drop_index(op.f('ix_job_kind'), table_name='job')
+    op.drop_table('job')

--- a/plans/152-SYNC-JOB-QUEUE.md
+++ b/plans/152-SYNC-JOB-QUEUE.md
@@ -1,0 +1,69 @@
+# 152 - Sync Job Queue
+
+## What exists
+
+- No job queueing anywhere in the backend. `POST /api/v1/workflows/{id}/run`
+  executes `WorkflowExecutor.execute_workflow` synchronously inside the request
+  (blocking the event loop for long workflows). Agent ticks either run inline or
+  as a fire-and-forget `subprocess.Popen('tick.py')` with no result channel.
+- `WorkflowRun` rows journal execution status (running/completed/failed) but are
+  not a queue: there is no queued state and nothing claims work later.
+- The repo preference (claude.md) is minimal inline implementations over new
+  dependencies; persistence is SQLAlchemy over SQLite (default) or PostgreSQL.
+
+## What to add
+
+A compact, durable, pure-Python job queue on the existing database — no broker,
+no new dependencies.
+
+### Data model (`app/models/database/job.py`)
+
+`job` table: `job_id`, `kind` (handler key), `payload` (JSON text),
+`status` (queued | running | succeeded | failed), `attempts`, `max_attempts`,
+`run_after` (visibility time for delays/retry backoff), `result` (JSON text),
+`error`, `created_at`, `updated_at`. Module-level helpers in the established
+style: `enqueue_job`, `claim_next_job`, `mark_job_succeeded`, `mark_job_failed`
+(requeues with exponential backoff until `max_attempts`, then fails),
+`get_job`, `get_jobs`.
+
+Claiming is one transaction: select the oldest visible queued row, flip it to
+running, increment attempts. On PostgreSQL the select adds
+`FOR UPDATE SKIP LOCKED` so multiple workers never double-claim; SQLite is a
+single-writer database so the plain transaction is already safe.
+
+### Service (`app/services/job_queue.py`)
+
+- Handler registry: `register_job_handler(kind, fn)` / `@job_handler(kind)`.
+  Handlers take the payload dict and return a JSON-serializable result.
+- `enqueue(kind, payload, max_attempts, delay_seconds)` — insert one row.
+- `JobWorker`: single background thread; `run_once()` claims and dispatches one
+  job (unknown kind or handler exception -> `mark_job_failed`), loop polls at a
+  configurable interval. `start_worker()`/`stop_worker()` manage a process
+  singleton, gated by `GEIST_JOB_WORKER_ENABLED` (default on) and
+  `GEIST_JOB_POLL_INTERVAL`.
+- Built-in `workflow.run` handler that loads the workflow and calls the
+  existing `WorkflowExecutor`, so workflow runs can be queued.
+
+### API (`app/api/v1/endpoints/jobs.py` + `app/schemas/job.py`)
+
+- `POST /api/v1/jobs` — enqueue (400 on unregistered kind).
+- `GET /api/v1/jobs/{job_id}` — status/result polling.
+- `GET /api/v1/jobs` — list, optional status filter.
+- `POST /api/v1/workflows/{id}/run?background=true` — enqueue instead of
+  executing inline; response carries `job_id` with `status: queued`.
+  Default behavior is unchanged (synchronous).
+
+### Wiring
+
+- Router registered in `create_app`; worker started/stopped via FastAPI
+  startup/shutdown events.
+- Alembic migration `add job table` on head `b8c4d2e6f0a3`; model imported in
+  `app/models/database/__init__.py` so `initdb.py` creates it.
+
+### Tests
+
+- `tests/database/test_job_queue.py` — enqueue/claim FIFO ordering, delayed
+  visibility, succeed/fail transitions, retry backoff to terminal failure.
+- `tests/services/test_job_worker.py` — worker dispatch to registered handlers,
+  result persistence, handler-exception retry, unknown-kind failure, and the
+  `workflow.run` handler end-to-end on SQLite.

--- a/plans/152-SYNC-JOB-QUEUE.md
+++ b/plans/152-SYNC-JOB-QUEUE.md
@@ -46,12 +46,18 @@ single-writer database so the plain transaction is already safe.
 
 ### API (`app/api/v1/endpoints/jobs.py` + `app/schemas/job.py`)
 
-- `POST /api/v1/jobs` — enqueue (400 on unregistered kind).
+Enqueueing is internal-only: feature code calls
+`app.services.job_queue.enqueue` after enforcing its own authorization.
+There is deliberately no generic enqueue endpoint — one would let API callers
+queue arbitrary kinds/payloads and sidestep domain checks (e.g. workflow
+ownership). The HTTP surface is read-only observability plus per-feature
+async options:
+
 - `GET /api/v1/jobs/{job_id}` — status/result polling.
 - `GET /api/v1/jobs` — list, optional status filter.
-- `POST /api/v1/workflows/{id}/run?background=true` — enqueue instead of
-  executing inline; response carries `job_id` with `status: queued`.
-  Default behavior is unchanged (synchronous).
+- `POST /api/v1/workflows/{id}/run?background=true` — validates ownership,
+  then enqueues instead of executing inline; response carries `job_id` with
+  `status: queued`. Default behavior is unchanged (synchronous).
 
 ### Wiring
 

--- a/tests/database/test_job_queue.py
+++ b/tests/database/test_job_queue.py
@@ -1,0 +1,130 @@
+"""Tests for the database-backed job queue model."""
+import datetime
+import importlib
+
+import pytest
+
+from app.models.database.database import (
+    DATABASE_CONFIG,
+    Base,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+from app.models.database.job import (
+    Job,
+    JobStatus,
+    claim_next_job,
+    enqueue_job,
+    get_job,
+    get_jobs,
+    mark_job_failed,
+    mark_job_succeeded,
+)
+
+
+@pytest.fixture()
+def sqlite_database(tmp_path):
+    original_config = DATABASE_CONFIG
+    sqlite_config = DatabaseConfig(
+        provider="sqlite",
+        database_url=f"sqlite:///{tmp_path / 'geist.sqlite3'}",
+    )
+
+    engine = configure_database(sqlite_config)
+
+    importlib.import_module("app.models.database")
+
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Session.remove()
+        Base.metadata.drop_all(bind=engine)
+        configure_database(original_config)
+
+
+def _set_run_after(job_id: int, when: datetime.datetime) -> None:
+    with SessionLocal() as session:
+        job = session.query(Job).filter_by(job_id=job_id).first()
+        job.run_after = when
+        session.commit()
+
+
+def test_enqueue_and_claim_fifo(sqlite_database):
+    first = enqueue_job("noop", payload={"n": 1})
+    second = enqueue_job("noop", payload={"n": 2})
+
+    claimed = claim_next_job()
+    assert claimed.job_id == first.job_id
+    assert claimed.status == JobStatus.RUNNING.value
+    assert claimed.attempts == 1
+    assert claimed.to_dict()["payload"] == {"n": 1}
+
+    claimed_second = claim_next_job()
+    assert claimed_second.job_id == second.job_id
+
+
+def test_claim_returns_none_when_queue_empty(sqlite_database):
+    assert claim_next_job() is None
+
+
+def test_claim_respects_run_after_delay(sqlite_database):
+    delayed = enqueue_job("noop", delay_seconds=3600)
+    assert claim_next_job() is None
+
+    _set_run_after(delayed.job_id, datetime.datetime.utcnow() - datetime.timedelta(seconds=1))
+    claimed = claim_next_job()
+    assert claimed.job_id == delayed.job_id
+
+
+def test_mark_succeeded_records_result(sqlite_database):
+    job = enqueue_job("noop")
+    claim_next_job()
+
+    done = mark_job_succeeded(job.job_id, result={"answer": 42})
+    assert done.status == JobStatus.SUCCEEDED.value
+    assert done.to_dict()["result"] == {"answer": 42}
+    assert done.error is None
+
+
+def test_failed_job_requeues_with_backoff_then_fails(sqlite_database):
+    job = enqueue_job("noop", max_attempts=2)
+
+    claim_next_job()
+    retried = mark_job_failed(job.job_id, "boom", retry_backoff_seconds=60)
+    assert retried.status == JobStatus.QUEUED.value
+    assert retried.error == "boom"
+    assert retried.run_after > datetime.datetime.utcnow()
+
+    # Not visible until the backoff elapses.
+    assert claim_next_job() is None
+    _set_run_after(job.job_id, datetime.datetime.utcnow() - datetime.timedelta(seconds=1))
+
+    claimed = claim_next_job()
+    assert claimed.attempts == 2
+    failed = mark_job_failed(job.job_id, "boom again", retry_backoff_seconds=60)
+    assert failed.status == JobStatus.FAILED.value
+    assert failed.error == "boom again"
+
+    # Terminal: nothing left to claim.
+    assert claim_next_job() is None
+
+
+def test_get_job_and_list_filtering(sqlite_database):
+    queued = enqueue_job("noop", payload={"n": 1})
+    finished = enqueue_job("noop", payload={"n": 2})
+    # Claim and finish the second job (FIFO claims the first, so claim twice).
+    claim_next_job()
+    claim_next_job()
+    mark_job_succeeded(finished.job_id, result="ok")
+
+    fetched = get_job(queued.job_id)
+    assert fetched is not None
+    assert fetched.job_id == queued.job_id
+    assert get_job(99999) is None
+
+    succeeded = get_jobs(status=JobStatus.SUCCEEDED.value)
+    assert [j.job_id for j in succeeded] == [finished.job_id]
+    assert len(get_jobs()) == 2

--- a/tests/services/test_job_worker.py
+++ b/tests/services/test_job_worker.py
@@ -1,0 +1,147 @@
+"""Tests for the job queue worker and handler registry."""
+import datetime
+import importlib
+import time
+
+import pytest
+
+from app.models.database.database import (
+    DATABASE_CONFIG,
+    Base,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+from app.models.database.job import Job, JobStatus, enqueue_job, get_job
+from app.services.job_queue import (
+    JobWorker,
+    _handlers,
+    enqueue,
+    register_job_handler,
+    registered_kinds,
+)
+
+
+@pytest.fixture()
+def sqlite_database(tmp_path):
+    original_config = DATABASE_CONFIG
+    sqlite_config = DatabaseConfig(
+        provider="sqlite",
+        database_url=f"sqlite:///{tmp_path / 'geist.sqlite3'}",
+    )
+
+    engine = configure_database(sqlite_config)
+
+    importlib.import_module("app.models.database")
+
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield
+    finally:
+        Session.remove()
+        Base.metadata.drop_all(bind=engine)
+        configure_database(original_config)
+
+
+@pytest.fixture()
+def temp_handler():
+    """Register a throwaway handler kind and clean it up afterwards."""
+    registered = []
+
+    def _register(kind, fn):
+        register_job_handler(kind, fn)
+        registered.append(kind)
+
+    try:
+        yield _register
+    finally:
+        for kind in registered:
+            _handlers.pop(kind, None)
+
+
+def test_worker_dispatches_and_records_result(sqlite_database, temp_handler):
+    temp_handler("test.echo", lambda payload: {"echoed": payload["value"]})
+
+    job = enqueue("test.echo", payload={"value": "hi"})
+    worker = JobWorker()
+
+    assert worker.run_once() is True
+    done = get_job(job.job_id)
+    assert done.status == JobStatus.SUCCEEDED.value
+    assert done.to_dict()["result"]["echoed"] == "hi"
+
+    # Queue drained.
+    assert worker.run_once() is False
+
+
+def test_worker_retries_handler_exception_then_fails(sqlite_database, temp_handler):
+    calls = []
+
+    def flaky(payload):
+        calls.append(1)
+        raise RuntimeError("kaboom")
+
+    temp_handler("test.flaky", flaky)
+    job = enqueue("test.flaky", max_attempts=2)
+    worker = JobWorker(retry_backoff_seconds=60)
+
+    assert worker.run_once() is True
+    after_first = get_job(job.job_id)
+    assert after_first.status == JobStatus.QUEUED.value
+    assert "kaboom" in after_first.error
+
+    # Pull the retry forward and let it exhaust max_attempts.
+    with SessionLocal() as session:
+        row = session.query(Job).filter_by(job_id=job.job_id).first()
+        row.run_after = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        session.commit()
+
+    assert worker.run_once() is True
+    final = get_job(job.job_id)
+    assert final.status == JobStatus.FAILED.value
+    assert len(calls) == 2
+
+
+def test_worker_fails_unknown_kind(sqlite_database):
+    job = enqueue_job("test.unregistered", max_attempts=1)
+    worker = JobWorker()
+
+    assert worker.run_once() is True
+    failed = get_job(job.job_id)
+    assert failed.status == JobStatus.FAILED.value
+    assert "No handler registered" in failed.error
+
+
+def test_worker_start_stop_processes_queued_job(sqlite_database, temp_handler):
+    temp_handler("test.threaded", lambda payload: "done")
+    job = enqueue("test.threaded")
+
+    worker = JobWorker(poll_interval=0.05)
+    worker.start()
+    try:
+        deadline = datetime.datetime.utcnow() + datetime.timedelta(seconds=5)
+        while datetime.datetime.utcnow() < deadline:
+            if get_job(job.job_id).status == JobStatus.SUCCEEDED.value:
+                break
+            time.sleep(0.05)
+        assert get_job(job.job_id).status == JobStatus.SUCCEEDED.value
+    finally:
+        worker.stop()
+
+
+def test_workflow_run_handler_is_registered_and_fails_cleanly(sqlite_database):
+    """The built-in workflow.run handler surfaces missing workflows as job failures."""
+    assert "workflow.run" in registered_kinds()
+
+    job = enqueue(
+        "workflow.run",
+        payload={"workflow_id": 999999, "user_id": 1, "input_data": {}},
+        max_attempts=1,
+    )
+    worker = JobWorker()
+    assert worker.run_once() is True
+
+    failed = get_job(job.job_id)
+    assert failed.status == JobStatus.FAILED.value
+    assert "not found" in failed.error


### PR DESCRIPTION
## Summary

A compact, durable job queue on the existing SQLAlchemy database — pure Python, no broker, no new dependencies. Plan: `plans/152-SYNC-JOB-QUEUE.md`.

Previously nothing in the backend queued work: `POST /workflows/{id}/run` executed synchronously inside the request (blocking the event loop for long workflows), and agent ticks were fire-and-forget subprocesses.

## What's included

- **`job` table + helpers** (`app/models/database/job.py`): enqueue is an INSERT; claiming is one atomic transaction that flips the oldest visible queued row to running. PostgreSQL claiming adds `FOR UPDATE SKIP LOCKED` so multiple workers could share a queue; SQLite's single writer is already race-free. Failures requeue with exponential backoff until `max_attempts`, then land in terminal `failed`.
- **Worker + registry** (`app/services/job_queue.py`): handlers registered by `kind`; a single daemon thread claims and dispatches jobs, started/stopped with the FastAPI app. Gated by `GEIST_JOB_WORKER_ENABLED` (default on) and `GEIST_JOB_POLL_INTERVAL`.
- **Enqueueing is internal-only.** There is deliberately no generic enqueue endpoint — one would let API callers queue arbitrary kinds/payloads and sidestep domain authorization (e.g. `workflow.run` with someone else's `user_id`). Feature code calls `app.services.job_queue.enqueue` after its own checks. The HTTP surface is read-only observability: `GET /api/v1/jobs` and `GET /api/v1/jobs/{id}` for polling status/results.
- **Workflow integration**: built-in `workflow.run` handler, and `POST /api/v1/workflows/{id}/run?background=true` validates ownership, enqueues, and returns a `job_id` to poll. Default behavior is unchanged (synchronous).
- **Migration** `c3a1f5e7d9b2_add_job_table` (head: `b8c4d2e6f0a3`), model registered in `app/models/database/__init__.py` so `initdb.py` creates the table.

## Testing

- `tests/database/test_job_queue.py`: FIFO claim ordering, delayed visibility (`run_after`), succeed/fail transitions, retry backoff to terminal failure, list filtering.
- `tests/services/test_job_worker.py`: handler dispatch and result persistence, exception retry then terminal failure, unknown-kind failure, threaded worker start/stop end-to-end, and `workflow.run` failure surfacing.
- Local execution was blocked in this environment (no Docker daemon; dependency installs gated), so this PR's CI run is the verification. `ruff` and `py_compile` pass locally on all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCgCh6dkArcAwz8NENmSW8