### PR TITLE
Add Geist chat loading animation

### DIFF
--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -919,6 +919,56 @@ textarea:focus-visible {
   text-align: center;
 }
 
+@keyframes chat-dot-bounce {
+  0%, 60%, 100% {
+    opacity: 0.42;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-4px);
+  }
+}
+
+.chat-loading-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: start;
+  width: fit-content;
+  min-width: 52px;
+  min-height: 38px;
+  padding: 10px 14px;
+  gap: 5px;
+  background: var(--geist-color-surface-strong);
+  border: 1px solid color-mix(in srgb, var(--geist-color-accent) 34%, var(--geist-color-border));
+  border-radius: var(--geist-radius-lg);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+}
+
+.chat-loading-dot {
+  width: 7px;
+  height: 7px;
+  background: var(--geist-color-accent-strong);
+  border-radius: 50%;
+  animation: chat-dot-bounce 1.2s var(--geist-ease-standard) infinite;
+}
+
+.chat-loading-dot:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.chat-loading-dot:nth-child(3) {
+  animation-delay: 300ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-loading-dot {
+    opacity: 1;
+    animation: none;
+  }
+}
+
 .chat-turn {
   display: grid;
   gap: 8px;

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -119,7 +119,7 @@ const Chat = () => {
     } else if (page === 1 && chatContainerRef.current && !shouldRestoreScrollRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
-  }, [chatHistory, page]);
+  }, [chatHistory, page, isLoading]);
 
   useEffect(() => {
     const container = chatContainerRef.current;
@@ -295,7 +295,11 @@ const Chat = () => {
       <section className="ChatContent">
         <div className="chat-stage">
           <div className="chat-transcript-layer" aria-hidden={chatDrawerState === 'expanded'}>
-            <ChatTextArea chatHistory={chatHistory?.chatHistory ?? []} ref={chatContainerRef} />
+            <ChatTextArea
+              chatHistory={chatHistory?.chatHistory ?? []}
+              isLoading={isLoading}
+              ref={chatContainerRef}
+            />
           </div>
 
           <aside

--- a/client/geist/src/Components/ChatTextArea.tsx
+++ b/client/geist/src/Components/ChatTextArea.tsx
@@ -9,8 +9,12 @@ export interface ChatHistory {
   chatHistory: ChatPair[];
 }
 
-const ChatTextArea = forwardRef<HTMLDivElement, ChatHistory>((props, ref) => {
-  const isEmpty = props.chatHistory.length === 0;
+interface ChatTextAreaProps extends ChatHistory {
+  isLoading?: boolean;
+}
+
+const ChatTextArea = forwardRef<HTMLDivElement, ChatTextAreaProps>((props, ref) => {
+  const isEmpty = props.chatHistory.length === 0 && !props.isLoading;
 
   return (
     <div ref={ref} className={`chat-history${isEmpty ? ' chat-history-empty' : ''}`}>
@@ -29,6 +33,17 @@ const ChatTextArea = forwardRef<HTMLDivElement, ChatHistory>((props, ref) => {
           </div>
         </div>
       ))}
+      {props.isLoading && (
+        <div
+          className="chat-loading-indicator"
+          role="status"
+          aria-label="Geist is responding"
+        >
+          <span className="chat-loading-dot" aria-hidden="true" />
+          <span className="chat-loading-dot" aria-hidden="true" />
+          <span className="chat-loading-dot" aria-hidden="true" />
+        </div>
+      )}
     </div>
   );
 });

--- a/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import ChatTextArea from '../ChatTextArea';
+
+describe('ChatTextArea', () => {
+  it('shows the Geist loading indicator while chat is loading', () => {
+    render(<ChatTextArea chatHistory={[]} isLoading />);
+
+    expect(screen.getByRole('status', { name: 'Geist is responding' })).toBeInTheDocument();
+    expect(screen.queryByText('Start a conversation with Geist.')).not.toBeInTheDocument();
+  });
+
+  it('hides the Geist loading indicator when chat is idle', () => {
+    render(<ChatTextArea chatHistory={[]} isLoading={false} />);
+
+    expect(screen.queryByRole('status', { name: 'Geist is responding' })).not.toBeInTheDocument();
+  });
+});

--- a/plans/152-CHAT-LOADING-ANIMATION.md
+++ b/plans/152-CHAT-LOADING-ANIMATION.md
@@ -1,0 +1,18 @@
+# Chat Loading Animation
+
+## Goal
+
+Show a Geist-themed animated ellipsis at the end of the chat history while the assistant response request is in progress.
+
+## Implementation
+
+1. Pass the existing chat request loading state into `ChatTextArea`.
+2. Render an accessible three-dot status indicator after the current messages.
+3. Style the indicator with the app's surface and accent tokens, staggered dot motion, and a reduced-motion fallback.
+4. Add focused component coverage for the loading and idle states.
+
+## Verification
+
+1. Run the focused frontend test.
+2. Run the production frontend build.
+3. Start the application with Docker, inspect container logs, and verify the UI at `localhost:3000` when the local environment supports it.


### PR DESCRIPTION
## Summary

- show a three-dot Geist loading indicator while the assistant response request is active
- style the indicator with the current surface, accent, radius, and motion tokens
- keep the indicator visible at the end of the transcript and respect reduced-motion preferences
- add focused loading and idle state coverage

## Why

Chat currently disables the composer while waiting for an assistant response but gives no visual feedback in the transcript. The animated ellipsis makes the pending response state clear without adding a dependency.

## User impact

Users see a compact themed response indicator immediately after submitting a chat message. Screen readers receive a `Geist is responding` status, and reduced-motion users see static dots.

## Validation

- `CI=true npm test -- --watchAll=false --runTestsByPath src/Components/__tests__/ChatTextArea.test.tsx`
- `npm run build` (passes with existing warnings in `useCompleteText.tsx` and `useVoiceChat.tsx`)