### PR TITLE
Add generic open-weight model support

### DIFF
--- a/agents/agent_registry.py
+++ b/agents/agent_registry.py
@@ -1,6 +1,7 @@
 import importlib.util
 import inspect
 import os
+import sys
 
 from agents.base_agent import BaseAgent  # Adjust the import according to your project structure
 
@@ -11,14 +12,18 @@ def get_all_base_agent_classes():
 
     for filename in os.listdir(directory):
         if filename.endswith(".py") and filename != "__init__.py":
-            module_name = filename[:-3]
+            module_name = f"_geist_agent_scan_{filename[:-3]}"
             module_path = os.path.join(directory, filename)
 
             spec = importlib.util.spec_from_file_location(module_name, module_path)
             if spec is None or spec.loader is None:
                 continue
             module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            sys.modules[module_name] = module
+            try:
+                spec.loader.exec_module(module)
+            finally:
+                sys.modules.pop(module_name, None)
 
             for _name, obj in inspect.getmembers(module, inspect.isclass):
                 if issubclass(obj, BaseAgent) and obj is not BaseAgent:

--- a/agents/architectures/registry.py
+++ b/agents/architectures/registry.py
@@ -1,15 +1,16 @@
 """
 Initialize and register all available runners.
 """
+from __future__ import annotations
 
+import importlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
-from agents.architectures.mlx_llama_runner import MLXLlamaRunner
-from agents.architectures.qwen3_runner import Qwen3Runner
-from agents.architectures.vllm_runner import VLLMRunner
+from agents.model_catalog import MODEL_SPECS, PROVIDERS
 
 
 logger = logging.getLogger(__name__)
@@ -179,7 +180,7 @@ class RunnerRegistry:
 
     def __init__(self):
         """Initialize an empty runner registry."""
-        self._registry: dict[str, type] = {}
+        self._registry: dict[str, Any] = {}
         self._logger = logging.getLogger(__name__)
 
     def register(self, name: str, runner_class: type) -> None:
@@ -196,6 +197,11 @@ class RunnerRegistry:
         self._registry[name] = runner_class
         self._logger.info(f"Registered runner '{name}': {runner_class.__name__}")
 
+    def register_lazy(self, name: str, module: str, class_name: str) -> None:
+        """Register a runner without importing its optional dependencies."""
+        self._registry[name] = (module, class_name)
+        self._logger.info("Registered lazy runner '%s': %s.%s", name, module, class_name)
+
     def get(self, name: str) -> type | None:
         """
         Get a runner class by name.
@@ -206,9 +212,14 @@ class RunnerRegistry:
         Returns:
             The runner class if found, None otherwise
         """
-        return self._registry.get(name)
+        value = self._registry.get(name)
+        if isinstance(value, tuple):
+            module, class_name = value
+            value = getattr(importlib.import_module(module), class_name)
+            self._registry[name] = value
+        return value
 
-    def list(self) -> dict[str, type]:
+    def list(self) -> dict[str, Any]:
         """
         Get all registered runners.
 
@@ -264,14 +275,16 @@ def register_all_runners(registry: RunnerRegistry | None = None) -> None:
 
     logger.info("Registering all available runners...")
 
-    # Register MLX Llama runner
-    registry.register("mlx_llama", MLXLlamaRunner)
-
-    # Register vLLM runner (Transformers-based shim shared with Qwen3Runner)
-    registry.register("vllm", VLLMRunner)
-
-    # Register Qwen 3 runner
-    registry.register("qwen3", Qwen3Runner)
+    registry.register_lazy(
+        "mlx_llama", "agents.architectures.mlx_llama_runner", "MLXLlamaRunner"
+    )
+    registry.register_lazy(
+        "transformers", "agents.architectures.transformers_runner", "TransformersRunner"
+    )
+    registry.register_lazy("vllm", "agents.architectures.vllm_runner", "VLLMRunner")
+    # Backward-compatible explicit Qwen runner. Automatic selection now uses
+    # the generic Transformers runner for every standard causal LM family.
+    registry.register_lazy("qwen3", "agents.architectures.qwen3_runner", "Qwen3Runner")
 
     _initialized = True
     logger.info("All runners registered successfully")
@@ -335,7 +348,7 @@ class ModelInfo:
 
     id: str  # Model identifier (e.g., "gpt-4")
     name: str  # Display name (e.g., "GPT-4")
-    provider: OnlineModelProviders  # Provider enum
+    provider: OnlineModelProviders | str  # Legacy enum or catalog provider ID
     context_window: int | None = None  # Max context tokens
     max_output_tokens: int | None = None  # Max output tokens
     supports_vision: bool = False  # Multimodal support
@@ -343,13 +356,23 @@ class ModelInfo:
     supports_streaming: bool = True
     recommended: bool = False  # Highlight recommended models
     family: str | None = None  # Model family (e.g., "gpt-4", "claude-3")
+    backend: str | None = None
+    supports_reasoning: bool = False
+    gated: bool = False
+    requires_remote_code: bool = False
+    min_transformers_version: str | None = None
+    parameter_count: str | None = None
+    activated_parameters: str | None = None
+    optional_dependencies: tuple[str, ...] = ()
+    local: bool = False
+    performance_note: str | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return {
             "id": self.id,
             "name": self.name,
-            "provider": self.provider.value,
+            "provider": provider_to_string(self.provider),
             "context_window": self.context_window,
             "max_output_tokens": self.max_output_tokens,
             "supports_vision": self.supports_vision,
@@ -357,11 +380,21 @@ class ModelInfo:
             "supports_streaming": self.supports_streaming,
             "recommended": self.recommended,
             "family": self.family,
+            "backend": self.backend,
+            "supports_reasoning": self.supports_reasoning,
+            "gated": self.gated,
+            "requires_remote_code": self.requires_remote_code,
+            "min_transformers_version": self.min_transformers_version,
+            "parameter_count": self.parameter_count,
+            "activated_parameters": self.activated_parameters,
+            "optional_dependencies": self.optional_dependencies,
+            "local": self.local,
+            "performance_note": self.performance_note,
         }
 
 
 # Static registry - always available as fallback
-STATIC_MODELS: dict[OnlineModelProviders, list[ModelInfo]] = {
+STATIC_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
     OnlineModelProviders.OPENAI: [
         ModelInfo(
             id="gpt-4",
@@ -695,12 +728,61 @@ STATIC_MODELS: dict[OnlineModelProviders, list[ModelInfo]] = {
     ],
 }
 
+# The hand-maintained catalog is the source of truth for new open-weight
+# families. Merge it after the legacy static registry so existing entries and
+# API contracts remain backward compatible while additions stay one-line-ish.
+
+for _spec in MODEL_SPECS:
+    try:
+        _provider = OnlineModelProviders(_spec.provider)
+    except ValueError:
+        _provider = _spec.provider
+    _models = STATIC_MODELS.setdefault(_provider, [])
+    _existing = next(
+        (existing for existing in _models if existing.id.lower() == _spec.id.lower()),
+        None,
+    )
+    if _existing:
+        _existing.backend = _spec.backend
+        _existing.supports_reasoning = _spec.supports_reasoning
+        _existing.gated = _spec.gated
+        _existing.requires_remote_code = _spec.requires_remote_code
+        _existing.min_transformers_version = _spec.min_transformers_version
+        _existing.parameter_count = _spec.parameter_count
+        _existing.activated_parameters = _spec.activated_parameters
+        _existing.optional_dependencies = _spec.optional_dependencies
+        _existing.local = _spec.local
+        _existing.performance_note = _spec.performance_note
+        continue
+    _models.append(ModelInfo(
+        id=_spec.id,
+        name=_spec.name,
+        provider=_provider,
+        context_window=_spec.context_window,
+        max_output_tokens=_spec.max_output_tokens,
+        supports_vision=_spec.supports_vision,
+        supports_function_calling=_spec.supports_function_calling,
+        supports_streaming=_spec.supports_streaming,
+        recommended=_spec.recommended,
+        family=_spec.family,
+        backend=_spec.backend,
+        supports_reasoning=_spec.supports_reasoning,
+        gated=_spec.gated,
+        requires_remote_code=_spec.requires_remote_code,
+        min_transformers_version=_spec.min_transformers_version,
+        parameter_count=_spec.parameter_count,
+        activated_parameters=_spec.activated_parameters,
+        optional_dependencies=_spec.optional_dependencies,
+        local=_spec.local,
+        performance_note=_spec.performance_note,
+    ))
+
 
 # Dynamic registry - populated by sync script
 # Auto-generated by scripts/sync_models.py
 # Do not edit manually
 
-DISCOVERED_MODELS: dict[OnlineModelProviders, list[ModelInfo]] = {
+DISCOVERED_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
     OnlineModelProviders.OPENAI: [
         ModelInfo(
             id="gpt-4-0613",
@@ -1343,7 +1425,12 @@ DISCOVERED_MODELS: dict[OnlineModelProviders, list[ModelInfo]] = {
 _last_model_sync: datetime | None = None
 
 
-def get_models_for_provider(provider: OnlineModelProviders) -> list[ModelInfo]:
+def provider_to_string(provider: OnlineModelProviders | str) -> str:
+    """Return the stable provider ID for enum and catalog-backed providers."""
+    return provider.value if isinstance(provider, OnlineModelProviders) else provider
+
+
+def get_models_for_provider(provider: OnlineModelProviders | str) -> list[ModelInfo]:
     """
     Get all available models for a provider, preferring discovered models.
 
@@ -1360,7 +1447,7 @@ def get_models_for_provider(provider: OnlineModelProviders) -> list[ModelInfo]:
         return STATIC_MODELS.get(provider, [])
 
 
-def get_all_models() -> dict[OnlineModelProviders, list[ModelInfo]]:
+def get_all_models() -> dict[OnlineModelProviders | str, list[ModelInfo]]:
     """
     Get all available models grouped by provider.
 
@@ -1368,7 +1455,10 @@ def get_all_models() -> dict[OnlineModelProviders, list[ModelInfo]]:
         Dictionary mapping Provider to list of ModelInfo
     """
     result = {}
-    for provider in OnlineModelProviders:
+    providers: list[OnlineModelProviders | str] = list(OnlineModelProviders)
+    providers.extend(provider for provider in STATIC_MODELS if provider not in providers)
+    providers.extend(provider for provider in DISCOVERED_MODELS if provider not in providers)
+    for provider in providers:
         models = get_models_for_provider(provider)
         if models:  # Only include providers with models
             result[provider] = models
@@ -1385,15 +1475,26 @@ def get_model_by_id(model_id: str) -> ModelInfo | None:
     Returns:
         ModelInfo if found, None otherwise
     """
-    for provider in OnlineModelProviders:
-        models = get_models_for_provider(provider)
+    matches = []
+    for models in get_all_models().values():
         for model in models:
             if model.id == model_id:
-                return model
-    return None
+                matches.append(model)
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda model: (
+            model.backend is not None,
+            model.local,
+            provider_to_string(model.provider) == "offline",
+        ),
+    )
 
 
-def update_discovered_models(provider: OnlineModelProviders, models: list[ModelInfo]) -> None:
+def update_discovered_models(
+    provider: OnlineModelProviders | str, models: list[ModelInfo]
+) -> None:
     """
     Update the discovered models for a provider.
 
