### PR TITLE
Grant container-security job security-events: write for SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,11 @@ jobs:
 
   container-security:
     runs-on: ubuntu-latest
+    # The SARIF upload writes to the Security tab; the default workflow token
+    # is read-only, so this job needs the security-events scope explicitly.
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the only red job on main. The last three CI runs on main (post #259/#245/#279) failed solely on `container-security`: Trivy's config scan succeeds, but the `github/codeql-action/upload-sarif` step is rejected with **"Resource not accessible by integration"**.

Root cause: the workflow declares no `permissions:` block, so jobs inherit the repository's read-only default token —

```
GITHUB_TOKEN Permissions:
  Contents: read
  Metadata: read
  Packages: read
```

— which lacks the `security-events: write` scope the SARIF upload to the Security tab requires.

## Change

Five lines: an explicit per-job permissions grant on `container-security` only:

```yaml
permissions:
  contents: read
  security-events: write
```

Scoping it per-job (rather than workflow-level) keeps the hardened read-only default for every other job.

## Testing

- YAML validated locally.
- Note: this job's failure only reproduces on push-to-main events under the restricted default token; the PR run exercises the same upload path and should now succeed with the explicit grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCgCh6dkArcAwz8NENmSW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCgCh6dkArcAwz8NENmSW8)_