@@ -1404,7 +1505,11 @@ def update_discovered_models(provider: OnlineModelProviders, models: list[ModelI
     global _last_model_sync
     DISCOVERED_MODELS[provider] = models
     _last_model_sync = datetime.utcnow()
-    logger.info(f"Updated discovered models for {provider.value}: {len(models)} models")
+    logger.info(
+        "Updated discovered models for %s: %s models",
+        provider_to_string(provider),
+        len(models),
+    )
 
 
 def get_last_model_sync_time() -> datetime | None:
@@ -1412,7 +1517,22 @@ def get_last_model_sync_time() -> datetime | None:
     return _last_model_sync
 
 
-def provider_from_string(provider_str: str) -> OnlineModelProviders | None:
+def get_provider_ids() -> list[str]:
+    """List legacy, catalog, static, and discovered provider IDs once."""
+    provider_ids = [provider.value for provider in OnlineModelProviders]
+    for provider in PROVIDERS:
+        if provider not in provider_ids:
+            provider_ids.append(provider)
+    for provider in (*STATIC_MODELS, *DISCOVERED_MODELS):
+        provider_id = provider_to_string(provider)
+        if provider_id not in provider_ids:
+            provider_ids.append(provider_id)
+    return provider_ids
+
+
+def provider_from_string(
+    provider_str: str,
+) -> OnlineModelProviders | str | None:
     """
     Convert a provider string to OnlineModelProviders enum.
 
@@ -1425,4 +1545,7 @@ def provider_from_string(provider_str: str) -> OnlineModelProviders | None:
     try:
         return OnlineModelProviders(provider_str.lower())
     except ValueError:
+        normalized = provider_str.lower()
+        if normalized in get_provider_ids():
+            return normalized
         return None

--- a/agents/architectures/registry.py
+++ b/agents/architectures/registry.py
@@ -8,7 +8,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from agents.model_catalog import MODEL_SPECS, PROVIDERS
 
@@ -217,7 +217,7 @@ class RunnerRegistry:
             module, class_name = value
             value = getattr(importlib.import_module(module), class_name)
             self._registry[name] = value
-        return value
+        return cast(type | None, value)
 
     def list(self) -> dict[str, Any]:
         """
@@ -733,6 +733,7 @@ STATIC_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
 # API contracts remain backward compatible while additions stay one-line-ish.
 
 for _spec in MODEL_SPECS:
+    _provider: OnlineModelProviders | str
     try:
         _provider = OnlineModelProviders(_spec.provider)
     except ValueError:
@@ -1523,8 +1524,9 @@ def get_provider_ids() -> list[str]:
     for provider in PROVIDERS:
         if provider not in provider_ids:
             provider_ids.append(provider)
-    for provider in (*STATIC_MODELS, *DISCOVERED_MODELS):
-        provider_id = provider_to_string(provider)
+    _provider_key: OnlineModelProviders | str
+    for _provider_key in (*STATIC_MODELS, *DISCOVERED_MODELS):
+        provider_id = provider_to_string(_provider_key)
         if provider_id not in provider_ids:
             provider_ids.append(provider_id)
     return provider_ids

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -8,7 +8,7 @@ import os
 import re
 from contextlib import suppress
 from importlib import metadata
-from typing import Any
+from typing import Any, cast
 
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
@@ -98,6 +98,11 @@ class TransformersRunner(BaseRunner):
         self.tokenizer = AutoTokenizer.from_pretrained(self.source, **common_kwargs)
         load_kwargs: dict[str, Any] = dict(common_kwargs)
         load_kwargs["torch_dtype"] = self._select_dtype(device_config.pop("dtype", None))
+        if self.device.type == "mps" and "attn_implementation" not in device_config:
+            # Torch 2.6 SDPA can abort the process for otherwise valid causal-LM
+            # shapes on Apple MPS. Eager attention is slower but stable, and an
+            # explicit device option can still opt into a newer implementation.
+            load_kwargs["attn_implementation"] = "eager"
 
         has_accelerate = importlib.util.find_spec("accelerate") is not None
         if has_accelerate:
@@ -124,7 +129,7 @@ class TransformersRunner(BaseRunner):
         )
         self.model = AutoModelForCausalLM.from_pretrained(self.source, **load_kwargs)
         if not getattr(self.model, "hf_device_map", None):
-            self.model = self.model.to(self.device)
+            self.model = cast(Any, self.model).to(self.device)
         self.model.eval()
         if hasattr(self.model, "config"):
             self.model.config.use_cache = True

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -1,0 +1,276 @@
+"""Generic, performance-aware Hugging Face causal language-model runner."""
+from __future__ import annotations
+
+import gc
+import importlib.util
+import logging
+import os
+import re
+from contextlib import suppress
+from importlib import metadata
+from typing import Any
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+from agents.architectures.base_runner import BaseRunner, GenerationConfig
+from agents.model_catalog import infer_model_spec
+from agents.models.llama_completion import strings_to_message_dict
+
+
+logger = logging.getLogger(__name__)
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", value)[:3])
+
+
+class TransformersRunner(BaseRunner):
+    """Run standard Hugging Face causal LMs without family-specific code."""
+
+    def __init__(self):
+        self.model = None
+        self.tokenizer = None
+        self.config = None
+        self.model_id = None
+        self.source = None
+        self.device = None
+        self.model_spec = None
+        self.trust_remote_code = False
+
+    def load(self, model_id: str, device_config: dict[str, Any] | None = None) -> None:
+        device_config = dict(device_config or {})
+        allow_server_backed = bool(device_config.pop("allow_server_backed", False))
+        self.model_id = model_id
+        self.model_spec = infer_model_spec(model_id)
+        if self.model_spec and not self.model_spec.local and not allow_server_backed:
+            raise ValueError(
+                f"{model_id} is cataloged as server-backed. Configure it as an online "
+                f"model using provider '{self.model_spec.provider}'."
+            )
+
+        self._check_transformers_version()
+        self.trust_remote_code = bool(device_config.pop("trust_remote_code", False))
+        if self.model_spec and self.model_spec.requires_remote_code and not self.trust_remote_code:
+            raise ValueError(
+                f"{model_id} requires remote model code. Set trust_remote_code=true only "
+                "after reviewing the repository, or use an OpenAI-compatible server."
+            )
+        if self.model_spec:
+            missing_optional = [
+                dependency
+                for dependency in self.model_spec.optional_dependencies
+                if importlib.util.find_spec(dependency) is None
+            ]
+            if missing_optional:
+                logger.warning(
+                    "%s is missing optional acceleration packages: %s",
+                    model_id,
+                    ", ".join(missing_optional),
+                )
+
+        weights_dir = device_config.pop("weights_dir", None)
+        default_dir = os.path.join("app", "model_weights", model_id.replace("/", "_"))
+        self.source = weights_dir or (default_dir if os.path.isdir(default_dir) else model_id)
+        explicit_device = device_config.pop("device", None)
+        self.device = self._select_device(explicit_device)
+        compile_model = bool(device_config.pop("compile", False))
+        if self.device.type == "cuda" and device_config.pop("allow_tf32", True):
+            torch.backends.cuda.matmul.allow_tf32 = True
+            torch.set_float32_matmul_precision("high")
+
+        common_kwargs = {"trust_remote_code": self.trust_remote_code}
+        token = os.getenv("HUGGING_FACE_HUB_TOKEN") or os.getenv("HF_TOKEN")
+        if token:
+            common_kwargs["token"] = token
+        for option in ("revision", "cache_dir", "local_files_only", "subfolder"):
+            if option in device_config:
+                common_kwargs[option] = device_config.pop(option)
+
+        self.config = AutoConfig.from_pretrained(self.source, **common_kwargs)
+        architectures = getattr(self.config, "architectures", None) or []
+        if any("ConditionalGeneration" in name or "Multimodal" in name for name in architectures):
+            raise ValueError(
+                f"{model_id} is multimodal and needs a processor/conditional-generation runner; "
+                "it cannot be loaded by the text-only Transformers runner."
+            )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.source, **common_kwargs)
+        load_kwargs = dict(common_kwargs)
+        load_kwargs["torch_dtype"] = self._select_dtype(device_config.pop("dtype", None))
+
+        has_accelerate = importlib.util.find_spec("accelerate") is not None
+        if has_accelerate:
+            load_kwargs["low_cpu_mem_usage"] = True
+            requested_device_map = device_config.pop("device_map", None)
+            if requested_device_map is not None:
+                load_kwargs["device_map"] = requested_device_map
+            elif self.device.type == "cuda" and explicit_device is None:
+                load_kwargs["device_map"] = "auto"
+
+        for option in (
+            "attn_implementation", "quantization_config", "load_in_4bit",
+            "load_in_8bit", "max_memory", "offload_folder",
+            "offload_state_dict", "use_safetensors",
+        ):
+            if option in device_config:
+                load_kwargs[option] = device_config.pop(option)
+        if device_config:
+            logger.warning("Ignoring unsupported Transformers device options: %s", sorted(device_config))
+
+        logger.info(
+            "Loading %s with Transformers on %s (%s)",
+            model_id, self.device, load_kwargs["torch_dtype"],
+        )
+        self.model = AutoModelForCausalLM.from_pretrained(self.source, **load_kwargs)
+        if not getattr(self.model, "hf_device_map", None):
+            self.model = self.model.to(self.device)
+        self.model.eval()
+        if hasattr(self.model, "config"):
+            self.model.config.use_cache = True
+        if compile_model and getattr(self.model, "hf_device_map", None):
+            raise ValueError("torch.compile is not supported with a sharded device_map")
+        if compile_model:
+            if not hasattr(torch, "compile"):
+                raise RuntimeError("torch.compile is unavailable in this PyTorch build")
+            self.model = torch.compile(self.model, mode="reduce-overhead")
+
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+
+    def _check_transformers_version(self) -> None:
+        required = self.model_spec.min_transformers_version if self.model_spec else None
+        if not required:
+            return
+        installed = metadata.version("transformers")
+        if _version_tuple(installed) < _version_tuple(required):
+            raise RuntimeError(
+                f"{self.model_id} requires transformers>={required}; installed version is {installed}. "
+                "Upgrade the environment or use an OpenAI-compatible inference server."
+            )
+
+    @staticmethod
+    def _select_device(explicit: str | None) -> torch.device:
+        if explicit:
+            return torch.device(explicit)
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    def _select_dtype(self, explicit: Any | None):
+        if explicit is not None:
+            if isinstance(explicit, torch.dtype):
+                return explicit
+            value = str(explicit).replace("torch.", "").lower()
+            dtypes = {
+                "auto": "auto", "float32": torch.float32, "fp32": torch.float32,
+                "float16": torch.float16, "fp16": torch.float16,
+                "bfloat16": torch.bfloat16, "bf16": torch.bfloat16,
+            }
+            if value not in dtypes:
+                raise ValueError(f"Unsupported dtype: {explicit}")
+            return dtypes[value]
+        if self.device.type == "cuda":
+            return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+        if self.device.type == "mps":
+            return torch.float16
+        return torch.float32
+
+    def generate(self, prompt: str, generation_config: GenerationConfig) -> dict[str, Any]:
+        return self.complete("", prompt, generation_config)
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        generation_config: GenerationConfig,
+    ) -> dict[str, Any]:
+        if self.model is None or self.tokenizer is None:
+            raise RuntimeError("Model not loaded. Call load() first.")
+
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        if not getattr(self.tokenizer, "chat_template", None):
+            raise ValueError(
+                f"{self.model_id} does not provide a tokenizer chat template. "
+                "Use an instruction-tuned checkpoint with a published chat template."
+            )
+
+        try:
+            inputs = self._apply_chat_template(messages)
+        except Exception:
+            if not system_prompt:
+                raise
+            # A few otherwise standard instruction checkpoints do not define a
+            # system role. Preserve the instruction without family-specific
+            # branching by placing it ahead of the user content.
+            logger.info(
+                "%s chat template rejected a system role; folding it into the user turn",
+                self.model_id,
+            )
+            inputs = self._apply_chat_template([
+                {"role": "user", "content": f"{system_prompt}\n\n{user_prompt}"}
+            ])
+        inputs = dict(inputs) if hasattr(inputs, "items") else {"input_ids": inputs}
+        target_device = getattr(self.model, "device", self.device)
+        inputs = {name: value.to(target_device) for name, value in inputs.items()}
+        input_length = inputs["input_ids"].shape[-1]
+        max_context = getattr(self.config, "max_position_embeddings", None)
+        max_new_tokens = generation_config.max_tokens
+        if isinstance(max_context, int) and max_context > 0:
+            available_tokens = max_context - input_length
+            if available_tokens <= 0:
+                raise ValueError(
+                    f"Prompt uses {input_length} tokens, exceeding the model context "
+                    f"window of {max_context}."
+                )
+            if max_new_tokens > available_tokens:
+                logger.warning(
+                    "Clamping max_new_tokens from %s to %s for model context limit",
+                    max_new_tokens, available_tokens,
+                )
+                max_new_tokens = available_tokens
+
+        do_sample = generation_config.temperature > 0
+        generation_kwargs = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+            "pad_token_id": self.tokenizer.pad_token_id,
+            "use_cache": True,
+        }
+        if do_sample:
+            generation_kwargs["temperature"] = generation_config.temperature
+            generation_kwargs["top_p"] = generation_config.top_p
+
+        with torch.inference_mode():
+            generated = self.model.generate(**inputs, **generation_kwargs)
+        response = self.tokenizer.decode(
+            generated[0][input_length:], skip_special_tokens=True
+        ).strip()
+        if generation_config.stop:
+            response = response.split(generation_config.stop, 1)[0].rstrip()
+        return strings_to_message_dict(user_prompt, response)
+
+    def _apply_chat_template(self, messages):
+        return self.tokenizer.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+
+    def cleanup(self) -> None:
+        self.model = None
+        self.tokenizer = None
+        self.config = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        if hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+            with suppress(RuntimeError):
+                torch.mps.empty_cache()

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -29,12 +29,12 @@ class TransformersRunner(BaseRunner):
     """Run standard Hugging Face causal LMs without family-specific code."""
 
     def __init__(self):
-        self.model = None
-        self.tokenizer = None
-        self.config = None
-        self.model_id = None
-        self.source = None
-        self.device = None
+        self.model: Any | None = None
+        self.tokenizer: Any | None = None
+        self.config: Any | None = None
+        self.model_id: str | None = None
+        self.source: str | None = None
+        self.device: torch.device | None = None
         self.model_spec = None
         self.trust_remote_code = False
 
@@ -79,7 +79,7 @@ class TransformersRunner(BaseRunner):
             torch.backends.cuda.matmul.allow_tf32 = True
             torch.set_float32_matmul_precision("high")
 
-        common_kwargs = {"trust_remote_code": self.trust_remote_code}
+        common_kwargs: dict[str, Any] = {"trust_remote_code": self.trust_remote_code}
         token = os.getenv("HUGGING_FACE_HUB_TOKEN") or os.getenv("HF_TOKEN")
         if token:
             common_kwargs["token"] = token
@@ -96,7 +96,7 @@ class TransformersRunner(BaseRunner):
             )
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.source, **common_kwargs)
-        load_kwargs = dict(common_kwargs)
+        load_kwargs: dict[str, Any] = dict(common_kwargs)
         load_kwargs["torch_dtype"] = self._select_dtype(device_config.pop("dtype", None))
 
         has_accelerate = importlib.util.find_spec("accelerate") is not None
@@ -172,13 +172,17 @@ class TransformersRunner(BaseRunner):
             if value not in dtypes:
                 raise ValueError(f"Unsupported dtype: {explicit}")
             return dtypes[value]
+        if self.device is None:
+            raise RuntimeError("Device not selected. Call load() first.")
         if self.device.type == "cuda":
             return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
         if self.device.type == "mps":
             return torch.float16
         return torch.float32
 
-    def generate(self, prompt: str, generation_config: GenerationConfig) -> dict[str, Any]:
+    def generate(
+        self, prompt: str, generation_config: GenerationConfig
+    ) -> list[dict[str, str]]:
         return self.complete("", prompt, generation_config)
 
     def complete(
@@ -186,7 +190,7 @@ class TransformersRunner(BaseRunner):
         system_prompt: str,
         user_prompt: str,
         generation_config: GenerationConfig,
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, str]]:
         if self.model is None or self.tokenizer is None:
             raise RuntimeError("Model not loaded. Call load() first.")
 
@@ -252,10 +256,24 @@ class TransformersRunner(BaseRunner):
             generated[0][input_length:], skip_special_tokens=True
         ).strip()
         if generation_config.stop:
-            response = response.split(generation_config.stop, 1)[0].rstrip()
+            stop_sequences = (
+                [generation_config.stop]
+                if isinstance(generation_config.stop, str)
+                else generation_config.stop
+            )
+            stop_positions = [
+                position
+                for stop_sequence in stop_sequences
+                if stop_sequence
+                if (position := response.find(stop_sequence)) >= 0
+            ]
+            if stop_positions:
+                response = response[: min(stop_positions)].rstrip()
         return strings_to_message_dict(user_prompt, response)
 
-    def _apply_chat_template(self, messages):
+    def _apply_chat_template(self, messages: list[dict[str, str]]) -> Any:
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer not loaded. Call load() first.")
         return self.tokenizer.apply_chat_template(
             messages,
             add_generation_prompt=True,

--- a/agents/architectures/vllm_runner.py
+++ b/agents/architectures/vllm_runner.py
@@ -100,9 +100,12 @@ class VLLMRunner(BaseRunner):
         return sorted(glob.glob(os.path.join(directory, "*.safetensors")))
 
     def _load_from_local(self) -> None:
-        self.tokenizer = AutoTokenizer.from_pretrained(self.weights_dir)
+        weights_dir = self.weights_dir
+        if weights_dir is None:
+            raise RuntimeError("Runner weights directory is not configured")
+        self.tokenizer = AutoTokenizer.from_pretrained(weights_dir)
         self.model = AutoModelForCausalLM.from_pretrained(
-            self.weights_dir,
+            weights_dir,
             torch_dtype=torch.float16,
         )
         self.model = self.model.to(self.device)
@@ -149,13 +152,16 @@ class VLLMRunner(BaseRunner):
         logger.info(f"Model loaded from safetensors. Parameters: {self.model.num_parameters()}")
 
     def _load_from_hub(self) -> None:
+        model_id = self.model_id
+        if model_id is None:
+            raise RuntimeError("Runner model ID is not configured")
         token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
         if token:
             login(token=token)
 
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id)
         self.model = AutoModelForCausalLM.from_pretrained(
-            self.model_id,
+            model_id,
             torch_dtype=torch.float16,
         )
         self.model = self.model.to(self.device)

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -154,20 +154,29 @@ class BaseAgent(ABC):
         """
         settings = self._agent_context.settings
 
-        def pick(value, setting, default):
+        generation_config = getattr(self, "generation_config", {})
+
+        def pick(name, value, setting, default):
             if value is not None:
                 return value
+            configured = generation_config.get(name)
+            if configured is not None:
+                return configured
             if setting is not None:
                 return setting
             return default
 
         return GenerationParams(
-            max_tokens=pick(max_tokens, settings.max_tokens, 16),
-            n=pick(n, settings.n, 1),
-            temperature=pick(temperature, settings.temperature, 1.0),
-            top_p=pick(top_p, settings.top_p, 1.0),
-            frequency_penalty=pick(frequency_penalty, settings.frequency_penalty, 0.0),
-            presence_penalty=pick(presence_penalty, settings.presence_penalty, 0.0),
+            max_tokens=pick("max_tokens", max_tokens, settings.max_tokens, 16),
+            n=pick("n", n, settings.n, 1),
+            temperature=pick("temperature", temperature, settings.temperature, 1.0),
+            top_p=pick("top_p", top_p, settings.top_p, 1.0),
+            frequency_penalty=pick(
+                "frequency_penalty", frequency_penalty, settings.frequency_penalty, 0.0
+            ),
+            presence_penalty=pick(
+                "presence_penalty", presence_penalty, settings.presence_penalty, 0.0
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/agents/factory.py
+++ b/agents/factory.py
@@ -61,25 +61,26 @@ class AgentFactory:
             )
         else:
             raise ValueError(f"Unknown agent type: {agent_type}. Must be 'local' or 'online'")
-
-    # Model ID prefixes that should use the qwen3 runner
-    _QWEN3_PREFIXES = ("qwen/qwen3", "qwen3")
-
     @staticmethod
     def _infer_runner_type(model: str) -> str:
-        """
-        Infer the appropriate runner type from a model identifier.
+        """Infer a backend from catalog capabilities, not provider branding."""
+        from agents.model_catalog import infer_model_spec
 
-        Args:
-            model: Model identifier string
+        spec = infer_model_spec(model)
+        if spec:
+            if not spec.local:
+                raise ValueError(
+                    f"{model} is server-backed. Create an online agent with the "
+                    f"'{spec.provider}' provider or an OpenAI-compatible endpoint."
+                )
+            return spec.backend
 
-        Returns:
-            Runner type string ("qwen3" or "mlx_llama")
-        """
-        model_lower = model.lower()
-        if any(model_lower.startswith(prefix) for prefix in AgentFactory._QWEN3_PREFIXES):
-            return "qwen3"
-        return "mlx_llama"
+        # Preserve legacy bare Llama weight-directory names. Unknown Hugging
+        # Face causal models intentionally fall back to the generic runner so
+        # adding a compatible model does not require a code change.
+        if model.lower().startswith(("meta-llama-", "llama_3", "llama-3")):
+            return "mlx_llama"
+        return "transformers"
 
     @staticmethod
     def _create_local_agent(
@@ -92,10 +93,8 @@ class AgentFactory:
         """
         Create a LocalAgent instance.
 
-        If runner_type is not specified it is inferred from the model ID.
-        For Qwen 3 models a "weights_dir" key in device_config (passed via
-        kwargs) tells the runner where to find local safetensors / pretrained
-        weights on disk.
+        If runner_type is not specified it is inferred from model catalog
+        metadata. A ``weights_dir`` key can point any runner at local weights.
         """
         try:
             from agents.local_agent import LocalAgent
@@ -104,9 +103,22 @@ class AgentFactory:
             if not model:
                 model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
 
+            runner_was_explicit = runner_type is not None
             # Auto-detect runner type from model ID when not explicitly set
             if not runner_type:
                 runner_type = AgentFactory._infer_runner_type(model)
+
+            # Automatic selection protects users from accidental 32B+ loads.
+            # A deliberate Transformers override is the opt-in for capable
+            # hardware and is forwarded as a narrowly scoped runner flag.
+            if runner_was_explicit and runner_type == "transformers":
+                from agents.model_catalog import infer_model_spec
+
+                spec = infer_model_spec(model)
+                if spec and not spec.local:
+                    device_config = kwargs.pop("device_config", None) or {}
+                    device_config.setdefault("allow_server_backed", True)
+                    kwargs["device_config"] = device_config
 
             # Propagate weights_dir into device_config so the runner can
             # load safetensors / pretrained weights from a custom path.
@@ -140,11 +152,21 @@ class AgentFactory:
         try:
             from agents.online_agent import OnlineAgent
 
-            # Default values
-            if not endpoint:
-                endpoint = "https://api.openai.com/v1/chat/completions"
             if not model:
                 model = "gpt-4"
+            if not endpoint:
+                from agents.model_catalog import get_provider_endpoint, infer_model_spec
+
+                spec = infer_model_spec(model)
+                if spec and spec.backend == "openai_compatible":
+                    endpoint = get_provider_endpoint(spec.provider)
+                    if not endpoint:
+                        raise ValueError(
+                            f"{model} requires an OpenAI-compatible endpoint. Pass endpoint=... "
+                            "or set OPENAI_COMPATIBLE_BASE_URL."
+                        )
+                else:
+                    endpoint = "https://api.openai.com/v1"
 
             logger.info(f"Creating OnlineAgent with endpoint: {endpoint}, model: {model}")
             return OnlineAgent(

--- a/agents/local_agent.py
+++ b/agents/local_agent.py
@@ -30,6 +30,7 @@ class LocalAgent(BaseAgent):
         model_id: str,
         runner_type: str = "mlx_llama",
         device_config: dict[str, Any] | None = None,
+        generation_config: dict[str, Any] | None = None,
         as_subprocess: bool = False,
     ):
         """
@@ -40,6 +41,7 @@ class LocalAgent(BaseAgent):
             model_id: Model identifier to load
             runner_type: Type of runner to use (default: "mlx_llama")
             device_config: Optional device configuration
+            generation_config: Optional default generation parameters
             as_subprocess: Whether to run as subprocess
         """
         super().__init__(agent_context, as_subprocess)
@@ -47,8 +49,8 @@ class LocalAgent(BaseAgent):
         self.model_id = model_id
         self.runner_type = runner_type
         self.device_config = device_config or {}
+        self.generation_config = generation_config or {}
         self.runner: BaseRunner | None = None
-
         # Initialize the runner
         self._initialize_runner()
 

--- a/agents/model_catalog.py
+++ b/agents/model_catalog.py
@@ -1,0 +1,336 @@
+"""Capability and provider metadata for supported model families.
+
+Adding a standard causal language model should normally require only a
+``ModelSpec`` entry here.  Runner selection consumes backend metadata instead
+of growing model-name conditionals throughout the application.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    id: str
+    name: str
+    base_url: str
+    api_key_env: str
+    openai_compatible: bool = True
+    base_url_env: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    id: str
+    name: str
+    family: str
+    provider: str = "offline"
+    backend: str = "transformers"
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+    supports_vision: bool = False
+    supports_function_calling: bool = False
+    supports_reasoning: bool = False
+    supports_streaming: bool = False
+    recommended: bool = False
+    gated: bool = False
+    requires_remote_code: bool = False
+    min_transformers_version: str | None = None
+    parameter_count: str | None = None
+    activated_parameters: str | None = None
+    optional_dependencies: tuple[str, ...] = ()
+    local: bool = True
+    performance_note: str | None = None
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "openai": ProviderSpec("openai", "OpenAI", "https://api.openai.com/v1", "OPENAI_API_KEY"),
+    "groq": ProviderSpec("groq", "Groq", "https://api.groq.com/openai/v1", "GROQ_API_KEY"),
+    "xai": ProviderSpec("xai", "xAI", "https://api.x.ai/v1", "GROK_API_KEY"),
+    "moonshot": ProviderSpec(
+        "moonshot", "Moonshot AI", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY"
+    ),
+    "zai": ProviderSpec(
+        "zai", "Z.AI", "https://api.z.ai/api/paas/v4", "ZAI_API_KEY"
+    ),
+    "deepseek": ProviderSpec(
+        "deepseek", "DeepSeek", "https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"
+    ),
+    "self-hosted": ProviderSpec(
+        "self-hosted",
+        "Self-hosted OpenAI-compatible",
+        "",
+        "API_KEY",
+        base_url_env="OPENAI_COMPATIBLE_BASE_URL",
+    ),
+}
+
+
+MODEL_SPECS: tuple[ModelSpec, ...] = (
+    # Existing families and practical local reference checkpoints.
+    ModelSpec(
+        "Meta-Llama-3.1-8B-Instruct", "Meta Llama 3.1 8B Instruct (Local)",
+        "llama", backend="mlx_llama", context_window=131072,
+        max_output_tokens=8192, recommended=True, gated=True,
+        parameter_count="8B", performance_note="Optimized legacy MLX path on Apple Silicon.",
+    ),
+    ModelSpec(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct", "Meta Llama 3.1 8B Instruct (HF Local)",
+        "llama", backend="mlx_llama", context_window=131072, max_output_tokens=8192, gated=True,
+        parameter_count="8B",
+        performance_note="Preserves Geist's optimized Llama path; use an explicit transformers override for HF-native loading.",
+    ),
+    ModelSpec(
+        "Qwen/Qwen2.5-3B-Instruct", "Qwen 2.5 3B Instruct (Local)", "qwen",
+        context_window=32768, max_output_tokens=8192, supports_function_calling=True,
+        recommended=True, parameter_count="3B",
+        performance_note="Good laptop baseline; use 4-bit weights when available.",
+    ),
+    ModelSpec(
+        "Qwen/Qwen3-4B", "Qwen 3 4B (Local)", "qwen",
+        context_window=32768, max_output_tokens=8192, supports_function_calling=True,
+        supports_reasoning=True, recommended=True, parameter_count="4B",
+        performance_note="Use non-thinking mode for lower latency when reasoning is unnecessary.",
+    ),
+    ModelSpec(
+        "Qwen/Qwen3-8B", "Qwen 3 8B (Local)", "qwen",
+        context_window=32768, max_output_tokens=8192, supports_function_calling=True,
+        supports_reasoning=True, parameter_count="8B",
+        performance_note="Use 4-bit weights and non-thinking mode for lower local latency.",
+    ),
+    ModelSpec(
+        "Qwen/Qwen3-1.7B", "Qwen 3 1.7B (Local)", "qwen",
+        context_window=32768, max_output_tokens=8192, supports_reasoning=True,
+        parameter_count="1.7B", performance_note="Small laptop-friendly reference model.",
+    ),
+    ModelSpec(
+        "mistralai/Mistral-7B-Instruct-v0.3", "Mistral 7B Instruct v0.3 (Local)",
+        "mistral", context_window=32768, max_output_tokens=8192,
+        supports_function_calling=True, recommended=True, parameter_count="7B",
+        performance_note="Quantized MLX/GGUF weights are recommended on laptops.",
+    ),
+    ModelSpec(
+        "microsoft/Phi-4-mini-instruct", "Phi 4 Mini Instruct (Local)", "phi",
+        context_window=131072, max_output_tokens=8192, supports_function_calling=True,
+        recommended=True, min_transformers_version="4.49.0", parameter_count="3.8B",
+        performance_note="Strong small-model option; ONNX/INT4 variants improve CPU latency.",
+    ),
+    ModelSpec(
+        "HuggingFaceTB/SmolLM3-3B", "SmolLM3 3B (Local)", "smollm",
+        context_window=131072, max_output_tokens=8192, supports_function_calling=True,
+        supports_reasoning=True,
+        recommended=True, min_transformers_version="4.53.0", parameter_count="3B",
+        performance_note="Lightweight reference model suitable for local smoke tests.",
+    ),
+    ModelSpec(
+        "google/gemma-3-1b-it", "Gemma 3 1B IT (Local)", "gemma",
+        context_window=32768, max_output_tokens=8192, recommended=True, gated=True,
+        min_transformers_version="4.50.0", parameter_count="1B",
+        performance_note="Very small footprint; Hugging Face license acceptance is required.",
+    ),
+    ModelSpec(
+        "ibm-granite/granite-3.3-8b-instruct", "Granite 3.3 8B Instruct (Local)",
+        "granite", context_window=131072, max_output_tokens=8192,
+        supports_function_calling=True, supports_reasoning=True, parameter_count="8B",
+        performance_note="Prefer quantized weights or a local OpenAI-compatible server.",
+    ),
+    ModelSpec(
+        "allenai/Olmo-3-7B-Instruct", "OLMo 3 7B Instruct (Local)", "olmo",
+        context_window=65536, max_output_tokens=32768, supports_function_calling=True,
+        supports_reasoning=True,
+        min_transformers_version="4.57.0", parameter_count="7B",
+        performance_note="Prefer quantized weights for laptop deployment.",
+    ),
+    ModelSpec(
+        "zai-org/glm-4-9b-chat-hf", "GLM 4 9B Chat HF (Local)", "glm",
+        context_window=131072, max_output_tokens=8192,
+        supports_function_calling=True, min_transformers_version="4.46.0",
+        parameter_count="9B",
+        performance_note="Transformers-native GLM baseline; prefer 4-bit weights on laptops.",
+    ),
+    ModelSpec(
+        "openai/gpt-oss-20b", "gpt-oss 20B (Local/Server)", "gpt-oss",
+        context_window=131072, max_output_tokens=32768, supports_function_calling=True,
+        supports_reasoning=True, min_transformers_version="4.55.0",
+        parameter_count="21B", activated_parameters="3.6B",
+        optional_dependencies=("kernels",),
+        performance_note="Native MXFP4 fits near 16 GB; preserve the tokenizer Harmony template.",
+    ),
+    ModelSpec(
+        "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", "DeepSeek R1 Distill Qwen 7B (Local)",
+        "deepseek-distill", context_window=131072, max_output_tokens=32768,
+        supports_reasoning=True, parameter_count="7B",
+        performance_note="Uses the underlying Qwen architecture and generic runner.",
+    ),
+    # Heavyweight models are deliberately server-backed.
+    ModelSpec(
+        "zai-org/GLM-4.7-Flash", "GLM 4.7 Flash (Self-hosted)", "glm",
+        provider="self-hosted", backend="openai_compatible",
+        context_window=131072, max_output_tokens=131072,
+        supports_function_calling=True, supports_reasoning=True,
+        supports_streaming=True, parameter_count="31B",
+        activated_parameters="3B", local=False,
+        performance_note="Serve with vLLM/SGLang; sparse compute does not remove the 31B weight-residency cost.",
+    ),
+    ModelSpec(
+        "meta-llama/Llama-3.3-70B-Instruct", "Llama 3.3 70B (Self-hosted)",
+        "llama", provider="self-hosted", backend="openai_compatible",
+        context_window=131072, max_output_tokens=32768,
+        supports_function_calling=True, supports_streaming=True,
+        parameter_count="70B", local=False,
+        performance_note="Use a quantized runtime or a multi-GPU OpenAI-compatible server.",
+    ),
+    ModelSpec(
+        "Qwen/Qwen2.5-72B-Instruct", "Qwen 2.5 72B (Self-hosted)",
+        "qwen", provider="self-hosted", backend="openai_compatible",
+        context_window=131072, max_output_tokens=32768,
+        supports_function_calling=True, supports_streaming=True,
+        parameter_count="72B", local=False,
+        performance_note="Use a quantized runtime or a multi-GPU OpenAI-compatible server.",
+    ),
+    ModelSpec(
+        "mistralai/Mixtral-8x7B-Instruct-v0.1", "Mixtral 8x7B (Self-hosted)",
+        "mistral", provider="self-hosted", backend="openai_compatible",
+        context_window=32768, max_output_tokens=8192,
+        supports_function_calling=True, supports_streaming=True,
+        parameter_count="46.7B", activated_parameters="12.9B", local=False,
+        performance_note="MoE compute is sparse, but all expert weights still require residency.",
+    ),
+    ModelSpec(
+        "openai/gpt-oss-120b", "gpt-oss 120B (Self-hosted)", "gpt-oss",
+        provider="self-hosted", backend="openai_compatible",
+        context_window=131072, max_output_tokens=32768,
+        supports_function_calling=True, supports_reasoning=True,
+        supports_streaming=True, min_transformers_version="4.55.0",
+        parameter_count="117B", activated_parameters="5.1B", local=False,
+        performance_note="MXFP4 still targets roughly 80 GB of accelerator memory.",
+    ),
+    ModelSpec(
+        "kimi-k2.5", "Kimi K2.5", "kimi", provider="moonshot",
+        backend="openai_compatible", context_window=262144, max_output_tokens=65536,
+        supports_vision=True, supports_function_calling=True, supports_reasoning=True,
+        supports_streaming=True, recommended=True, requires_remote_code=True,
+        min_transformers_version="4.57.1", parameter_count="1T",
+        activated_parameters="32B", local=False,
+        performance_note="Server-only baseline; the official repository is hundreds of GB.",
+    ),
+    ModelSpec(
+        "glm-5.2", "GLM 5.2", "glm", provider="zai", backend="openai_compatible",
+        context_window=1000000, max_output_tokens=131072,
+        supports_function_calling=True, supports_reasoning=True, supports_streaming=True,
+        recommended=True, parameter_count="753B", local=False,
+        performance_note="Use Z.AI or a multi-GPU OpenAI-compatible deployment.",
+    ),
+    ModelSpec(
+        "glm-4.7-flash", "GLM 4.7 Flash (Hosted)", "glm", provider="zai",
+        backend="openai_compatible", context_window=131072,
+        max_output_tokens=131072, supports_function_calling=True,
+        supports_reasoning=True, supports_streaming=True, local=False,
+        parameter_count="31B", activated_parameters="3B",
+        performance_note="Hosted alternative to running the 31B Flash checkpoint on your own server.",
+    ),
+    ModelSpec(
+        "deepseek-reasoner", "DeepSeek R1", "deepseek", provider="deepseek",
+        backend="openai_compatible", context_window=131072, max_output_tokens=32768,
+        supports_function_calling=True, supports_reasoning=True, supports_streaming=True,
+        parameter_count="671B", activated_parameters="37B", local=False,
+        performance_note="Use the hosted API or a specialized multi-GPU deployment.",
+    ),
+)
+
+
+_MODEL_INDEX = {spec.id.lower(): spec for spec in MODEL_SPECS}
+
+
+def get_model_spec(model_id: str) -> ModelSpec | None:
+    """Return exact catalog metadata using case-insensitive model IDs."""
+    return _MODEL_INDEX.get(model_id.lower())
+
+
+def infer_model_spec(model_id: str) -> ModelSpec | None:
+    """Resolve known fine-tunes/quantizations to a family-level catalog entry."""
+    exact = get_model_spec(model_id)
+    if exact:
+        return exact
+
+    value = model_id.lower()
+    # Map heavyweight Hugging Face repository IDs to their server-backed
+    # catalog entries so they can never fall through to an accidental local
+    # trillion-parameter load.
+    if "moonshotai/kimi-k2" in value:
+        return get_model_spec("kimi-k2.5")
+    if "zai-org/glm-5" in value:
+        return get_model_spec("glm-5.2")
+    if "deepseek-ai/deepseek-r1" in value and "distill" not in value:
+        return get_model_spec("deepseek-reasoner")
+    if "gpt-oss-120b" in value:
+        return get_model_spec("openai/gpt-oss-120b")
+    heavyweight_parameters = _heavyweight_parameter_count(value)
+    if heavyweight_parameters is not None:
+        return ModelSpec(
+            id=model_id,
+            name=f"{model_id} (Self-hosted)",
+            family="large-model",
+            provider="self-hosted",
+            backend="openai_compatible",
+            parameter_count=f"{heavyweight_parameters:g}B",
+            local=False,
+            performance_note=(
+                "Automatically routed to a server because the model ID indicates "
+                "at least 32B total parameters."
+            ),
+        )
+    prefix_map = (
+        (("qwen/", "qwen", "deepseek-r1-distill-qwen"), "Qwen/Qwen3-4B"),
+        (("mistralai/", "mistral", "mixtral"), "mistralai/Mistral-7B-Instruct-v0.3"),
+        (("microsoft/phi", "phi-"), "microsoft/Phi-4-mini-instruct"),
+        (("huggingfacetb/smollm", "smollm"), "HuggingFaceTB/SmolLM3-3B"),
+        (("google/gemma", "gemma"), "google/gemma-3-1b-it"),
+        (("ibm-granite/", "granite"), "ibm-granite/granite-3.3-8b-instruct"),
+        (("allenai/olmo", "olmo"), "allenai/Olmo-3-7B-Instruct"),
+        (("zai-org/glm-4", "thudm/glm-4", "glm-4"), "zai-org/glm-4-9b-chat-hf"),
+        (("openai/gpt-oss", "gpt-oss"), "openai/gpt-oss-20b"),
+    )
+    for prefixes, reference_id in prefix_map:
+        if any(prefix in value for prefix in prefixes):
+            return get_model_spec(reference_id)
+    return None
+
+
+def _heavyweight_parameter_count(model_id: str) -> float | None:
+    """Infer clearly large total parameter counts from conventional model IDs."""
+    moe_match = re.search(r"(?:^|[-_/])(\d+)x(\d+(?:\.\d+)?)b(?:[-_/]|$)", model_id)
+    if moe_match:
+        total = int(moe_match.group(1)) * float(moe_match.group(2))
+        return total if total >= 32 else None
+
+    trillion_matches = [
+        float(value) * 1000
+        for value in re.findall(r"(?:^|[-_/])(\d+(?:\.\d+)?)t(?:[-_/]|$)", model_id)
+    ]
+    billion_matches = [
+        float(value)
+        for value in re.findall(r"(?:^|[-_/])(\d+(?:\.\d+)?)b(?:[-_/]|$)", model_id)
+    ]
+    candidates = trillion_matches + billion_matches
+    if not candidates:
+        return None
+    total = max(candidates)
+    return total if total >= 32 else None
+
+
+def get_provider_spec(provider_id: str) -> ProviderSpec | None:
+    return PROVIDERS.get(provider_id.lower())
+
+
+def get_provider_endpoint(provider_id: str) -> str | None:
+    provider = get_provider_spec(provider_id)
+    if not provider:
+        return None
+    if provider.base_url_env:
+        configured = os.getenv(provider.base_url_env)
+        if configured:
+            return configured.rstrip("/")
+    return provider.base_url or None

--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -14,6 +14,7 @@ import httpx
 from agents.agent_context import AgentContext
 from agents.base_agent import BaseAgent
 from agents.exceptions import CompletionRequestError
+from agents.model_catalog import PROVIDERS
 from agents.models.generic_completion import GenericCompletion
 from agents.tool_calling import (
     ToolCall,
@@ -41,6 +42,7 @@ class OnlineAgent(BaseAgent):
         model: str,
         api_key: str | None = None,
         backup_providers: list[dict[str, str]] | None = None,
+        generation_config: dict[str, Any] | None = None,
         timeout: float = 30.0,
         max_retries: int = 3,
         as_subprocess: bool = False,
@@ -55,6 +57,7 @@ class OnlineAgent(BaseAgent):
             model: Model name to use
             api_key: API key for authentication
             backup_providers: List of backup provider configurations
+            generation_config: Optional default generation parameters
             timeout: Request timeout in seconds
             max_retries: Maximum number of retries
             as_subprocess: Whether to run as subprocess
@@ -65,6 +68,7 @@ class OnlineAgent(BaseAgent):
         self.model = model
         self.api_key = api_key or self._get_api_key_from_env()
         self.backup_providers = backup_providers or []
+        self.generation_config = generation_config or {}
         self.timeout = timeout
         self.max_retries = max_retries
 
@@ -78,6 +82,9 @@ class OnlineAgent(BaseAgent):
 
     def _get_api_key_from_env(self) -> str | None:
         """Get provider-specific API key from environment variables based on the endpoint."""
+        for provider in PROVIDERS.values():
+            if provider.base_url and provider.base_url.rstrip("/") in self.base_url:
+                return os.getenv(provider.api_key_env)
         if "openai.com" in self.base_url:
             return os.getenv("OPENAI_API_KEY")
         elif "anthropic" in self.base_url:
@@ -86,8 +93,7 @@ class OnlineAgent(BaseAgent):
             return os.getenv("GROQ_API_KEY")
         elif "x.ai" in self.base_url:  # Grok
             return os.getenv("GROK_API_KEY")
-        return None
-
+        return os.getenv("API_KEY")
     def _make_request(
         self, payload: dict[str, Any], use_backup: bool = False, backup_index: int = 0
     ) -> dict[str, Any]:
@@ -226,7 +232,6 @@ class OnlineAgent(BaseAgent):
             system_prompt,
             chat_id,
         )
-
         # Make request
         response_data = self._make_request(payload)
 
@@ -273,7 +278,6 @@ class OnlineAgent(BaseAgent):
             chat_id,
         )
         payload["stream"] = True
-
         # Ensure endpoint includes chat/completions
         current_url = self.base_url
         if not current_url.endswith("/chat/completions"):

--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -93,7 +93,8 @@ class OnlineAgent(BaseAgent):
             return os.getenv("GROQ_API_KEY")
         elif "x.ai" in self.base_url:  # Grok
             return os.getenv("GROK_API_KEY")
-        return os.getenv("API_KEY")
+        return None
+
     def _make_request(
         self, payload: dict[str, Any], use_backup: bool = False, backup_index: int = 0
     ) -> dict[str, Any]:

--- a/app/api/v1/endpoints/models.py
+++ b/app/api/v1/endpoints/models.py
@@ -8,12 +8,13 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from agents.architectures.registry import (
-    OnlineModelProviders,
     get_all_models,
     get_last_model_sync_time,
     get_model_by_id,
     get_models_for_provider,
+    get_provider_ids,
     provider_from_string,
+    provider_to_string,
 )
 
 
@@ -35,6 +36,16 @@ class ModelResponse(BaseModel):
     #recommended models can be filtered to the top in the UI.
     recommended: bool
     family: str | None
+    backend: str | None = None
+    supports_reasoning: bool = False
+    gated: bool = False
+    requires_remote_code: bool = False
+    min_transformers_version: str | None = None
+    parameter_count: str | None = None
+    activated_parameters: str | None = None
+    optional_dependencies: tuple[str, ...] = ()
+    local: bool = False
+    performance_note: str | None = None
 
 
 class ModelsListResponse(BaseModel):
@@ -56,7 +67,7 @@ async def get_available_models():
 
         providers_dict = {}
         for provider, models in all_models.items():
-            providers_dict[provider.value] = [
+            providers_dict[provider_to_string(provider)] = [
                 ModelResponse(**model.to_dict()) for model in models
             ]
 
@@ -85,7 +96,7 @@ async def get_models_by_provider(provider: str):
         if provider_enum is None:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid provider: {provider}. Valid providers: {[p.value for p in OnlineModelProviders]}"
+                detail=f"Invalid provider: {provider}. Valid providers: {get_provider_ids()}"
             )
 
         models = get_models_for_provider(provider_enum)
@@ -129,4 +140,4 @@ async def get_providers():
     Returns:
         List[str]: List of provider names
     """
-    return [p.value for p in OnlineModelProviders]
+    return get_provider_ids()

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from agents.agent_type import AgentType
 
 # Initialize agent architecture registry
 from agents.architectures.registry import register_all_runners
-from agents.local_agent import LocalAgent
+from agents.factory import AgentFactory
 from agents.models.agent_completion import AgentCompletion
 from agents.online_agent import OnlineAgent
 from agents.prompt.prompt import AGENT_PROMPTS
@@ -313,8 +313,14 @@ def get_local_agent():
     agent_context = get_default_agent_context()
     # Get user settings to determine local model configuration
     settings = UserSettingsService.get_default_user_settings()
+    factory_config = AgentFactoryConfig.from_user_settings(settings)
     model_id = settings.default_local_model or DEFAULT_LOCAL_MODEL
-    return LocalAgent(agent_context=agent_context, model_id=model_id, runner_type="mlx_llama")
+    return AgentFactory.create_agent(
+        agent_type="local",
+        agent_context=agent_context,
+        model=model_id,
+        generation_config=factory_config.generation_config,
+    )
 
 
 def get_online_agent():
@@ -323,23 +329,14 @@ def get_online_agent():
     settings = UserSettingsService.get_default_user_settings()
     factory_config = AgentFactoryConfig.from_user_settings(settings)
 
-    # Get provider-specific API key from environment
-    provider = settings.default_online_provider
-    api_key = None
-    if provider == "openai":
-        api_key = os.getenv("OPENAI_API_KEY")
-    elif provider == "anthropic":
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-    elif provider == "groq":
-        api_key = os.getenv("GROQ_API_KEY")
-    elif provider == "grok":
-        api_key = os.getenv("GROK_API_KEY")
-
-    return OnlineAgent(
+    return AgentFactory.create_agent(
+        agent_type="online",
         agent_context=agent_context,
-        base_url=factory_config.endpoint or DEFAULT_API_URL,
+        # Preserve None so AgentFactory can infer the catalog endpoint and can
+        # fail safely when a self-hosted model has no configured server.
+        endpoint=factory_config.endpoint,
         model=factory_config.model,
-        api_key=api_key,
+        generation_config=factory_config.generation_config,
     )
 
 

--- a/app/models/user_settings.py
+++ b/app/models/user_settings.py
@@ -92,23 +92,22 @@ class AgentFactoryConfig(BaseModel):
 
         if agent_type == "local":
             model = overrides.model or settings.default_local_model
-            runner_type = overrides.runner_type or "mlx_llama"
+            # Leave unset so AgentFactory can select a backend from catalog
+            # capabilities. Explicit user overrides still take precedence.
+            runner_type = overrides.runner_type
             endpoint = None
             api_key = None
         else:  # online
             model = overrides.model or settings.default_online_model
             runner_type = None
-            # Default endpoint based on provider
-            if settings.default_online_provider == "openai":
-                endpoint = overrides.endpoint or "https://api.openai.com/v1/chat/completions"
-            elif settings.default_online_provider == "anthropic":
+            # Anthropic is not OpenAI wire-compatible. Other providers use the
+            # generic provider catalog and the existing OpenAI-compatible agent.
+            if settings.default_online_provider == "anthropic":
                 endpoint = overrides.endpoint or "https://api.anthropic.com/v1/messages"
-            elif settings.default_online_provider == "groq":
-                endpoint = overrides.endpoint or "https://api.groq.com/openai/v1/chat/completions"
-            elif settings.default_online_provider == "grok":
-                endpoint = overrides.endpoint or "https://api.x.ai/v1/chat/completions"
             else:
-                endpoint = overrides.endpoint
+                from agents.model_catalog import get_provider_endpoint
+                provider = "xai" if settings.default_online_provider == "grok" else settings.default_online_provider
+                endpoint = overrides.endpoint or get_provider_endpoint(provider)
             api_key = None  # Will be retrieved from environment
 
         # Convert backup providers
@@ -118,11 +117,19 @@ class AgentFactoryConfig(BaseModel):
 
         # Generation config
         generation_config = {
-            "max_tokens": overrides.max_tokens or settings.default_max_tokens,
-            "temperature": overrides.temperature or settings.default_temperature,
-            "top_p": overrides.top_p or settings.default_top_p,
-            "frequency_penalty": overrides.frequency_penalty or settings.default_frequency_penalty,
-            "presence_penalty": overrides.presence_penalty or settings.default_presence_penalty,
+            "max_tokens": overrides.max_tokens if overrides.max_tokens is not None else settings.default_max_tokens,
+            "temperature": overrides.temperature if overrides.temperature is not None else settings.default_temperature,
+            "top_p": overrides.top_p if overrides.top_p is not None else settings.default_top_p,
+            "frequency_penalty": (
+                overrides.frequency_penalty
+                if overrides.frequency_penalty is not None
+                else settings.default_frequency_penalty
+            ),
+            "presence_penalty": (
+                overrides.presence_penalty
+                if overrides.presence_penalty is not None
+                else settings.default_presence_penalty
+            ),
         }
 
         return cls(

--- a/app/services/user_settings_service.py
+++ b/app/services/user_settings_service.py
@@ -189,7 +189,7 @@ class UserSettingsService:
             api_key=factory_config.api_key,
             runner_type=factory_config.runner_type,
             backup_providers=[provider.dict() for provider in factory_config.backup_providers],
-            **factory_config.generation_config
+            generation_config=factory_config.generation_config,
         )
 
         return agent

--- a/client/geist/src/Components/AgentConfigSection.tsx
+++ b/client/geist/src/Components/AgentConfigSection.tsx
@@ -18,6 +18,10 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   xai: 'xAI (Grok)',
   groq: 'Groq',
   huggingface: 'Hugging Face',
+  moonshot: 'Moonshot AI',
+  zai: 'Z.AI',
+  deepseek: 'DeepSeek',
+  'self-hosted': 'Self-hosted Server',
   offline: 'Local/Offline',
   custom: 'Custom Provider'
 };
@@ -31,7 +35,12 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
   onOnlineProviderChange,
   onOnlineModelChange
 }) => {
-  const { getModelsForProvider, loading: modelsLoading, providers } = useAvailableModels();
+  const {
+    getModelById,
+    getModelsForProvider,
+    loading: modelsLoading,
+    providers,
+  } = useAvailableModels();
 
   const localModelOptions = useMemo(() => {
     const offlineModels = getModelsForProvider('offline');
@@ -89,7 +98,10 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
           value={localModel}
           options={localModelOptions}
           onChange={onLocalModelChange}
-          description="Select which local model to use for generation."
+          description={
+            getModelById(localModel)?.performance_note ||
+            'Select which local model to use for generation'
+          }
         />
       ) : (
         <>
@@ -106,7 +118,12 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
             value={onlineModel}
             options={onlineModelOptions}
             onChange={onOnlineModelChange}
-            description={modelsLoading ? 'Loading models...' : 'Choose which model from the provider to use.'}
+            description={
+              modelsLoading
+                ? 'Loading models...'
+                : getModelById(onlineModel)?.performance_note ||
+                  'Choose which model from the provider to use'
+            }
           />
         </>
       )}

--- a/client/geist/src/Components/__tests__/AgentConfigSection.test.tsx
+++ b/client/geist/src/Components/__tests__/AgentConfigSection.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import AgentConfigSection from '../AgentConfigSection';
 
 describe('AgentConfigSection', () => {
+  const originalFetch = global.fetch;
   const defaultProps = {
     agentType: 'online',
     localModel: 'Meta-Llama-3.1-8B-Instruct',
@@ -16,6 +17,10 @@ describe('AgentConfigSection', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   describe('Provider filtering', () => {
@@ -222,6 +227,42 @@ describe('AgentConfigSection', () => {
       expect(screen.getByText('Select your preferred online API provider.')).toBeInTheDocument();
       // Description may show "Loading models..." or the actual text depending on loading state
       expect(screen.getByText(/Choose which model from the provider to use|Loading models.../)).toBeInTheDocument();
+    });
+
+    it('displays performance guidance supplied by the model API', async () => {
+      const performanceNote = 'Use 4-bit weights for tolerable laptop latency.';
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          providers: {
+            offline: [{
+              id: 'example/future-model-3b',
+              name: 'Future Model 3B',
+              provider: 'offline',
+              context_window: 32768,
+              max_output_tokens: 4096,
+              supports_vision: false,
+              supports_function_calling: true,
+              supports_streaming: false,
+              recommended: true,
+              family: 'future-family',
+              performance_note: performanceNote,
+            }],
+          },
+          last_updated: null,
+        }),
+      });
+
+      render(
+        <AgentConfigSection
+          {...defaultProps}
+          agentType="local"
+          localModel="example/future-model-3b"
+        />
+      );
+
+      expect(await screen.findByText(performanceNote)).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Future Model 3B' })).toBeInTheDocument();
     });
   });
 });

--- a/client/geist/src/Hooks/useAvailableModels.tsx
+++ b/client/geist/src/Hooks/useAvailableModels.tsx
@@ -11,6 +11,16 @@ export interface ModelInfo {
   supports_streaming: boolean;
   recommended: boolean;
   family: string | null;
+  backend?: string | null;
+  supports_reasoning?: boolean;
+  gated?: boolean;
+  requires_remote_code?: boolean;
+  min_transformers_version?: string | null;
+  parameter_count?: string | null;
+  activated_parameters?: string | null;
+  optional_dependencies?: string[];
+  local?: boolean;
+  performance_note?: string | null;
 }
 
 export interface AvailableModels {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -195,6 +195,11 @@ User settings control default agent behavior and can be configured via API:
 - `ANTHROPIC_API_KEY` - Anthropic API key
 - `GROQ_API_KEY` - Groq API key
 - `GROK_API_KEY` - Grok (X.AI) API key
+- `MOONSHOT_API_KEY` - Moonshot API key for Kimi models
+- `ZAI_API_KEY` - Z.AI API key for hosted GLM models
+- `DEEPSEEK_API_KEY` - DeepSeek API key
+- `OPENAI_COMPATIBLE_BASE_URL` - Base `/v1` URL for a self-hosted inference server
+- `API_KEY` - Generic fallback API key
 
 ## Usage Examples
 

--- a/docs/open_weight_models.md
+++ b/docs/open_weight_models.md
@@ -1,0 +1,92 @@
+# Open-weight model support
+
+Geist separates model identity from inference backend. Standard Hugging Face
+causal language models use the generic `transformers` runner; heavyweight
+models use any OpenAI-compatible hosted or self-hosted endpoint. The supported
+catalog lives in `agents/model_catalog.py`.
+
+## Baseline families
+
+Local reference checkpoints cover Llama, Qwen 2.5/3, Mistral, Phi, SmolLM,
+Gemma text, Granite, OLMo, GLM 4 9B Chat HF, gpt-oss, and DeepSeek distillations.
+Kimi K2.5, GLM 4.7 Flash/5.2, full DeepSeek R1, Llama 70B, Qwen 72B, Mixtral
+8x7B, and gpt-oss 120B are intentionally server-backed.
+Their total resident weights make an in-process laptop load impractical even
+when their mixture-of-experts active-parameter count is much smaller.
+
+## Adding a model or provider
+
+1. Add a `ModelSpec` to `agents/model_catalog.py`.
+2. For a new OpenAI-compatible provider, add one `ProviderSpec` with its base
+   URL and API-key environment variable.
+3. Add runner code only when the model is not a standard causal LM (for
+   example, native multimodal processor input).
+
+Unknown instruction-tuned Hugging Face causal models default to the generic
+runner. Explicit `runner_type` settings continue to override catalog routing.
+As a memory-safety default, conventional IDs indicating 32B or more total
+parameters—including MoE names such as `8x22B`—route to the self-hosted
+provider. An explicit local `runner_type` override opts capable machines back
+into in-process loading.
+Catalog providers use string IDs, so adding one does not require extending the
+legacy `OnlineModelProviders` enum or changing the model API routes.
+
+Any self-hosted llama.cpp, vLLM, SGLang, or Transformers server can be used
+without a provider entry by creating an online agent with its base endpoint and
+served model name:
+
+```python
+AgentFactory.create_agent(
+    "online",
+    agent_context,
+    model="zai-org/GLM-4.7-Flash",
+    endpoint="http://inference-host:8000/v1",
+)
+```
+
+The online agent appends `/chat/completions` when the supplied endpoint is a
+base `/v1` URL.
+For persisted self-hosted settings, set `OPENAI_COMPATIBLE_BASE_URL` to that
+base URL and optionally set `API_KEY`.
+
+## Local inference performance
+
+The generic runner applies the following automatically:
+
+- inference mode and `model.eval()` to disable gradient work;
+- direct `model.generate()` rather than allocating a text-generation pipeline;
+- BF16 on supported CUDA, FP16 on MPS/CUDA, and FP32 on CPU;
+- automatic multi-GPU dispatch and low-memory loading through the pinned
+  Accelerate runtime;
+- one tokenizer/model instance per agent and generated-suffix-only decoding;
+- no second full-model `.to(device)` copy after Accelerate dispatches weights.
+
+Optional `device_config` keys are `device`, `dtype`, `device_map`,
+`attn_implementation`, `quantization_config`, `load_in_4bit`, `load_in_8bit`,
+`max_memory`, `offload_folder`, `offload_state_dict`, `use_safetensors`,
+`compile`, `allow_tf32`, `revision`, `cache_dir`, `local_files_only`,
+`subfolder`, `weights_dir`, `trust_remote_code`, and the advanced
+`allow_server_backed` safety override.
+Remote repository code is disabled by default. CUDA TF32 is enabled by default;
+`compile` is opt-in because its startup cost only pays off for longer sessions.
+The existing Meta Llama 3.1 ID continues to use Geist's MLX-specialized path;
+an explicit `runner_type: transformers` override selects HF-native loading.
+
+For tolerable laptop inference:
+
+- Prefer 1B-4B models for unquantized execution.
+- Prefer 4-bit MLX or GGUF weights for 7B and larger models.
+- Treat active parameters as compute cost, not memory footprint: all MoE
+  experts still need storage/residency.
+- Run GLM 4.7 Flash, gpt-oss 20B, and larger models behind a local
+  OpenAI-compatible llama.cpp, vLLM, or SGLang server when practical.
+- Use `zai-org/glm-4-9b-chat-hf` for the Transformers-native local GLM
+  baseline; it avoids remote repository code and supports the generic runner.
+- Use non-thinking/instant modes when deep reasoning is unnecessary; this can
+  reduce generated tokens and time-to-final-answer substantially.
+
+Catalog `performance_note` values are returned by the model API so clients can
+show hardware guidance before starting a large download.
+The API also returns `optional_dependencies`; for example, gpt-oss advertises
+the CUDA-only `kernels` accelerator without forcing that dependency into CPU or
+Apple Silicon environments.

--- a/plans/152-GENERIC-OPEN-WEIGHT-MODEL-SUPPORT.md
+++ b/plans/152-GENERIC-OPEN-WEIGHT-MODEL-SUPPORT.md
@@ -1,0 +1,49 @@
+# Generic Open-Weight Model Support
+
+## Goal
+
+Add extensible model support without creating one agent or runner per model brand. Separate model capabilities from inference backends so local Hugging Face models and OpenAI-compatible hosted/self-hosted models share one registry.
+
+## Supported families
+
+- Local causal language models: Llama, Qwen 2.5/3, Mistral, Phi, SmolLM, Gemma text, Granite, OLMo, GLM 4 9B, and compatible DeepSeek distillations.
+- Specialized local models: gpt-oss through the same Transformers runner plus format/capability metadata.
+- Server-backed heavyweight models: Kimi K2.5, GLM 5.2, full DeepSeek, and other OpenAI-compatible deployments.
+- Multimodal models are advertised with capability metadata but are not falsely routed through the text-only local runner.
+
+## Architecture
+
+1. Introduce a model catalog containing stable metadata: family, provider, backend, context limits, vision/tools/reasoning support, gating, remote-code requirements, minimum Transformers version, and performance notes.
+2. Add a generic `TransformersRunner` based on `AutoConfig`, `AutoTokenizer`, `AutoModelForCausalLM`, and tokenizer chat templates.
+3. Select local runners from catalog/backend metadata and conservative family rules. Preserve explicit runner overrides and the legacy MLX Llama runner.
+4. Keep heavyweight models provider-neutral by routing them through the existing OpenAI-compatible `OnlineAgent`; publish default provider endpoints separately from model architecture metadata.
+   Catalog provider IDs must not require adding another fixed enum member.
+5. Make runner registration lazy so optional MLX, Torch, and model-specific dependencies are imported only when selected.
+6. Extend model API responses and frontend types with backend/capability/performance metadata while remaining backward compatible.
+
+## Performance strategy
+
+- Prefer `device_map="auto"` on CUDA and avoid copying a fully loaded model with a second `.to(...)` pass.
+- Use automatic dtype selection: BF16 where supported, FP16 on MPS/compatible CUDA, FP32 on CPU unless quantized.
+- Enable `low_cpu_mem_usage`, inference mode, model evaluation mode, tokenizer/model reuse, and generated-suffix decoding without a high-level pipeline allocation.
+- Support optional attention implementation and quantization settings through `device_config`, without adding mandatory dependencies.
+- Recommend quantized GGUF/MLX or OpenAI-compatible local servers for models whose full weights are not laptop practical.
+- Fail early with actionable messages for gated repositories, incompatible Transformers versions, unsafe remote-code requirements, or models too large for the selected backend.
+
+## Implementation steps
+
+1. Add the catalog and generic Transformers runner.
+2. Refactor runner registration and factory routing to be lazy and capability-based.
+3. Populate backend and API registries for all target families and heavyweight provider endpoints.
+4. Update model synchronization, weight-copy helpers, and frontend fallback/type handling.
+5. Add unit tests for catalog resolution, runner loading/generation, device/dtype behavior, routing, API serialization, and backward compatibility.
+6. Run focused host tests, then the required Docker startup/log/curl validation.
+
+## Acceptance criteria
+
+- A new standard Hugging Face causal LM can be added primarily by one catalog entry.
+- Qwen 2.5/3, Mistral, Phi, SmolLM, Gemma text, Granite, OLMo, and the Transformers-native GLM 4 9B checkpoint resolve to the generic Transformers runner.
+- Existing Llama MLX and explicit runner selection remain functional.
+- Kimi K2.5, GLM 4.7 Flash/5.2, and full DeepSeek models are exposed as OpenAI-compatible server models, not misrepresented as laptop-local.
+- Local generation uses the model's own chat template and performs no pipeline recreation or duplicate device transfer.
+- Tests pass and the app starts under Docker with clean backend logs and a successful request to `localhost:3000`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,10 @@ dependencies = [
     "torchtune==0.6.0",
     # torchtune imports torchao at runtime but does not declare it as a dependency.
     "torchao==0.10.0",
-    "transformers==4.48.3",
-    "tokenizers==0.21.0",
-    "huggingface-hub==0.28.1",
+    "accelerate==1.14.0",
+    "transformers==4.57.6",
+    "tokenizers==0.22.1",
+    "huggingface-hub==0.36.0",
     "safetensors==0.5.2",
     "sentencepiece==0.2.0",
     "einops==0.8.1",

--- a/scripts/copy_weights.py
+++ b/scripts/copy_weights.py
@@ -9,6 +9,7 @@ This script provides functionality to:
 
 import logging
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -27,7 +28,10 @@ DEFAULT_MODEL = "llama_3_1"
 
 def model_dir_name(model_id: str) -> str:
     """Use the same deterministic directory convention as local runners."""
-    return model_id.replace("/", "_")
+    directory_name = re.sub(r"[\\/]+", "_", model_id.strip()).strip(".")
+    if not directory_name:
+        raise ValueError("Model ID must contain a directory-safe name")
+    return directory_name
 
 
 def destination_for_model(model_id: str) -> Path:

--- a/scripts/copy_weights.py
+++ b/scripts/copy_weights.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Script to manage model weights for llama_3_1.
+Script to manage local model weights.
 
 This script provides functionality to:
-1. Delete all weights in the app/model_weights/llama_3_1 folder
-2. Copy weights from a desktop location to the app/model_weights/llama_3_1 folder
+1. Delete weights from a model-specific directory.
+2. Copy weights from a desktop or configured location to that directory.
 """
 
 import logging
@@ -22,10 +22,16 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 # Load environment variables
 load_dotenv()
 
-models = {
-    "llama_3_1" : "llama_3_1",
-    "qwen3" : "qwen3"
-}
+DEFAULT_MODEL = "llama_3_1"
+
+
+def model_dir_name(model_id: str) -> str:
+    """Use the same deterministic directory convention as local runners."""
+    return model_id.replace("/", "_")
+
+
+def destination_for_model(model_id: str) -> Path:
+    return Path(__file__).parent.parent / "app" / "model_weights" / model_dir_name(model_id)
 
 def delete_weights(weights_dir: str | Path = None) -> tuple[bool, str]:
     """
@@ -127,10 +133,10 @@ def copy_weights(source_dir: str | Path,
         logger.error(f"Error copying files: {str(e)}")
         return False, f"Error copying files: {str(e)}"
 
-def copy_from_desktop() -> tuple[bool, str]:
+def copy_from_desktop(model_id: str = DEFAULT_MODEL) -> tuple[bool, str]:
     """
     Copy model weights from the directory specified in LOCAL_WEIGHTS_DIR environment variable
-    to app/model_weights/llama_3_1.
+    to a model-specific directory under app/model_weights.
 
     If LOCAL_WEIGHTS_DIR is not set, falls back to desktop llama_3_1 folder.
 
@@ -144,33 +150,32 @@ def copy_from_desktop() -> tuple[bool, str]:
 
     if local_weights_dir:
         local_weights_path = Path(local_weights_dir)
-        for model in models:
-            model_path = local_weights_path / models[model]
-            if model_path.exists():
-                logger.info(f"Using weights from LOCAL_WEIGHTS_DIR: {model_path}")
-                return copy_weights(model_path)
-            else:
-                logger.warning(f"LOCAL_WEIGHTS_DIR path does not exist: {model_path}")
+        model_path = local_weights_path / model_dir_name(model_id)
+        if model_path.exists():
+            logger.info(f"Using weights from LOCAL_WEIGHTS_DIR: {model_path}")
+            return copy_weights(model_path, destination_for_model(model_id))
+        logger.warning(f"LOCAL_WEIGHTS_DIR path does not exist: {model_path}")
 
     # Fall back to desktop path if LOCAL_WEIGHTS_DIR is not set or doesn't exist
     home_dir = Path.home()
-    desktop_dir = home_dir / "Desktop" / "llama_3_1"
+    desktop_dir = home_dir / "Desktop" / model_dir_name(model_id)
 
     if not desktop_dir.exists():
         # Try alternative desktop path on some systems
-        desktop_dir = home_dir / "OneDrive" / "Desktop" / "llama_3_1"
+        desktop_dir = home_dir / "OneDrive" / "Desktop" / model_dir_name(model_id)
 
         if not desktop_dir.exists():
-            logger.error("Could not find llama_3_1 folder on desktop.")
-            return False, "Could not find llama_3_1 folder on desktop."
+            logger.error(f"Could not find {model_dir_name(model_id)} folder on desktop.")
+            return False, f"Could not find {model_dir_name(model_id)} folder on desktop."
 
     logger.info(f"Using weights from desktop: {desktop_dir}")
-    return copy_weights(desktop_dir)
+    return copy_weights(desktop_dir, destination_for_model(model_id))
 
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Manage llama_3_1 model weights")
+    parser = argparse.ArgumentParser(description="Manage local model weights")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID or local model directory name")
     subparsers = parser.add_subparsers(dest="command", help="Command to execute")
 
     # Delete command
@@ -183,15 +188,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == "delete":
-        success, message = delete_weights()
+        success, message = delete_weights(destination_for_model(args.model))
         print(message)
         exit(0 if success else 1)
 
     elif args.command == "copy":
         if args.source:
-            success, message = copy_weights(args.source)
+            success, message = copy_weights(args.source, destination_for_model(args.model))
         else:
-            success, message = copy_from_desktop()
+            success, message = copy_from_desktop(args.model)
         print(message)
         exit(0 if success else 1)
 

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 import subprocess
 
 from huggingface_hub import snapshot_download
@@ -8,11 +9,19 @@ from huggingface_hub import snapshot_download
 DEFAULT_MODEL_ID = "meta-llama/Meta-Llama-3.1-8B-Instruct"
 
 
+def model_dir_name(model_id):
+    """Convert repository IDs to one safe local directory component."""
+    directory_name = re.sub(r"[\\/]+", "_", model_id.strip()).strip(".")
+    if not directory_name:
+        raise ValueError("Model ID must contain a directory-safe name")
+    return directory_name
+
+
 def default_weights_dir(model_id):
     """Preserve the existing MLX Llama directory; isolate all other models."""
     if model_id == DEFAULT_MODEL_ID:
         return os.path.join("app", "model_weights", "llama_3_1")
-    return os.path.join("app", "model_weights", model_id.replace("/", "_"))
+    return os.path.join("app", "model_weights", model_dir_name(model_id))
 
 
 def download_model_weights(model_id, weights_dir=None, use_cli=False, revision=None):

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -2,48 +2,56 @@ import argparse
 import os
 import subprocess
 
-from huggingface_hub import login
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from huggingface_hub import snapshot_download
 
 
-def download_llama_weights(model_id, weights_dir, use_cli=False):
-    # Login to Hugging Face
-    token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    if not token:
-        raise ValueError("HUGGING_FACE_HUB_TOKEN not found in environment variables")
-    login(token=token)
+DEFAULT_MODEL_ID = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+
+def default_weights_dir(model_id):
+    """Preserve the existing MLX Llama directory; isolate all other models."""
+    if model_id == DEFAULT_MODEL_ID:
+        return os.path.join("app", "model_weights", "llama_3_1")
+    return os.path.join("app", "model_weights", model_id.replace("/", "_"))
+
+
+def download_model_weights(model_id, weights_dir=None, use_cli=False, revision=None):
+    """Download files without instantiating the model or doubling memory use."""
+    token = os.environ.get("HUGGING_FACE_HUB_TOKEN") or os.environ.get("HF_TOKEN")
+    weights_dir = weights_dir or default_weights_dir(model_id)
 
     if use_cli:
-        # Download using huggingface-cli
         print(f"Downloading model to {weights_dir} using huggingface-cli")
-        command = f"huggingface-cli download {model_id} --include \"original/*\" --local-dir {weights_dir}"
-        subprocess.run(command, shell=True, check=True)
+        command = ["huggingface-cli", "download", model_id, "--local-dir", weights_dir]
+        if revision:
+            command.extend(["--revision", revision])
+        subprocess.run(command, check=True)
     else:
-        # Download model and tokenizer using transformers
-        print(f"Downloading model to {weights_dir} using transformers")
-
-        # Add custom configuration to handle rope_scaling mismatch
-        config_kwargs = {
-            "rope_scaling": {
-                "type": "linear",
-                "factor": 8.0
-            },
-        }
-
-        AutoModelForCausalLM.from_pretrained(model_id, cache_dir=weights_dir, token=token, **config_kwargs)
-        AutoTokenizer.from_pretrained(model_id, cache_dir=weights_dir, token=token)
+        print(f"Downloading model files to {weights_dir}")
+        snapshot_download(
+            repo_id=model_id,
+            local_dir=weights_dir,
+            token=token,
+            revision=revision,
+        )
 
     print("Download complete!")
 
+
+# Backward-compatible import for existing scripts.
+download_llama_weights = download_model_weights
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Download Llama model weights")
-    parser.add_argument("--model_id", type=str, default="meta-llama/Meta-Llama-3.1-8B-Instruct",
+    parser = argparse.ArgumentParser(description="Download Hugging Face model weights")
+    parser.add_argument("--model_id", type=str, default=DEFAULT_MODEL_ID,
                         help="Hugging Face model ID")
-    parser.add_argument("--weights_dir", type=str, default="app/model_weights/llama_3_1",
-                        help="Directory to store the model weights")
+    parser.add_argument("--weights_dir", type=str, default=None,
+                        help="Directory to store weights (defaults to a model-specific directory)")
+    parser.add_argument("--revision", type=str, default=None,
+                        help="Optional immutable model revision")
     parser.add_argument("--use_cli", action="store_true",
                         help="Use huggingface-cli for downloading instead of transformers")
 
     args = parser.parse_args()
 
-    download_llama_weights(args.model_id, args.weights_dir, args.use_cli)
+    download_model_weights(args.model_id, args.weights_dir, args.use_cli, args.revision)

--- a/scripts/model_filter_config.py
+++ b/scripts/model_filter_config.py
@@ -27,7 +27,6 @@ ALWAYS_INCLUDE: list[str] = [
 
 # Patterns to exclude (regex)
 EXCLUDE_PATTERNS: list[str] = [
-    r".*-instruct$",       # Exclude instruct variants for some providers
     r".*-vision-preview$", # Exclude preview versions
     r"ft:.*",              # Exclude fine-tuned models
     r".*:ft:.*",           # Exclude fine-tuned models (alt format)
@@ -56,6 +55,16 @@ CHAT_MODEL_PREFIXES: list[str] = [
     "llama",
     "mixtral",
     "qwen",
+    "mistral",
+    "phi",
+    "gemma",
+    "smollm",
+    "granite",
+    "olmo",
+    "glm",
+    "gpt-oss",
+    "kimi",
+    "deepseek",
 ]
 
 # Model metadata overrides - used to enhance API-provided data
@@ -218,8 +227,12 @@ HUGGINGFACE_MODEL_FAMILIES: list[str] = [
     "google",
     "deepseek-ai",
     "01-ai",
-    "THUDM",  # GLM models
-    "moonshot",  # Kimi models
+    "zai-org",  # GLM models
+    "moonshotai",  # Kimi models
+    "ibm-granite",
+    "allenai",
+    "HuggingFaceTB",
+    "openai",
 ]
 
 # Specific HuggingFace models to include
@@ -229,14 +242,23 @@ HUGGINGFACE_MODELS: list[str] = [
     "meta-llama/Llama-3.3-70B-Instruct",
     "Qwen/Qwen2.5-72B-Instruct",
     "Qwen/Qwen2.5-7B-Instruct",
+    "Qwen/Qwen2.5-3B-Instruct",
     "Qwen/Qwen3-8B",
     "Qwen/Qwen3-4B",
     "Qwen/Qwen3-1.7B",
     "Qwen/Qwen3-0.6B",
     "mistralai/Mixtral-8x7B-Instruct-v0.1",
     "mistralai/Mistral-7B-Instruct-v0.3",
-    "deepseek-ai/DeepSeek-V2.5",
-    "THUDM/glm-4-9b-chat",
+    "microsoft/Phi-4-mini-instruct",
+    "HuggingFaceTB/SmolLM3-3B",
+    "google/gemma-3-1b-it",
+    "ibm-granite/granite-3.3-8b-instruct",
+    "allenai/Olmo-3-7B-Instruct",
+    "zai-org/glm-4-9b-chat-hf",
+    "zai-org/GLM-4.7-Flash",
+    "openai/gpt-oss-20b",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+    "moonshotai/Kimi-K2.5",
 ]
 
 

--- a/tests/agents/test_model_catalog.py
+++ b/tests/agents/test_model_catalog.py
@@ -1,0 +1,256 @@
+"""Tests for generic model/provider catalog and runner routing."""
+import asyncio
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.factory import AgentFactory
+from agents.model_catalog import (
+    MODEL_SPECS,
+    PROVIDERS,
+    ProviderSpec,
+    get_model_spec,
+    get_provider_endpoint,
+    infer_model_spec,
+)
+
+
+def test_catalog_covers_requested_families():
+    families = {spec.family for spec in MODEL_SPECS}
+    assert {
+        "llama", "qwen", "mistral", "phi", "smollm", "gemma",
+        "granite", "olmo", "glm", "gpt-oss", "kimi", "deepseek",
+    }.issubset(families)
+
+
+def test_family_inference_supports_future_finetunes():
+    assert infer_model_spec("Qwen/custom-Qwen3-finetune").family == "qwen"
+    assert infer_model_spec("mlx-community/Mistral-7B-Instruct-v0.3").family == "mistral"
+    assert infer_model_spec("my-org/gemma-3-quantized").family == "gemma"
+
+
+def test_heavyweight_models_are_server_backed():
+    kimi = get_model_spec("kimi-k2.5")
+    assert kimi.backend == "openai_compatible"
+    assert kimi.local is False
+    assert get_provider_endpoint(kimi.provider) == "https://api.moonshot.ai/v1"
+
+    from agents.architectures.registry import get_all_models, provider_from_string
+
+    assert provider_from_string("moonshot") == "moonshot"
+    assert "moonshot" in get_all_models()
+
+    hosted_glm = get_model_spec("glm-4.7-flash")
+    assert hosted_glm.local is False
+    assert get_provider_endpoint(hosted_glm.provider) == "https://api.z.ai/api/paas/v4"
+
+
+@pytest.mark.parametrize("model_id", [
+    "Qwen/Qwen2.5-3B-Instruct",
+    "Qwen/Qwen3-4B",
+    "mistralai/Mistral-7B-Instruct-v0.3",
+    "microsoft/Phi-4-mini-instruct",
+    "HuggingFaceTB/SmolLM3-3B",
+    "google/gemma-3-1b-it",
+    "ibm-granite/granite-3.3-8b-instruct",
+    "allenai/Olmo-3-7B-Instruct",
+    "zai-org/glm-4-9b-chat-hf",
+    "openai/gpt-oss-20b",
+])
+def test_standard_local_models_use_generic_runner(model_id):
+    assert AgentFactory._infer_runner_type(model_id) == "transformers"
+
+
+def test_unknown_huggingface_model_uses_generic_runner():
+    assert AgentFactory._infer_runner_type("new-org/future-causal-lm") == "transformers"
+    assert AgentFactory._infer_runner_type("new-org/future-8B-instruct") == "transformers"
+
+
+@pytest.mark.parametrize(
+    "model_id, expected_parameters",
+    [
+        ("meta-llama/Meta-Llama-3.1-70B-Instruct", "70B"),
+        ("Qwen/Qwen3-32B", "32B"),
+        ("future-org/Future-8x22B-Instruct", "176B"),
+        ("future-org/Future-1T-Instruct", "1000B"),
+    ],
+)
+def test_future_heavyweight_ids_default_to_server(model_id, expected_parameters):
+    spec = infer_model_spec(model_id)
+    assert spec.local is False
+    assert spec.provider == "self-hosted"
+    assert spec.parameter_count == expected_parameters
+    with pytest.raises(ValueError, match="server-backed"):
+        AgentFactory._infer_runner_type(model_id)
+
+
+def test_explicit_runner_override_allows_large_local_model():
+    context = MagicMock()
+    with patch("agents.local_agent.LocalAgent") as local_agent:
+        AgentFactory.create_agent(
+            "local",
+            context,
+            model="future-org/Future-70B-Instruct",
+            runner_type="transformers",
+        )
+    assert local_agent.call_args.kwargs["runner_type"] == "transformers"
+    assert local_agent.call_args.kwargs["device_config"]["allow_server_backed"] is True
+
+
+def test_existing_llama_id_preserves_optimized_runner():
+    assert AgentFactory._infer_runner_type(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    ) == "mlx_llama"
+
+
+@pytest.mark.parametrize("model_id", [
+    "kimi-k2.5",
+    "moonshotai/Kimi-K2.5",
+    "glm-4.7-flash",
+    "zai-org/GLM-4.7-Flash",
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "Qwen/Qwen2.5-72B-Instruct",
+    "mistralai/Mixtral-8x7B-Instruct-v0.1",
+    "openai/gpt-oss-120b",
+    "zai-org/GLM-5.2",
+    "deepseek-ai/DeepSeek-R1",
+])
+def test_server_model_cannot_be_accidentally_loaded_locally(model_id):
+    with pytest.raises(ValueError, match="server-backed"):
+        AgentFactory._infer_runner_type(model_id)
+
+
+@pytest.mark.parametrize("model_id", ["kimi-k2.5", "moonshotai/Kimi-K2.5"])
+def test_server_model_infers_openai_compatible_provider_endpoint(model_id):
+    context = MagicMock()
+    with patch("agents.online_agent.OnlineAgent") as online_agent:
+        AgentFactory.create_agent("online", context, model=model_id)
+    assert online_agent.call_args.kwargs["base_url"] == "https://api.moonshot.ai/v1"
+
+
+def test_hosted_glm_infers_zai_endpoint():
+    context = MagicMock()
+    with patch("agents.online_agent.OnlineAgent") as online_agent:
+        AgentFactory.create_agent("online", context, model="glm-4.7-flash")
+    assert online_agent.call_args.kwargs["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+def test_self_hosted_model_requires_endpoint_or_environment():
+    context = MagicMock()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(ValueError, match="OPENAI_COMPATIBLE_BASE_URL"),
+    ):
+        AgentFactory.create_agent("online", context, model="openai/gpt-oss-120b")
+
+
+def test_self_hosted_model_uses_environment_endpoint():
+    context = MagicMock()
+    with (
+        patch.dict(
+            os.environ,
+            {"OPENAI_COMPATIBLE_BASE_URL": "http://inference:8000/v1/"},
+            clear=True,
+        ),
+        patch("agents.online_agent.OnlineAgent") as online_agent,
+    ):
+        AgentFactory.create_agent("online", context, model="openai/gpt-oss-120b")
+    assert online_agent.call_args.kwargs["base_url"] == "http://inference:8000/v1"
+
+
+def test_lazy_registry_does_not_import_every_backend():
+    from agents.architectures.registry import clear_registry, get_registry, register_all_runners
+
+    clear_registry()
+    register_all_runners()
+    raw_values = get_registry().list()
+    assert isinstance(raw_values["mlx_llama"], tuple)
+    assert isinstance(raw_values["transformers"], tuple)
+
+
+def test_model_api_metadata_contains_performance_fields():
+    from agents.architectures.registry import (
+        OnlineModelProviders,
+        get_model_by_id,
+        get_models_for_provider,
+    )
+
+    local_models = get_models_for_provider(OnlineModelProviders.OFFLINE)
+    local_glm = next(
+        model for model in local_models if model.id == "zai-org/glm-4-9b-chat-hf"
+    )
+    assert local_glm.backend == "transformers"
+    assert local_glm.local is True
+
+    hosted_models = get_models_for_provider("self-hosted")
+    glm = next(model for model in hosted_models if model.id == "zai-org/GLM-4.7-Flash")
+    payload = glm.to_dict()
+    assert payload["backend"] == "openai_compatible"
+    assert payload["supports_reasoning"] is True
+    assert payload["activated_parameters"] == "3B"
+    assert "vLLM/SGLang" in payload["performance_note"]
+
+    gpt_oss = get_model_by_id("openai/gpt-oss-20b")
+    assert gpt_oss.optional_dependencies == ("kernels",)
+
+    # Mistral also exists in the legacy Hugging Face provider list. Direct
+    # lookup should return the catalog-enriched local record.
+    mistral = get_model_by_id("mistralai/Mistral-7B-Instruct-v0.3")
+    assert mistral.backend == "transformers"
+    assert mistral.local is True
+    assert mistral.provider == OnlineModelProviders.OFFLINE
+
+
+def test_future_provider_does_not_require_enum_change(monkeypatch):
+    from agents.architectures.registry import (
+        STATIC_MODELS,
+        ModelInfo,
+        get_all_models,
+        get_provider_ids,
+        provider_from_string,
+    )
+
+    monkeypatch.setitem(
+        PROVIDERS,
+        "future-provider",
+        ProviderSpec(
+            "future-provider",
+            "Future Provider",
+            "https://future.example/v1",
+            "FUTURE_API_KEY",
+        ),
+    )
+    model = ModelInfo(
+        id="future-model",
+        name="Future Model",
+        provider="future-provider",
+    )
+    monkeypatch.setitem(STATIC_MODELS, "future-provider", [model])
+
+    assert provider_from_string("future-provider") == "future-provider"
+    assert "future-provider" in get_provider_ids()
+    assert get_all_models()["future-provider"] == [model]
+    assert model.to_dict()["provider"] == "future-provider"
+
+
+def test_model_routes_serialize_string_backed_providers():
+    from app.api.v1.endpoints.models import (
+        get_available_models,
+        get_models_by_provider,
+        get_providers,
+    )
+
+    provider_ids = asyncio.run(get_providers())
+    assert "self-hosted" in provider_ids
+    assert "moonshot" in provider_ids
+
+    response = asyncio.run(get_available_models())
+    assert "self-hosted" in response.providers
+    assert any(
+        model.id == "openai/gpt-oss-120b"
+        for model in response.providers["self-hosted"]
+    )
+
+    hosted_models = asyncio.run(get_models_by_provider("self-hosted"))
+    assert all(model.provider == "self-hosted" for model in hosted_models)

--- a/tests/agents/test_new_architecture.py
+++ b/tests/agents/test_new_architecture.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from agents.agent_settings import AgentSettings
 from agents.architectures.base_runner import BaseRunner, GenerationConfig
 from agents.architectures.registry import clear_registry, get_runner, register_runner
 from agents.factory import AgentFactory
@@ -138,6 +139,23 @@ class TestAgentFactory:
                 agent_context=context
             )
 
+
+def test_local_generation_config_preserves_zero_temperature():
+    """Greedy decoding must not be changed back to the 1.0 default."""
+    from agents.local_agent import LocalAgent
+
+    agent = LocalAgent.__new__(LocalAgent)
+    agent._agent_context = Mock(
+        settings=AgentSettings(name="test", version="1", description="test")
+    )
+    agent.generation_config = {"temperature": 0.4}
+
+    config = agent._create_generation_config(temperature=0.0)
+    assert config.temperature == 0.0
+
+    config = agent._create_generation_config()
+    assert config.temperature == 0.4
+
 class TestUserSettingsIntegration:
     """Test integration with user settings."""
 
@@ -145,7 +163,11 @@ class TestUserSettingsIntegration:
         """Test creating agent factory config from user settings."""
         from datetime import datetime
 
-        from app.models.user_settings import AgentFactoryConfig, UserSettingsResponse
+        from app.models.user_settings import (
+            AgentConfigRequest,
+            AgentFactoryConfig,
+            UserSettingsResponse,
+        )
 
         # Mock user settings
         settings = UserSettingsResponse(
@@ -172,7 +194,7 @@ class TestUserSettingsIntegration:
         config = AgentFactoryConfig.from_user_settings(settings)
         assert config.agent_type == "local"
         assert config.model == "test-model"
-        assert config.runner_type == "mlx_llama"
+        assert config.runner_type is None
         assert config.endpoint is None
 
         # Test online agent config
@@ -180,8 +202,12 @@ class TestUserSettingsIntegration:
         config = AgentFactoryConfig.from_user_settings(settings)
         assert config.agent_type == "online"
         assert config.model == "gpt-4"
-        assert config.endpoint == "https://api.openai.com/v1/chat/completions"
+        assert config.endpoint == "https://api.openai.com/v1"
         assert config.runner_type is None
+
+        overrides = AgentConfigRequest(temperature=0.0)
+        config = AgentFactoryConfig.from_user_settings(settings, overrides)
+        assert config.generation_config["temperature"] == 0.0
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/agents/test_qwen3.py
+++ b/tests/agents/test_qwen3.py
@@ -532,26 +532,26 @@ class TestQwen3RunnerRegistry:
 # Factory: auto-detection and weights_dir
 # ---------------------------------------------------------------------------
 
-class TestFactoryQwen3AutoDetection:
+class TestFactoryGenericAutoDetection:
 
-    def test_infer_runner_type_qwen3_models(self):
-        assert AgentFactory._infer_runner_type("Qwen/Qwen3-8B") == "qwen3"
-        assert AgentFactory._infer_runner_type("Qwen/Qwen3-4B") == "qwen3"
-        assert AgentFactory._infer_runner_type("Qwen/Qwen3-1.7B") == "qwen3"
-        assert AgentFactory._infer_runner_type("Qwen/Qwen3-0.6B") == "qwen3"
-        assert AgentFactory._infer_runner_type("qwen3-custom") == "qwen3"
+    def test_infer_runner_type_qwen_models(self):
+        assert AgentFactory._infer_runner_type("Qwen/Qwen3-8B") == "transformers"
+        assert AgentFactory._infer_runner_type("Qwen/Qwen3-4B") == "transformers"
+        assert AgentFactory._infer_runner_type("Qwen/Qwen2.5-3B-Instruct") == "transformers"
+        assert AgentFactory._infer_runner_type("qwen3-custom") == "transformers"
 
     def test_infer_runner_type_non_qwen(self):
         assert AgentFactory._infer_runner_type("meta-llama/Meta-Llama-3.1-8B-Instruct") == "mlx_llama"
-        assert AgentFactory._infer_runner_type("gpt-4") == "mlx_llama"
-        assert AgentFactory._infer_runner_type("Qwen/Qwen2.5-72B-Instruct") == "mlx_llama"
+        assert AgentFactory._infer_runner_type("future-org/future-model") == "transformers"
+        with pytest.raises(ValueError, match="server-backed"):
+            AgentFactory._infer_runner_type("Qwen/Qwen2.5-72B-Instruct")
 
     def test_infer_runner_type_case_insensitive(self):
-        assert AgentFactory._infer_runner_type("QWEN/QWEN3-8B") == "qwen3"
-        assert AgentFactory._infer_runner_type("qwen/qwen3-8b") == "qwen3"
+        assert AgentFactory._infer_runner_type("QWEN/QWEN3-8B") == "transformers"
+        assert AgentFactory._infer_runner_type("qwen/qwen3-8b") == "transformers"
 
     def test_factory_auto_detects_qwen3(self):
-        """create_agent with a Qwen3 model ID should use the qwen3 runner."""
+        """Qwen uses the same generic runner as other standard causal LMs."""
         context = Mock()
         context.settings = Mock()
 
@@ -564,7 +564,7 @@ class TestFactoryQwen3AutoDetection:
 
             MockLocalAgent.assert_called_once()
             _, kwargs = MockLocalAgent.call_args
-            assert kwargs["runner_type"] == "qwen3"
+            assert kwargs["runner_type"] == "transformers"
             assert kwargs["model_id"] == "Qwen/Qwen3-8B"
 
     def test_factory_explicit_runner_overrides_auto(self):
@@ -658,7 +658,7 @@ class TestFactoryCreateFromConfig:
             AgentFactory.create_from_config(config, context)
 
             _, kwargs = MockLocalAgent.call_args
-            assert kwargs["runner_type"] == "qwen3"
+            assert kwargs["runner_type"] == "transformers"
             assert kwargs["device_config"]["weights_dir"] == "/data/qwen3"
 
 

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -1,0 +1,182 @@
+"""Unit tests for the generic Transformers causal-LM runner."""
+from collections import UserDict
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from agents.architectures.base_runner import GenerationConfig
+from agents.architectures.transformers_runner import TransformersRunner
+
+
+def _tokenizer():
+    tokenizer = MagicMock()
+    tokenizer.chat_template = "{{ messages }}"
+    tokenizer.pad_token_id = 0
+    tokenizer.eos_token_id = 0
+    tokenizer.apply_chat_template.return_value = {
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "attention_mask": torch.tensor([[1, 1, 1]]),
+    }
+    tokenizer.decode.return_value = "fast response"
+    return tokenizer
+
+
+def _model():
+    model = MagicMock()
+    model.to.return_value = model
+    model.device = torch.device("cpu")
+    model.hf_device_map = None
+    model.generate.return_value = torch.tensor([[1, 2, 3, 8, 9]])
+    return model
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_load_and_generate_uses_direct_suffix_decode(
+    config_cls, tokenizer_cls, model_cls, _find_spec
+):
+    config_cls.from_pretrained.return_value = MagicMock(
+        architectures=["Qwen2ForCausalLM"], max_position_embeddings=64
+    )
+    tokenizer = _tokenizer()
+    model = _model()
+    tokenizer_cls.from_pretrained.return_value = tokenizer
+    model_cls.from_pretrained.return_value = model
+
+    runner = TransformersRunner()
+    runner.load("Qwen/Qwen2.5-3B-Instruct", {"device": "cpu"})
+    result = runner.complete(
+        "Be helpful", "hello", GenerationConfig(max_tokens=100, temperature=0.0)
+    )
+
+    model.to.assert_called_once_with(torch.device("cpu"))
+    model.eval.assert_called_once()
+    model.generate.assert_called_once()
+    assert model.generate.call_args.kwargs["do_sample"] is False
+    assert model.generate.call_args.kwargs["use_cache"] is True
+    assert model.generate.call_args.kwargs["max_new_tokens"] == 61
+    tokenizer.decode.assert_called_once()
+    decoded_ids = tokenizer.decode.call_args.args[0]
+    assert decoded_ids.tolist() == [8, 9]
+    assert result[1]["content"] == "fast response"
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_revision_is_shared_by_config_tokenizer_and_model(
+    config_cls, tokenizer_cls, model_cls, _find_spec
+):
+    config_cls.from_pretrained.return_value = MagicMock(architectures=["Phi3ForCausalLM"])
+    tokenizer_cls.from_pretrained.return_value = _tokenizer()
+    model_cls.from_pretrained.return_value = _model()
+
+    TransformersRunner().load(
+        "microsoft/Phi-4-mini-instruct",
+        {"device": "cpu", "revision": "immutable-sha"},
+    )
+
+    for loader in (config_cls, tokenizer_cls, model_cls):
+        assert loader.from_pretrained.call_args.kwargs["revision"] == "immutable-sha"
+
+
+def test_mapping_like_batch_encoding_and_system_role_fallback():
+    runner = TransformersRunner()
+    runner.model_id = "google/gemma-example"
+    runner.model = _model()
+    runner.tokenizer = _tokenizer()
+    runner.config = MagicMock(max_position_embeddings=64)
+    encoded = UserDict({
+        "input_ids": torch.tensor([[1, 2, 3]]),
+        "attention_mask": torch.tensor([[1, 1, 1]]),
+    })
+    runner.tokenizer.apply_chat_template.side_effect = [
+        ValueError("system role unsupported"),
+        encoded,
+    ]
+
+    runner.complete(
+        "Be concise", "hello", GenerationConfig(max_tokens=4, temperature=0.0)
+    )
+
+    fallback_messages = runner.tokenizer.apply_chat_template.call_args.args[0]
+    assert fallback_messages == [
+        {"role": "user", "content": "Be concise\n\nhello"}
+    ]
+    kwargs = runner.model.generate.call_args.kwargs
+    assert {"input_ids", "attention_mask"}.issubset(kwargs)
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec")
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_cuda_uses_accelerate_without_duplicate_device_copy(
+    config_cls, tokenizer_cls, model_cls, find_spec
+):
+    find_spec.return_value = MagicMock()
+    config_cls.from_pretrained.return_value = MagicMock(architectures=["Qwen2ForCausalLM"])
+    tokenizer_cls.from_pretrained.return_value = _tokenizer()
+    model = _model()
+    model.hf_device_map = {"": 0}
+    model_cls.from_pretrained.return_value = model
+
+    with patch.object(
+        TransformersRunner, "_select_device", return_value=torch.device("cuda")
+    ):
+        TransformersRunner().load("Qwen/Qwen2.5-3B-Instruct")
+
+    kwargs = model_cls.from_pretrained.call_args.kwargs
+    assert kwargs["low_cpu_mem_usage"] is True
+    assert kwargs["device_map"] == "auto"
+    model.to.assert_not_called()
+
+
+@patch("agents.architectures.transformers_runner.metadata.version", return_value="4.48.0")
+def test_minimum_transformers_version_fails_early(_version):
+    runner = TransformersRunner()
+    with pytest.raises(RuntimeError, match="transformers>=4.57.0"):
+        runner.load("allenai/Olmo-3-7B-Instruct", {"device": "cpu"})
+
+
+def test_server_backed_model_fails_before_loading():
+    runner = TransformersRunner()
+    with pytest.raises(ValueError, match="server-backed"):
+        runner.load("kimi-k2.5")
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_explicit_override_can_load_server_backed_text_model(
+    config_cls, tokenizer_cls, model_cls, _find_spec
+):
+    config_cls.from_pretrained.return_value = MagicMock(
+        architectures=["Glm4MoeLiteForCausalLM"]
+    )
+    tokenizer_cls.from_pretrained.return_value = _tokenizer()
+    model_cls.from_pretrained.return_value = _model()
+
+    TransformersRunner().load(
+        "zai-org/GLM-4.7-Flash",
+        {"device": "cpu", "allow_server_backed": True},
+    )
+
+    model_cls.from_pretrained.assert_called_once()
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_multimodal_architecture_is_not_misrouted(config_cls, _tokenizer, _find_spec):
+    config_cls.from_pretrained.return_value = MagicMock(
+        architectures=["Mistral3ForConditionalGeneration"]
+    )
+    runner = TransformersRunner()
+    with pytest.raises(ValueError, match="multimodal"):
+        runner.load("some-org/multimodal-model", {"device": "cpu"})

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -111,6 +111,21 @@ def test_mapping_like_batch_encoding_and_system_role_fallback():
     assert {"input_ids", "attention_mask"}.issubset(kwargs)
 
 
+def test_multiple_stop_sequences_use_the_earliest_match():
+    runner = TransformersRunner()
+    runner.model_id = "test/model"
+    runner.model = _model()
+    runner.tokenizer = _tokenizer()
+    runner.tokenizer.decode.return_value = "first END trailing STOP ignored"
+    runner.config = MagicMock(max_position_embeddings=64)
+
+    result = runner.complete(
+        "", "hello", GenerationConfig(max_tokens=8, temperature=0.0, stop=["STOP", "END"])
+    )
+
+    assert result[1]["content"] == "first"
+
+
 @patch("agents.architectures.transformers_runner.importlib.util.find_spec")
 @patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
 @patch("agents.architectures.transformers_runner.AutoTokenizer")

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -151,6 +151,25 @@ def test_cuda_uses_accelerate_without_duplicate_device_copy(
     model.to.assert_not_called()
 
 
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_mps_defaults_to_stable_eager_attention(
+    config_cls, tokenizer_cls, model_cls, _find_spec
+):
+    config_cls.from_pretrained.return_value = MagicMock(architectures=["SmolLMForCausalLM"])
+    tokenizer_cls.from_pretrained.return_value = _tokenizer()
+    model_cls.from_pretrained.return_value = _model()
+
+    TransformersRunner().load(
+        "HuggingFaceTB/SmolLM2-135M-Instruct",
+        {"device": "mps"},
+    )
+
+    assert model_cls.from_pretrained.call_args.kwargs["attn_implementation"] == "eager"
+
+
 @patch("agents.architectures.transformers_runner.metadata.version", return_value="4.48.0")
 def test_minimum_transformers_version_fails_early(_version):
     runner = TransformersRunner()

--- a/tests/scripts/test_download_models.py
+++ b/tests/scripts/test_download_models.py
@@ -1,4 +1,7 @@
 """Tests for model-specific weight download locations."""
+import os
+
+from scripts.copy_weights import model_dir_name as copy_model_dir_name
 from scripts.download_models import DEFAULT_MODEL_ID, default_weights_dir
 
 
@@ -8,3 +11,11 @@ def test_default_llama_download_preserves_legacy_mlx_directory():
 
 def test_other_models_use_isolated_directories():
     assert default_weights_dir("Qwen/Qwen3-4B") == "app/model_weights/Qwen_Qwen3-4B"
+
+
+def test_model_directories_cannot_escape_on_windows_or_posix():
+    hostile_model_id = r"..\..\private/model"
+    download_path = default_weights_dir(hostile_model_id)
+
+    assert os.path.dirname(download_path) == "app/model_weights"
+    assert copy_model_dir_name(hostile_model_id) == "_.._private_model"

--- a/tests/scripts/test_download_models.py
+++ b/tests/scripts/test_download_models.py
@@ -1,0 +1,10 @@
+"""Tests for model-specific weight download locations."""
+from scripts.download_models import DEFAULT_MODEL_ID, default_weights_dir
+
+
+def test_default_llama_download_preserves_legacy_mlx_directory():
+    assert default_weights_dir(DEFAULT_MODEL_ID) == "app/model_weights/llama_3_1"
+
+
+def test_other_models_use_isolated_directories():
+    assert default_weights_dir("Qwen/Qwen3-4B") == "app/model_weights/Qwen_Qwen3-4B"

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,24 @@ supported-markers = [
 ]
 
 [[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "safetensors", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "torch", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -345,6 +363,7 @@ name = "geist"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "accelerate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "aiohttp-retry", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "alembic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -401,6 +420,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", specifier = "==1.14.0" },
     { name = "aiohttp", specifier = "==3.11.12" },
     { name = "aiohttp-retry", specifier = "==2.9.1" },
     { name = "alembic", specifier = "==1.15.2" },
@@ -408,7 +428,7 @@ requires-dist = [
     { name = "einops", specifier = "==0.8.1" },
     { name = "fastapi", specifier = "==0.115.8" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "huggingface-hub", specifier = "==0.28.1" },
+    { name = "huggingface-hub", specifier = "==0.36.0" },
     { name = "mlx", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = "==0.31.2" },
     { name = "mlx", extras = ["cpu"], marker = "sys_platform == 'linux'", specifier = "==0.31.2" },
     { name = "numpy", specifier = "==2.2.3" },
@@ -426,12 +446,12 @@ requires-dist = [
     { name = "sphn", marker = "extra == 'voice'", specifier = "==0.1.12" },
     { name = "sqlalchemy", specifier = "==2.0.38" },
     { name = "tiktoken", specifier = "==0.9.0" },
-    { name = "tokenizers", specifier = "==0.21.0" },
+    { name = "tokenizers", specifier = "==0.22.1" },
     { name = "torch", specifier = "==2.6.0" },
     { name = "torchao", specifier = "==0.10.0" },
     { name = "torchaudio", specifier = "==2.6.0" },
     { name = "torchtune", specifier = "==0.6.0" },
-    { name = "transformers", specifier = "==4.48.3" },
+    { name = "transformers", specifier = "==4.57.6" },
     { name = "twilio", specifier = "==9.4.5" },
     { name = "uvicorn", specifier = "==0.34.0" },
     { name = "websockets", specifier = "==15.0.1" },
@@ -495,6 +515,20 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -524,20 +558,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.28.1"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "fsspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "hf-xet", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'amd64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ce/a734204aaae6c35a22f9956ebcd8d8708ae5b842e15d6f42bd6f49e634a4/huggingface_hub-0.28.1.tar.gz", hash = "sha256:893471090c98e3b6efbdfdacafe4052b20b84d59866fb6f54c33d9af18c303ae", size = 387074, upload-time = "2025-01-30T13:45:41.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/da/6c2bea5327b640920267d3bf2c9fc114cfbd0a5de234d81cda80cc9e33c8/huggingface_hub-0.28.1-py3-none-any.whl", hash = "sha256:aa6b9a3ffdae939b72c464dbb0d7f99f56e649b55c3d52406f49e0a5a620c0a7", size = 464068, upload-time = "2025-01-30T13:45:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
 ]
 
 [package.optional-dependencies]
@@ -1456,25 +1491,25 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.0"
+version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/41/c2be10975ca37f6ec40d7abd7e98a5213bb04f284b869c1a24e6504fd94d/tokenizers-0.21.0.tar.gz", hash = "sha256:ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4", size = 343021, upload-time = "2024-11-27T13:11:23.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/46/fb6854cec3278fbfa4a75b50232c77622bc517ac886156e6afbfa4d8fc6e/tokenizers-0.22.1.tar.gz", hash = "sha256:61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9", size = 363123, upload-time = "2025-09-19T09:49:23.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/5c/8b09607b37e996dc47e70d6a7b6f4bdd4e4d5ab22fe49d7374565c7fefaf/tokenizers-0.21.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3c4c93eae637e7d2aaae3d376f06085164e1660f89304c0ab2b1d08a406636b2", size = 2647461, upload-time = "2024-11-27T13:11:07.911Z" },
-    { url = "https://files.pythonhosted.org/packages/22/7a/88e58bb297c22633ed1c9d16029316e5b5ac5ee44012164c2edede599a5e/tokenizers-0.21.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:f53ea537c925422a2e0e92a24cce96f6bc5046bbef24a1652a5edc8ba975f62e", size = 2563639, upload-time = "2024-11-27T13:11:05.908Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/14/83429177c19364df27d22bc096d4c2e431e0ba43e56c525434f1f9b0fd00/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b177fb54c4702ef611de0c069d9169f0004233890e0c4c5bd5508ae05abf193", size = 2903304, upload-time = "2024-11-27T13:10:51.315Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/db/3433eab42347e0dc5452d8fcc8da03f638c9accffefe5a7c78146666964a/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6b43779a269f4629bebb114e19c3fca0223296ae9fea8bb9a7a6c6fb0657ff8e", size = 2804378, upload-time = "2024-11-27T13:10:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/57/8b/7da5e6f89736c2ade02816b4733983fca1c226b0c42980b1ae9dc8fcf5cc/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9aeb255802be90acfd363626753fda0064a8df06031012fe7d52fd9a905eb00e", size = 3095488, upload-time = "2024-11-27T13:11:00.662Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f6/5ed6711093dc2c04a4e03f6461798b12669bc5a17c8be7cce1240e0b5ce8/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8b09dbeb7a8d73ee204a70f94fc06ea0f17dcf0844f16102b9f414f0b7463ba", size = 3121410, upload-time = "2024-11-27T13:10:55.674Z" },
-    { url = "https://files.pythonhosted.org/packages/81/42/07600892d48950c5e80505b81411044a2d969368cdc0d929b1c847bf6697/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:400832c0904f77ce87c40f1a8a27493071282f785724ae62144324f171377273", size = 3388821, upload-time = "2024-11-27T13:10:58.401Z" },
-    { url = "https://files.pythonhosted.org/packages/22/06/69d7ce374747edaf1695a4f61b83570d91cc8bbfc51ccfecf76f56ab4aac/tokenizers-0.21.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e84ca973b3a96894d1707e189c14a774b701596d579ffc7e69debfc036a61a04", size = 3008868, upload-time = "2024-11-27T13:11:03.734Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/69/54a0aee4d576045b49a0eb8bffdc495634309c823bf886042e6f46b80058/tokenizers-0.21.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eb7202d231b273c34ec67767378cd04c767e967fda12d4a9e36208a34e2f137e", size = 8975831, upload-time = "2024-11-27T13:11:10.32Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/f3/b776061e4f3ebf2905ba1a25d90380aafd10c02d406437a8ba22d1724d76/tokenizers-0.21.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:089d56db6782a73a27fd8abf3ba21779f5b85d4a9f35e3b493c7bbcbbf0d539b", size = 8920746, upload-time = "2024-11-27T13:11:13.238Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ee/ce83d5ec8b6844ad4c3ecfe3333d58ecc1adc61f0878b323a15355bcab24/tokenizers-0.21.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:c87ca3dc48b9b1222d984b6b7490355a6fdb411a2d810f6f05977258400ddb74", size = 9161814, upload-time = "2024-11-27T13:11:16.675Z" },
-    { url = "https://files.pythonhosted.org/packages/18/07/3e88e65c0ed28fa93aa0c4d264988428eef3df2764c3126dc83e243cb36f/tokenizers-0.21.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4145505a973116f91bc3ac45988a92e618a6f83eb458f49ea0790df94ee243ff", size = 9357138, upload-time = "2024-11-27T13:11:20.09Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/33/f4b2d94ada7ab297328fc671fed209368ddb82f965ec2224eb1892674c3a/tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73", size = 3069318, upload-time = "2025-09-19T09:49:11.848Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/58/2aa8c874d02b974990e89ff95826a4852a8b2a273c7d1b4411cdd45a4565/tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc", size = 2926478, upload-time = "2025-09-19T09:49:09.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3b/55e64befa1e7bfea963cf4b787b2cea1011362c4193f5477047532ce127e/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d2962dd28bc67c1f205ab180578a78eef89ac60ca7ef7cbe9635a46a56422a", size = 3256994, upload-time = "2025-09-19T09:48:56.701Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0b/fbfecf42f67d9b7b80fde4aabb2b3110a97fac6585c9470b5bff103a80cb/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38201f15cdb1f8a6843e6563e6e79f4abd053394992b9bbdf5213ea3469b4ae7", size = 3153141, upload-time = "2025-09-19T09:48:59.749Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a9/b38f4e74e0817af8f8ef925507c63c6ae8171e3c4cb2d5d4624bf58fca69/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1cbe5454c9a15df1b3443c726063d930c16f047a3cc724b9e6e1a91140e5a21", size = 3508049, upload-time = "2025-09-19T09:49:05.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/48/dd2b3dac46bb9134a88e35d72e1aa4869579eacc1a27238f1577270773ff/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7d094ae6312d69cc2a872b54b91b309f4f6fbce871ef28eb27b52a98e4d0214", size = 3710730, upload-time = "2025-09-19T09:49:01.832Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0e/ccabc8d16ae4ba84a55d41345207c1e2ea88784651a5a487547d80851398/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afd7594a56656ace95cdd6df4cca2e4059d294c5cfb1679c57824b605556cb2f", size = 3412560, upload-time = "2025-09-19T09:49:03.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/dc3a0db5a6766416c32c034286d7c2d406da1f498e4de04ab1b8959edd00/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ef6063d7a84994129732b47e7915e8710f27f99f3a3260b8a38fc7ccd083f4", size = 3250221, upload-time = "2025-09-19T09:49:07.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a6/2c8486eef79671601ff57b093889a345dd3d576713ef047776015dc66de7/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ba0a64f450b9ef412c98f6bcd2a50c6df6e2443b560024a09fa6a03189726879", size = 9345569, upload-time = "2025-09-19T09:49:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/32ce667f14c35537f5f605fe9bea3e415ea1b0a646389d2295ec348d5657/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:331d6d149fa9c7d632cde4490fb8bbb12337fa3a0232e77892be656464f4b446", size = 9271599, upload-time = "2025-09-19T09:49:16.639Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7c/a5f7898a3f6baa3fc2685c705e04c98c1094c523051c805cdd9306b8f87e/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:607989f2ea68a46cb1dfbaf3e3aabdf3f21d8748312dbeb6263d1b3b66c5010a", size = 9533862, upload-time = "2025-09-19T09:49:19.146Z" },
+    { url = "https://files.pythonhosted.org/packages/36/65/7e75caea90bc73c1dd8d40438adf1a7bc26af3b8d0a6705ea190462506e1/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a0f307d490295717726598ef6fa4f24af9d484809223bbc253b201c740a06390", size = 9681250, upload-time = "2025-09-19T09:49:21.501Z" },
 ]
 
 [[package]]
@@ -1579,7 +1614,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.48.3"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1593,9 +1628,9 @@ dependencies = [
     { name = "tokenizers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/82/cebeb7af5e64440f1638f18c4ed0f89156d0eeaa6290d98da8ca93ac3872/transformers-4.48.3.tar.gz", hash = "sha256:a5e8f1e9a6430aa78215836be70cecd3f872d99eeda300f41ad6cc841724afdb", size = 8373458, upload-time = "2025-02-07T10:10:47.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/1a/efeecb8d83705f2f4beac98d46f2148c95ecd7babfb31b5c0f1e7017e83d/transformers-4.48.3-py3-none-any.whl", hash = "sha256:78697f990f5ef350c23b46bf86d5081ce96b49479ab180b2de7687267de8fd36", size = 9669412, upload-time = "2025-02-07T10:10:43.395Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a central capability-driven catalog for local, hosted, and self-hosted open-weight models
- add a generic lazy-loaded Transformers runner for Mistral, Phi, SmolLM, Gemma, Granite, OLMo, GLM, gpt-oss, DeepSeek distillations, and future standard causal LMs
- add hosted/self-hosted OpenAI-compatible routing for Kimi K2.5, GLM 4.7/5.2, DeepSeek R1, and heavyweight Llama/Qwen/Mixtral/gpt-oss checkpoints
- expose model capability and performance metadata through the API and agent configuration UI
- generalize model download/copy tooling and document the extension and local-inference paths

## Why

Geist's Llama- and Qwen-specific routing made every additional open-weight family a code change. This moves identity, provider, backend, hardware guidance, and safety metadata into one catalog so most new models and OpenAI-compatible providers can be added declaratively.

The catalog deliberately routes very large models to hosted or self-hosted endpoints. Local inference uses lazy imports, inference mode, KV caching, device-aware dtype selection, Accelerate dispatch, generated-suffix-only decoding, optional quantization, and context-window clamping to keep laptop execution practical.

## Validation

- [x] focused Ruff validation for changed Python files
- [x] 87 focused backend tests for the catalog, runners, factory, generation settings, and download tooling
- [x] 14 `AgentConfigSection` tests
- [x] production React build
- [x] `git diff --check`
- [ ] Docker rebuild, backend startup/log inspection, and localhost curl smoke test (pending runtime approval)

## Notes

- React build completed with pre-existing warnings in `useCompleteText.tsx` and `useVoiceChat.tsx`.
- The locked frontend dependency tree currently reports existing npm audit findings; this PR does not change frontend dependencies.
