### PR TITLE
Fix chat recovery and unify agent conversation state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,54 @@ jobs:
         cd client/geist
         npm test -- --watchAll=false --passWithNoTests
 
+  browser-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        version: "0.9.5"
+        enable-cache: true
+
+    - name: Install backend dependencies
+      run: uv sync --frozen
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: client/geist/package-lock.json
+
+    - name: Install frontend dependencies
+      run: |
+        cd client/geist
+        npm ci --ignore-scripts --audit=false --fund=false
+
+    - name: Run browser end-to-end tests
+      run: |
+        cd client/geist
+        npm run test:e2e
+
+    - name: Upload browser test artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: |
+          client/geist/playwright-report
+          client/geist/test-results
+        if-no-files-found: ignore
+
   security:
     runs-on: ubuntu-latest
 
@@ -218,7 +266,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [test, frontend-test]
+    needs: [test, frontend-test, browser-e2e]
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,7 @@ safety-report.json
 npm-audit-report.json
 trivy-results.sarif
 requirements-check.txt
+
+# Playwright browser-test artifacts
+client/geist/playwright-report/
+client/geist/test-results/

--- a/agents/architectures/base_runner.py
+++ b/agents/architectures/base_runner.py
@@ -1,6 +1,7 @@
 """
 Base runner abstract class for all inference backends.
 """
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
@@ -9,12 +10,14 @@ from typing import Any
 @dataclass
 class GenerationConfig:
     """Configuration for text generation."""
+
     max_tokens: int = 16
     temperature: float = 1.0
     top_p: float = 1.0
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
     stop: str | list[str] | None = None
+
 
 class BaseRunner(ABC):
     """Abstract base class for all inference runners."""
@@ -31,7 +34,9 @@ class BaseRunner(ABC):
         pass
 
     @abstractmethod
-    def generate(self, prompt: str, generation_config: GenerationConfig) -> dict[str, Any] | list[dict[str, str]]:
+    def generate(
+        self, prompt: str, generation_config: GenerationConfig
+    ) -> dict[str, Any] | list[dict[str, str]]:
         """
         Generate text based on the given prompt.
 
@@ -45,7 +50,9 @@ class BaseRunner(ABC):
         pass
 
     @abstractmethod
-    def complete(self, system_prompt: str, user_prompt: str, generation_config: GenerationConfig) -> list[dict[str, str]]:
+    def complete(
+        self, system_prompt: str, user_prompt: str, generation_config: GenerationConfig
+    ) -> list[dict[str, str]]:
         """
         Complete a conversation with system and user prompts.
 
@@ -58,6 +65,30 @@ class BaseRunner(ABC):
             Dictionary containing completion and metadata
         """
         pass
+
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+        generation_config: GenerationConfig,
+    ) -> list[dict[str, str]]:
+        """Complete structured chat messages with a text-only compatibility fallback."""
+        system_prompt = "\n\n".join(
+            message.get("content") or "" for message in messages if message.get("role") == "system"
+        )
+        conversation = []
+        for message in messages:
+            role = message.get("role")
+            if role == "system":
+                continue
+            label = "Assistant" if role == "assistant" else "User"
+            if role == "tool":
+                label = "Tool"
+            conversation.append(f"{label}: {message.get('content') or ''}")
+        return self.complete(
+            system_prompt=system_prompt,
+            user_prompt="\n".join(conversation),
+            generation_config=generation_config,
+        )
 
     def cleanup(self) -> None:  # noqa: B027 - optional hook, runners override as needed
         """

--- a/agents/architectures/llama/llama_mlx.py
+++ b/agents/architectures/llama/llama_mlx.py
@@ -53,11 +53,11 @@ class KVCache:
                 self.values = mx.concatenate([self.values, new_values], axis=2)
 
         self.offset = required
-        self.keys[..., previous:self.offset, :] = keys
-        self.values[..., previous:self.offset, :] = values
+        self.keys[..., previous : self.offset, :] = keys
+        self.values[..., previous : self.offset, :] = values
         return (
-            self.keys[..., :self.offset, :],
-            self.values[..., :self.offset, :],
+            self.keys[..., : self.offset, :],
+            self.values[..., : self.offset, :],
         )
 
 
@@ -73,9 +73,7 @@ def sample_logits(logits: mx.array, temperature: float, top_p: float) -> mx.arra
     if top_p < 1:
         probabilities = mx.softmax(logits, axis=-1)
         sorted_indices = mx.argsort(probabilities, axis=-1)
-        sorted_probabilities = mx.take_along_axis(
-            probabilities, sorted_indices, axis=-1
-        )
+        sorted_probabilities = mx.take_along_axis(probabilities, sorted_indices, axis=-1)
         cumulative_probabilities = mx.cumsum(sorted_probabilities, axis=-1)
         kept_probabilities = mx.where(
             cumulative_probabilities > 1 - top_p,
@@ -83,9 +81,7 @@ def sample_logits(logits: mx.array, temperature: float, top_p: float) -> mx.arra
             0,
         )
         inverse_indices = mx.argsort(sorted_indices, axis=-1)
-        probabilities = mx.take_along_axis(
-            kept_probabilities, inverse_indices, axis=-1
-        )
+        probabilities = mx.take_along_axis(kept_probabilities, inverse_indices, axis=-1)
         logits = mx.log(probabilities)
 
     return mx.random.categorical(logits / temperature)
@@ -96,12 +92,13 @@ class ModelConfig:
     """
     ModelConfig.
     """
+
     # Matches the naming of the first script for correctness, with some defaults:
-    dim: int = 4096          # was "n_embd" in second script
-    n_layers: int = 32       # was "n_layer"
-    n_heads: int = 32        # was "n_head"
+    dim: int = 4096  # was "n_embd" in second script
+    n_layers: int = 32  # was "n_layer"
+    n_heads: int = 32  # was "n_head"
     # Additional fields from the first code:
-    head_dim: int = 128      # will often be dim // n_heads
+    head_dim: int = 128  # will often be dim // n_heads
     n_kv_heads: int = 32
     hidden_dim: int = 11008
     norm_eps: float = 1e-5
@@ -116,6 +113,7 @@ class Llama3RoPE(nn.Module):
     """
     Llama 3 style RoPE scaling with low/high frequency factors.
     """
+
     def __init__(self, dim: int, base: float, rope_scaling: dict, max_position_embeddings: int):
         super().__init__()
         self.dim = dim
@@ -125,7 +123,9 @@ class Llama3RoPE(nn.Module):
         factor = float(self.rope_scaling.get("factor", 1.0))
         low_freq_factor = float(self.rope_scaling.get("low_freq_factor", 1.0))
         high_freq_factor = float(self.rope_scaling.get("high_freq_factor", 1.0))
-        orig_max_pos = float(self.rope_scaling.get("original_max_position_embeddings", self.max_position_embeddings))
+        orig_max_pos = float(
+            self.rope_scaling.get("original_max_position_embeddings", self.max_position_embeddings)
+        )
 
         frequencies = self.base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim)
         wavelen = 2.0 * mx.pi * frequencies
@@ -138,9 +138,7 @@ class Llama3RoPE(nn.Module):
             frequencies,
         )
         medium = (wavelen > high_freq_wavelen) & (wavelen < low_freq_wavelen)
-        smooth = (orig_max_pos / wavelen - low_freq_factor) / (
-            high_freq_factor - low_freq_factor
-        )
+        smooth = (orig_max_pos / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
         smooth_frequencies = frequencies / ((1.0 - smooth) / factor + smooth)
         self._frequencies = mx.where(medium, smooth_frequencies, frequencies)
 
@@ -155,6 +153,7 @@ class Llama3RoPE(nn.Module):
             freqs=self._frequencies,
         )
 
+
 class Attention(nn.Module):
     def __init__(self, args: ModelConfig):
         super().__init__()
@@ -164,7 +163,7 @@ class Attention(nn.Module):
         self.n_kv_heads = args.n_kv_heads
 
         # Per the LLama approach, scale = head_dim^-0.5
-        self.scale = args.head_dim ** -0.5
+        self.scale = args.head_dim**-0.5
 
         self.wq = nn.Linear(args.dim, args.n_heads * args.head_dim, bias=False)
         self.wk = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
@@ -180,7 +179,9 @@ class Attention(nn.Module):
                 max_position_embeddings=args.max_position_embeddings,
             )
         else:
-            self.rope = nn.RoPE(args.head_dim, traditional=args.rope_traditional, base=args.rope_theta)
+            self.rope = nn.RoPE(
+                args.head_dim, traditional=args.rope_traditional, base=args.rope_theta
+            )
 
     def __call__(
         self,
@@ -191,17 +192,17 @@ class Attention(nn.Module):
         batch, sequence_length, model_dim = x.shape
 
         queries = self.wq(x)
-        keys    = self.wk(x)
-        values  = self.wv(x)
+        keys = self.wk(x)
+        values = self.wv(x)
 
         # Reshape into (B, n_heads, L, head_dim) for queries,
         #            (B, n_kv_heads, L, head_dim) for keys/values
         queries = queries.reshape(
             batch, sequence_length, self.n_heads, self.args.head_dim
         ).transpose(0, 2, 1, 3)
-        keys = keys.reshape(
-            batch, sequence_length, self.n_kv_heads, self.args.head_dim
-        ).transpose(0, 2, 1, 3)
+        keys = keys.reshape(batch, sequence_length, self.n_kv_heads, self.args.head_dim).transpose(
+            0, 2, 1, 3
+        )
         values = values.reshape(
             batch, sequence_length, self.n_kv_heads, self.args.head_dim
         ).transpose(0, 2, 1, 3)
@@ -210,11 +211,11 @@ class Attention(nn.Module):
         if cache is not None:
             offset = cache.offset
             queries = self.rope(queries, offset=offset)
-            keys    = self.rope(keys,    offset=offset)
+            keys = self.rope(keys, offset=offset)
             keys, values = cache.update_and_fetch(keys, values)
         else:
             queries = self.rope(queries)
-            keys    = self.rope(keys)
+            keys = self.rope(keys)
 
         output = mx.fast.scaled_dot_product_attention(
             queries,
@@ -223,9 +224,7 @@ class Attention(nn.Module):
             scale=self.scale,
             mask=mask,
         )
-        output = output.transpose(0, 2, 1, 3).reshape(
-            batch, sequence_length, model_dim
-        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, sequence_length, model_dim)
         return self.wo(output), cache
 
 
@@ -268,6 +267,7 @@ class Llama(nn.Module):
     """
     Core LLaMA model definition from the first code sample.
     """
+
     def __init__(self, args: ModelConfig):
         super().__init__()
         self.args = args
@@ -338,9 +338,7 @@ class Llama(nn.Module):
             if eos_ids is not None and token_id in eos_ids:
                 break
             if time.time() - start_time > max_generation_time:
-                logger.warning(
-                    "Generation timed out after %s seconds", max_generation_time
-                )
+                logger.warning("Generation timed out after %s seconds", max_generation_time)
                 break
             if tokens_generated == max_new_tokens:
                 break
@@ -491,6 +489,25 @@ class LlamaMLX:
             "<|start_header_id|>assistant<|end_header_id|>\n\n"
         )
 
+    def _build_messages_prompt(self, messages: list[dict[str, str | None]]) -> str:
+        normalized = [
+            {"role": message["role"], "content": message.get("content") or ""}
+            for message in messages
+        ]
+        if hasattr(self.tokenizer, "apply_chat_template"):
+            return self.tokenizer.apply_chat_template(
+                normalized,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        prompt = "<|begin_of_text|>"
+        for message in normalized:
+            prompt += (
+                f"<|start_header_id|>{message['role']}<|end_header_id|>\n\n"
+                f"{message['content']}<|eot_id|>"
+            )
+        return f"{prompt}<|start_header_id|>assistant<|end_header_id|>\n\n"
+
     def download_model(self):
         """
         Download model files from huggingface_hub if they are not present locally.
@@ -501,9 +518,7 @@ class LlamaMLX:
         weights = glob.glob(os.path.join(self.weights_dir, "model*.safetensors"))
 
         # If any key file doesn't exist, pull them
-        if not (os.path.exists(config_path) and
-                weights and
-                os.path.exists(tokenizer_path)):
+        if not (os.path.exists(config_path) and weights and os.path.exists(tokenizer_path)):
             logger.info("Downloading model files from HuggingFace...")
             token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
             if not token:
@@ -634,7 +649,7 @@ class LlamaMLX:
             temp=self.temperature,
             top_p=self.top_p,
             max_new_tokens=self.max_new_tokens,
-            eos_token_id=self.eos_token_ids or self.tokenizer.eos_token_id
+            eos_token_id=self.eos_token_ids or self.tokenizer.eos_token_id,
         )
 
         for new_tok in token_iter:
@@ -651,7 +666,9 @@ class LlamaMLX:
                     len(generated_tokens) - len(prompt_ids),
                 )
 
-        logger.info(f"Generated tokens: {len(generated_tokens) - len(prompt_ids)} new, {len(generated_tokens)} total")
+        logger.info(
+            f"Generated tokens: {len(generated_tokens) - len(prompt_ids)} new, {len(generated_tokens)} total"
+        )
         return mx.array(generated_tokens)
 
     def complete(self, system_prompt: str, user_prompt: str) -> list[dict[str, str]]:
@@ -666,21 +683,27 @@ class LlamaMLX:
         Returns:
             str: The generated completion text
         """
-        logger.info("Beginning completion call...")
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        return self.complete_messages(messages)
 
-        # Format the prompt according to the tokenizer's chat template when available.
-        if hasattr(self.tokenizer, "apply_chat_template"):
-            messages = []
-            if system_prompt:
-                messages.append({"role": "system", "content": system_prompt})
-            messages.append({"role": "user", "content": user_prompt})
-            prompt = self.tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-            )
-        else:
-            prompt = self._build_instruct_prompt(system_prompt, user_prompt)
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+    ) -> list[dict[str, str]]:
+        """Complete a structured conversation using native chat-template roles."""
+        logger.info("Beginning completion call...")
+        prompt = self._build_messages_prompt(messages)
+        user_prompt = next(
+            (
+                message.get("content") or ""
+                for message in reversed(messages)
+                if message.get("role") == "user"
+            ),
+            "",
+        )
 
         logger.info(
             f"Starting text generation with temperature={self.temperature}, "
@@ -691,7 +714,7 @@ class LlamaMLX:
             # Generate
             output_tokens = self.generate_text(prompt)
             # Decode only newly generated IDs so prompt text cannot leak into the response.
-            output_list = output_tokens.tolist()[self._last_prompt_token_count:]
+            output_list = output_tokens.tolist()[self._last_prompt_token_count :]
             output_text = self.tokenizer.decode(
                 output_list,
                 skip_special_tokens=True,

--- a/agents/architectures/llama/mlx_lm_backend.py
+++ b/agents/architectures/llama/mlx_lm_backend.py
@@ -37,18 +37,36 @@ class MLXLMBackend:
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": user_prompt})
+        return self._build_messages_prompt(messages)
+
+    def _build_messages_prompt(self, messages: list[dict[str, str | None]]) -> str:
+        normalized = [
+            {"role": message["role"], "content": message.get("content") or ""}
+            for message in messages
+        ]
         return self.tokenizer.apply_chat_template(
-            messages,
+            normalized,
             tokenize=False,
             add_generation_prompt=True,
         )
 
     def stream_text(self, system_prompt: str, user_prompt: str) -> Iterator[str]:
         """Yield decoded text segments and retain mlx-lm timing statistics."""
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        yield from self.stream_messages(messages)
+
+    def stream_messages(
+        self,
+        messages: list[dict[str, str | None]],
+    ) -> Iterator[str]:
+        """Yield decoded text for a structured conversation."""
         from mlx_lm import stream_generate
         from mlx_lm.sample_utils import make_sampler
 
-        prompt = self._build_prompt(system_prompt, user_prompt)
+        prompt = self._build_messages_prompt(messages)
         sampler = make_sampler(temp=self.temperature, top_p=self.top_p)
         started = time.perf_counter()
         final_response = None
@@ -75,5 +93,23 @@ class MLXLMBackend:
             }
 
     def complete(self, system_prompt: str, user_prompt: str) -> list[dict[str, str]]:
-        response = "".join(self.stream_text(system_prompt, user_prompt)).strip()
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        return self.complete_messages(messages)
+
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+    ) -> list[dict[str, str]]:
+        response = "".join(self.stream_messages(messages)).strip()
+        user_prompt = next(
+            (
+                message.get("content") or ""
+                for message in reversed(messages)
+                if message.get("role") == "user"
+            ),
+            "",
+        )
         return strings_to_message_dict(user_prompt, response)

--- a/agents/architectures/mlx_llama_runner.py
+++ b/agents/architectures/mlx_llama_runner.py
@@ -19,6 +19,11 @@ class _MLXBackend(Protocol):
 
     def complete(self, system_prompt: str, user_prompt: str) -> list[dict[str, str]]: ...
 
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+    ) -> list[dict[str, str]]: ...
+
 
 class MLXLlamaRunner(BaseRunner):
     """Run Llama through Geist's manual MLX code or the mlx-lm adapter."""
@@ -118,6 +123,14 @@ class MLXLlamaRunner(BaseRunner):
             system_prompt=system_prompt or "You are a helpful assistant.",
             user_prompt=user_prompt,
         )
+
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+        generation_config: GenerationConfig,
+    ) -> list[dict[str, str]]:
+        backend = self._apply_generation_config(generation_config)
+        return backend.complete_messages(messages)
 
     def cleanup(self) -> None:
         self.llama = None

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -70,8 +70,16 @@ class TransformersRunner(BaseRunner):
                 )
 
         weights_dir = device_config.pop("weights_dir", None)
-        default_dir = os.path.join("app", "model_weights", model_id.replace("/", "_"))
-        self.source = weights_dir or (default_dir if os.path.isdir(default_dir) else model_id)
+        default_dirs = [
+            os.path.join("app", "model_weights", model_id.replace("/", "_"))
+        ]
+        if model_id == "meta-llama/Meta-Llama-3.1-8B-Instruct":
+            default_dirs.append(os.path.join("app", "model_weights", "llama_3_1"))
+        local_default = next(
+            (path for path in default_dirs if os.path.isfile(os.path.join(path, "config.json"))),
+            None,
+        )
+        self.source = weights_dir or local_default or model_id
         explicit_device = device_config.pop("device", None)
         self.device = self._select_device(explicit_device)
         compile_model = bool(device_config.pop("compile", False))

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -1,4 +1,5 @@
 """Generic, performance-aware Hugging Face causal language-model runner."""
+
 from __future__ import annotations
 
 import gc
@@ -70,9 +71,7 @@ class TransformersRunner(BaseRunner):
                 )
 
         weights_dir = device_config.pop("weights_dir", None)
-        default_dirs = [
-            os.path.join("app", "model_weights", model_id.replace("/", "_"))
-        ]
+        default_dirs = [os.path.join("app", "model_weights", model_id.replace("/", "_"))]
         if model_id == "meta-llama/Meta-Llama-3.1-8B-Instruct":
             default_dirs.append(os.path.join("app", "model_weights", "llama_3_1"))
         local_default = next(
@@ -122,18 +121,27 @@ class TransformersRunner(BaseRunner):
                 load_kwargs["device_map"] = "auto"
 
         for option in (
-            "attn_implementation", "quantization_config", "load_in_4bit",
-            "load_in_8bit", "max_memory", "offload_folder",
-            "offload_state_dict", "use_safetensors",
+            "attn_implementation",
+            "quantization_config",
+            "load_in_4bit",
+            "load_in_8bit",
+            "max_memory",
+            "offload_folder",
+            "offload_state_dict",
+            "use_safetensors",
         ):
             if option in device_config:
                 load_kwargs[option] = device_config.pop(option)
         if device_config:
-            logger.warning("Ignoring unsupported Transformers device options: %s", sorted(device_config))
+            logger.warning(
+                "Ignoring unsupported Transformers device options: %s", sorted(device_config)
+            )
 
         logger.info(
             "Loading %s with Transformers on %s (%s)",
-            model_id, self.device, load_kwargs["torch_dtype"],
+            model_id,
+            self.device,
+            load_kwargs["torch_dtype"],
         )
         self.model = AutoModelForCausalLM.from_pretrained(self.source, **load_kwargs)
         if not getattr(self.model, "hf_device_map", None):
@@ -178,9 +186,13 @@ class TransformersRunner(BaseRunner):
                 return explicit
             value = str(explicit).replace("torch.", "").lower()
             dtypes = {
-                "auto": "auto", "float32": torch.float32, "fp32": torch.float32,
-                "float16": torch.float16, "fp16": torch.float16,
-                "bfloat16": torch.bfloat16, "bf16": torch.bfloat16,
+                "auto": "auto",
+                "float32": torch.float32,
+                "fp32": torch.float32,
+                "float16": torch.float16,
+                "fp16": torch.float16,
+                "bfloat16": torch.bfloat16,
+                "bf16": torch.bfloat16,
             }
             if value not in dtypes:
                 raise ValueError(f"Unsupported dtype: {explicit}")
@@ -193,9 +205,7 @@ class TransformersRunner(BaseRunner):
             return torch.float16
         return torch.float32
 
-    def generate(
-        self, prompt: str, generation_config: GenerationConfig
-    ) -> list[dict[str, str]]:
+    def generate(self, prompt: str, generation_config: GenerationConfig) -> list[dict[str, str]]:
         return self.complete("", prompt, generation_config)
 
     def complete(
@@ -204,13 +214,27 @@ class TransformersRunner(BaseRunner):
         user_prompt: str,
         generation_config: GenerationConfig,
     ) -> list[dict[str, str]]:
-        if self.model is None or self.tokenizer is None:
-            raise RuntimeError("Model not loaded. Call load() first.")
-
-        messages = []
+        messages: list[dict[str, str | None]] = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": user_prompt})
+        return self.complete_messages(messages, generation_config)
+
+    def complete_messages(
+        self,
+        messages: list[dict[str, str | None]],
+        generation_config: GenerationConfig,
+    ) -> list[dict[str, str]]:
+        if self.model is None or self.tokenizer is None:
+            raise RuntimeError("Model not loaded. Call load() first.")
+
+        normalized_messages: list[dict[str, str]] = [
+            {
+                "role": str(message.get("role") or ""),
+                "content": message.get("content") or "",
+            }
+            for message in messages
+        ]
         if not getattr(self.tokenizer, "chat_template", None):
             raise ValueError(
                 f"{self.model_id} does not provide a tokenizer chat template. "
@@ -218,20 +242,35 @@ class TransformersRunner(BaseRunner):
             )
 
         try:
-            inputs = self._apply_chat_template(messages)
+            inputs = self._apply_chat_template(normalized_messages)
         except Exception:
+            system_prompt = "\n\n".join(
+                message["content"] for message in normalized_messages if message["role"] == "system"
+            )
             if not system_prompt:
                 raise
             # A few otherwise standard instruction checkpoints do not define a
-            # system role. Preserve the instruction without family-specific
-            # branching by placing it ahead of the user content.
+            # system role. Preserve the instruction and all conversation turns
+            # by folding it into the first user message.
             logger.info(
                 "%s chat template rejected a system role; folding it into the user turn",
                 self.model_id,
             )
-            inputs = self._apply_chat_template([
-                {"role": "user", "content": f"{system_prompt}\n\n{user_prompt}"}
-            ])
+            fallback_messages = [
+                dict(message) for message in normalized_messages if message["role"] != "system"
+            ]
+            first_user = next(
+                (message for message in fallback_messages if message["role"] == "user"),
+                None,
+            )
+            if first_user is None:
+                fallback_messages.insert(
+                    0,
+                    {"role": "user", "content": system_prompt},
+                )
+            else:
+                first_user["content"] = f"{system_prompt}\n\n{first_user['content']}"
+            inputs = self._apply_chat_template(fallback_messages)
         inputs = dict(inputs) if hasattr(inputs, "items") else {"input_ids": inputs}
         target_device = getattr(self.model, "device", self.device)
         inputs = {name: value.to(target_device) for name, value in inputs.items()}
@@ -248,7 +287,8 @@ class TransformersRunner(BaseRunner):
             if max_new_tokens > available_tokens:
                 logger.warning(
                     "Clamping max_new_tokens from %s to %s for model context limit",
-                    max_new_tokens, available_tokens,
+                    max_new_tokens,
+                    available_tokens,
                 )
                 max_new_tokens = available_tokens
 
@@ -282,6 +322,14 @@ class TransformersRunner(BaseRunner):
             ]
             if stop_positions:
                 response = response[: min(stop_positions)].rstrip()
+        user_prompt = next(
+            (
+                message["content"]
+                for message in reversed(normalized_messages)
+                if message["role"] == "user"
+            ),
+            "",
+        )
         return strings_to_message_dict(user_prompt, response)
 
     def _apply_chat_template(self, messages: list[dict[str, str]]) -> Any:

--- a/agents/factory.py
+++ b/agents/factory.py
@@ -2,6 +2,7 @@
 Agent factory for instantiating LocalAgent and OnlineAgent instances.
 """
 import logging
+import os
 from typing import Any
 
 from agents.agent_context import AgentContext
@@ -103,10 +104,11 @@ class AgentFactory:
             if not model:
                 model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
 
-            runner_was_explicit = runner_type is not None
+            configured_runner = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip()
+            runner_was_explicit = runner_type is not None or bool(configured_runner)
             # Auto-detect runner type from model ID when not explicitly set
             if not runner_type:
-                runner_type = AgentFactory._infer_runner_type(model)
+                runner_type = configured_runner or AgentFactory._infer_runner_type(model)
 
             # Automatic selection protects users from accidental 32B+ loads.
             # A deliberate Transformers override is the opt-in for capable

--- a/agents/local_agent.py
+++ b/agents/local_agent.py
@@ -266,19 +266,6 @@ class LocalAgent(BaseAgent):
         if not self.runner:
             raise RuntimeError("Runner not initialized")
 
-        system_prompt = (
-            "\n\n".join(message.content or "" for message in messages if message.role == "system")
-            or SYSTEM_PROMPT
-        )
-        conversation = []
-        for message in messages:
-            if message.role == "system":
-                continue
-            label = "Assistant" if message.role == "assistant" else "User"
-            if message.role == "tool":
-                label = f"Tool {message.name or ''}".strip()
-            conversation.append(f"{label}: {message.content or ''}")
-
         generation_config = GenerationConfig(
             max_tokens=config.max_tokens,
             temperature=config.temperature,
@@ -287,11 +274,18 @@ class LocalAgent(BaseAgent):
             presence_penalty=config.presence_penalty,
             stop=config.stop[0] if config.stop else None,
         )
-        result = self.runner.complete(
-            system_prompt=system_prompt,
-            user_prompt="\n".join(conversation),
-            generation_config=generation_config,
-        )
+        structured_messages = [
+            {"role": message.role, "content": message.content} for message in messages
+        ]
+        complete_messages = getattr(self.runner, "complete_messages", None)
+        if complete_messages is None:
+            result = BaseRunner.complete_messages(
+                self.runner,
+                structured_messages,
+                generation_config,
+            )
+        else:
+            result = complete_messages(structured_messages, generation_config)
         completion = LlamaCompletion.from_dict(result)
         text = next(
             (message.content for message in completion.messages if message.role == "assistant"),

--- a/agents/models/agent_state.py
+++ b/agents/models/agent_state.py
@@ -1,0 +1,114 @@
+"""Scoped state for one conversation and one agent run."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from agents.models.chat_result import ToolCallResult, WorkArtifact
+from agents.models.tool_calling import ChatMessage
+
+
+RunStatus = Literal["running", "completed", "failed", "cancelled"]
+
+
+@dataclass
+class ConversationState:
+    """Structured state for one chat session."""
+
+    chat_id: int | None
+    user_id: int
+    messages: list[ChatMessage] = field(default_factory=list)
+
+    def add_system_prompt(self, prompt: str | None) -> None:
+        if prompt:
+            self.messages.append(ChatMessage(role="system", content=prompt))
+
+    def hydrate(self, messages: list[ChatMessage]) -> None:
+        self.messages.extend(messages)
+
+    def begin_run(self, prompt: str) -> AgentRunContext:
+        return AgentRunContext(
+            conversation=self,
+            prompt=prompt,
+            transcript=[ChatMessage(role="user", content=prompt)],
+        )
+
+    def accept_persisted_chat_id(self, chat_id: int | None) -> None:
+        if chat_id is not None:
+            self.chat_id = chat_id
+
+
+@dataclass
+class AgentRunContext:
+    """Mutable execution state for one model/tool run."""
+
+    conversation: ConversationState
+    prompt: str
+    run_id: str = field(default_factory=lambda: f"run_{uuid.uuid4().hex}")
+    transcript: list[ChatMessage] = field(default_factory=list)
+    tool_calls: list[ToolCallResult] = field(default_factory=list)
+    artifacts: list[WorkArtifact] = field(default_factory=list)
+    assistant_text_parts: list[str] = field(default_factory=list)
+    status: RunStatus = "running"
+    model_completed: bool = False
+    total_tool_calls: int = 0
+    tool_result_chars: int = 0
+    persisted: bool = False
+    persisted_status: RunStatus | None = None
+    _persistence_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        repr=False,
+        compare=False,
+    )
+
+    @property
+    def model_messages(self) -> list[ChatMessage]:
+        return [*self.conversation.messages, *self.transcript]
+
+    @property
+    def assistant_text(self) -> str:
+        return "\n\n".join(part for part in self.assistant_text_parts if part).strip()
+
+    @property
+    def persistence_lock(self) -> threading.Lock:
+        return self._persistence_lock
+
+    def record_assistant(self, message: ChatMessage) -> None:
+        if message.content:
+            self.assistant_text_parts.append(message.content)
+        self.transcript.append(message)
+
+    def record_tool_call(self, state: ToolCallResult) -> None:
+        self.tool_calls.append(state)
+
+    def record_tool_message(self, message: ChatMessage) -> None:
+        self.transcript.append(message)
+
+    def record_artifacts(self, artifacts: list[WorkArtifact]) -> None:
+        self.artifacts.extend(artifacts)
+
+    def transition(self, status: RunStatus) -> None:
+        self.status = status
+
+    def mark_model_completed(self) -> None:
+        self.model_completed = True
+
+    def persistence_snapshot(self) -> dict[str, Any]:
+        return {
+            "new_user_message": self.prompt,
+            "new_ai_message": self.assistant_text or None,
+            "session_id": self.conversation.chat_id,
+            "tool_calls": list(self.tool_calls),
+            "transcript": [message.to_dict() for message in self.transcript],
+            "user_id": self.conversation.user_id,
+            "run_id": self.run_id,
+            "status": self.status,
+        }
+
+    def mark_persisted(self, chat_id: int | None) -> None:
+        self.persisted = True
+        self.persisted_status = self.status
+        self.conversation.accept_persisted_chat_id(chat_id)

--- a/app/main.py
+++ b/app/main.py
@@ -150,7 +150,7 @@ def run_chat_completion(
     agent=None,
 ) -> AgentCompletion:
     active_agent = agent or get_active_agent(resolve_agent_type(params.agent_type))
-    if not params.enable_tools or not hasattr(active_agent, "stream_model_turn"):
+    if not hasattr(active_agent, "stream_model_turn"):
         completion = active_agent.complete_text(
             prompt=params.prompt,
             max_tokens=params.max_tokens,
@@ -182,7 +182,7 @@ def run_chat_completion(
 def stream_chat_completion(params: CompleteTextParams, chat_id: int | None = None):
     try:
         agent = get_active_agent(resolve_agent_type(params.agent_type))
-        if params.enable_tools and hasattr(agent, "stream_model_turn"):
+        if hasattr(agent, "stream_model_turn"):
             for event in chat_orchestrator.stream(
                 backend=agent,
                 prompt=params.prompt,

--- a/app/main.py
+++ b/app/main.py
@@ -180,51 +180,66 @@ def run_chat_completion(
 
 
 def stream_chat_completion(params: CompleteTextParams, chat_id: int | None = None):
-    agent = get_active_agent(resolve_agent_type(params.agent_type))
-    if params.enable_tools and hasattr(agent, "stream_model_turn"):
-        for event in chat_orchestrator.stream(
-            backend=agent,
+    try:
+        agent = get_active_agent(resolve_agent_type(params.agent_type))
+        if params.enable_tools and hasattr(agent, "stream_model_turn"):
+            for event in chat_orchestrator.stream(
+                backend=agent,
+                prompt=params.prompt,
+                user_id=get_default_user().user_id,
+                chat_id=chat_id,
+                config=model_request_config(params),
+                system_prompt=chat_system_prompt(params.enable_tools),
+                enable_tools=params.enable_tools,
+            ):
+                yield sse_event(event.event, event.payload)
+            return
+
+        # Legacy agents retain text-only behavior. Generate once and adapt the
+        # authoritative completion into SSE chunks; consuming a legacy text stream
+        # and then calling complete_text again can duplicate model work and database
+        # persistence.
+        completion = agent.complete_text(
             prompt=params.prompt,
-            user_id=get_default_user().user_id,
+            max_tokens=params.max_tokens,
+            n=params.n,
+            stop=params.stop,
+            temperature=params.temperature,
+            top_p=params.top_p,
+            frequency_penalty=params.frequency_penalty,
+            presence_penalty=params.presence_penalty,
+            echo=params.echo,
+            best_of=params.best_of,
+            prompt_tokens=params.prompt_tokens,
+            response_format=params.response_format,
+            system_prompt=DEFAULT_PROMPT,
             chat_id=chat_id,
-            config=model_request_config(params),
-            system_prompt=chat_system_prompt(params.enable_tools),
-            enable_tools=params.enable_tools,
+        )
+        completion_object = completion_to_response(completion)
+        for chunk in chunk_completion_text(
+            completion_object.message[0] if completion_object.message else ""
         ):
-            yield sse_event(event.event, event.payload)
-        return
+            yield sse_event("delta", {"text": chunk})
 
-    # Legacy agents retain text-only behavior. Generate once and adapt the
-    # authoritative completion into SSE chunks; consuming a legacy text stream
-    # and then calling complete_text again can duplicate model work and database
-    # persistence.
-    completion = agent.complete_text(
-        prompt=params.prompt,
-        max_tokens=params.max_tokens,
-        n=params.n,
-        stop=params.stop,
-        temperature=params.temperature,
-        top_p=params.top_p,
-        frequency_penalty=params.frequency_penalty,
-        presence_penalty=params.presence_penalty,
-        echo=params.echo,
-        best_of=params.best_of,
-        prompt_tokens=params.prompt_tokens,
-        response_format=params.response_format,
-        system_prompt=DEFAULT_PROMPT,
-        chat_id=chat_id,
-    )
-    completion_object = completion_to_response(completion)
-    for chunk in chunk_completion_text(
-        completion_object.message[0] if completion_object.message else ""
-    ):
-        yield sse_event("delta", {"text": chunk})
-
-    yield sse_event("final", completion_object)
-    yield sse_event(
-        "done",
-        {"run_id": completion_object.run_id, "chat_id": completion_object.chat_id},
-    )
+        yield sse_event("final", completion_object)
+        yield sse_event(
+            "done",
+            {"run_id": completion_object.run_id, "chat_id": completion_object.chat_id},
+        )
+    except Exception:
+        logger.exception("Chat stream failed before a terminal event")
+        yield sse_event(
+            "error",
+            {
+                "code": "chat_backend_error",
+                "message": (
+                    "Chat backend failed to start. Check the configured model, "
+                    "local weights, and required credentials."
+                ),
+                "chat_id": chat_id,
+            },
+        )
+        yield sse_event("done", {"run_id": None, "chat_id": chat_id})
 
 
 # App factory function

--- a/app/services/chat_orchestrator.py
+++ b/app/services/chat_orchestrator.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from agents.models.agent_completion import AgentCompletion
+from agents.models.agent_state import ConversationState, RunStatus
 from agents.models.chat_result import ToolCallResult, WorkArtifact
 from agents.models.tool_calling import (
     ChatMessage,
@@ -291,91 +292,71 @@ class ChatOrchestrator:
         system_prompt: str | None,
         enable_tools: bool = True,
     ) -> Iterator[ChatStreamEvent]:
-        run_id = f"run_{uuid.uuid4().hex}"
-        context = ToolContext(user_id=user_id, chat_id=chat_id, run_id=run_id)
+        conversation = ConversationState(chat_id=chat_id, user_id=user_id)
+        conversation.add_system_prompt(system_prompt)
+        if chat_id is not None:
+            try:
+                conversation.hydrate(self._history_messages(self.history_loader(chat_id)))
+            except Exception as error:
+                logger.warning("Could not hydrate chat %s: %s", chat_id, error)
+        run = conversation.begin_run(prompt)
+        context = ToolContext(user_id=user_id, chat_id=chat_id, run_id=run.run_id)
         native_tools = bool(getattr(backend, "supports_native_tool_calling", False))
         tools = (
             self.registry.definitions_for_context(context) if enable_tools and native_tools else []
         )
 
-        messages: list[ChatMessage] = []
-        if system_prompt:
-            messages.append(ChatMessage(role="system", content=system_prompt))
-        if chat_id is not None:
-            try:
-                messages.extend(self._history_messages(self.history_loader(chat_id)))
-            except Exception as error:
-                logger.warning("Could not hydrate chat %s: %s", chat_id, error)
-
-        current_transcript: list[ChatMessage] = [ChatMessage(role="user", content=prompt)]
-        messages.extend(current_transcript)
-        assistant_text_parts: list[str] = []
-        trajectory: list[ToolCallResult] = []
-        artifacts: list[WorkArtifact] = []
-        total_calls = 0
-        tool_result_chars = 0
-        completed = False
-        persisted = False
-        persisted_chat_id = chat_id
-        persisted_status: str | None = None
-        persistence_lock = threading.Lock()
-
-        def persist_turn(status: str, ai_message: str | None) -> int | None:
-            nonlocal persisted, persisted_chat_id, persisted_status
-            with persistence_lock:
-                if persisted:
-                    return persisted_chat_id
+        def persist_turn(status: RunStatus, ai_message: str | None) -> int | None:
+            with run.persistence_lock:
+                if run.persisted:
+                    return conversation.chat_id
 
                 # Snapshot mutable run state so a cancellation callback can
                 # safely persist while a provider/tool thread is unwinding.
-                trajectory_snapshot = list(trajectory)
-                artifact_snapshot = [
-                    self._artifact_for_history(artifact) for artifact in list(artifacts)
+                run.transition(status)
+                snapshot = run.persistence_snapshot()
+                snapshot["new_ai_message"] = ai_message
+                snapshot["artifacts"] = [
+                    self._artifact_for_history(artifact) for artifact in list(run.artifacts)
                 ]
-                transcript_snapshot = [message.to_dict() for message in list(current_transcript)]
                 try:
-                    history = self.history_writer(
-                        new_user_message=prompt,
-                        new_ai_message=ai_message,
-                        session_id=chat_id,
-                        tool_calls=trajectory_snapshot,
-                        artifacts=artifact_snapshot,
-                        transcript=transcript_snapshot,
-                        user_id=user_id,
-                        run_id=run_id,
-                        status=status,
-                    )
+                    history = self.history_writer(**snapshot)
                 except Exception:
-                    logger.exception("Could not persist terminal state for chat run %s", run_id)
+                    logger.exception(
+                        "Could not persist terminal state for chat run %s",
+                        run.run_id,
+                    )
                     if status == "completed":
                         raise
-                    return persisted_chat_id
-                persisted = True
-                persisted_chat_id = getattr(history, "chat_session_id", chat_id)
-                persisted_status = status
-                return persisted_chat_id
+                    return conversation.chat_id
+                persisted_chat_id = getattr(history, "chat_session_id", conversation.chat_id)
+                run.mark_persisted(persisted_chat_id)
+                return conversation.chat_id
 
         def cancelled_payload() -> dict[str, Any]:
             persisted_chat_id = persist_turn(
                 "cancelled",
-                "\n\n".join(part for part in assistant_text_parts if part).strip() or None,
+                run.assistant_text or None,
             )
-            return {"run_id": run_id, "chat_id": persisted_chat_id}
+            return {"run_id": run.run_id, "chat_id": persisted_chat_id}
 
         def persist_cancelled_state() -> bool:
             cancelled_payload()
-            return persisted_status == "cancelled"
+            return run.persisted_status == "cancelled"
 
         # Register durable cancellation before exposing the run ID. The cancel
         # endpoint therefore cannot acknowledge a run and then lose its terminal
         # record merely because the browser closes the SSE response.
         cancellation = self.run_controls.start(
-            run_id,
+            run.run_id,
             on_cancel=persist_cancelled_state,
         )
 
         try:
-            yield ChatStreamEvent("run_started", {"run_id": run_id, "chat_id": chat_id})
+            yield ChatStreamEvent(
+                "run_started",
+                {"run_id": run.run_id, "chat_id": conversation.chat_id},
+            )
 
             for _round_number in range(self.max_rounds):
                 if cancellation.is_set():
@@ -383,7 +364,7 @@ class ChatOrchestrator:
                     return
 
                 completed_turn = None
-                for event in backend.stream_model_turn(messages, tools, config):
+                for event in backend.stream_model_turn(run.model_messages, tools, config):
                     if cancellation.is_set():
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
@@ -397,22 +378,19 @@ class ChatOrchestrator:
                 if completed_turn is None:
                     raise RuntimeError("Model backend did not complete its turn")
 
-                if completed_turn.text:
-                    assistant_text_parts.append(completed_turn.text)
                 assistant_message = ChatMessage(
                     role="assistant",
                     content=completed_turn.text or None,
                     tool_calls=completed_turn.tool_calls,
                 )
-                messages.append(assistant_message)
-                current_transcript.append(assistant_message)
+                run.record_assistant(assistant_message)
 
                 if not completed_turn.tool_calls:
-                    completed = True
+                    run.mark_model_completed()
                     break
 
-                total_calls += len(completed_turn.tool_calls)
-                if total_calls > self.max_tool_calls:
+                run.total_tool_calls += len(completed_turn.tool_calls)
+                if run.total_tool_calls > self.max_tool_calls:
                     raise RuntimeError(f"Tool call limit exceeded ({self.max_tool_calls})")
 
                 for call in completed_turn.tool_calls:
@@ -427,7 +405,7 @@ class ChatOrchestrator:
 
                     if cancellation.is_set():
                         cancelled = self._tool_state(call, "cancelled")
-                        trajectory.append(cancelled)
+                        run.record_tool_call(cancelled)
                         yield ChatStreamEvent("tool_call", cancelled)
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
@@ -439,7 +417,9 @@ class ChatOrchestrator:
                     if cancellation.is_set():
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
-                    remaining_result_chars = self.max_tool_result_chars_total - tool_result_chars
+                    remaining_result_chars = (
+                        self.max_tool_result_chars_total - run.tool_result_chars
+                    )
                     if remaining_result_chars <= 0:
                         result.content = ""
                     elif len(result.content) > remaining_result_chars:
@@ -449,7 +429,10 @@ class ChatOrchestrator:
                         else:
                             retained_chars = remaining_result_chars - len(truncation_marker)
                             result.content = f"{result.content[:retained_chars]}{truncation_marker}"
-                    tool_result_chars += min(len(result.content), max(0, remaining_result_chars))
+                    run.tool_result_chars += min(
+                        len(result.content),
+                        max(0, remaining_result_chars),
+                    )
                     state = self._tool_state(
                         call,
                         result.status,
@@ -458,62 +441,64 @@ class ChatOrchestrator:
                         error=result.error,
                         requires_approval=requires_approval,
                     )
-                    trajectory.append(state)
-                    artifacts.extend(result.artifacts)
+                    run.record_tool_call(state)
+                    run.record_artifacts(result.artifacts)
                     for artifact in result.artifacts:
                         yield ChatStreamEvent("artifact", artifact)
                     yield ChatStreamEvent("tool_call", state)
 
                     tool_message = result.to_message()
-                    messages.append(tool_message)
-                    current_transcript.append(tool_message)
+                    run.record_tool_message(tool_message)
 
                     if cancellation.is_set():
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
 
-            if not completed:
+            if not run.model_completed:
                 raise RuntimeError(f"Model/tool round limit exceeded ({self.max_rounds})")
 
             if cancellation.is_set():
                 yield ChatStreamEvent("cancelled", cancelled_payload())
                 return
 
-            final_text = "\n\n".join(part for part in assistant_text_parts if part).strip()
+            final_text = run.assistant_text
             persisted_chat_id = persist_turn("completed", final_text)
-            if persisted_status == "cancelled":
+            if run.persisted_status == "cancelled":
                 yield ChatStreamEvent("cancelled", cancelled_payload())
                 return
             completion = AgentCompletion(
                 message=[final_text],
                 id=f"completion_{uuid.uuid4().hex}",
                 chat_id=persisted_chat_id,
-                run_id=run_id,
-                tool_calls=trajectory,
-                artifacts=artifacts,
+                run_id=run.run_id,
+                tool_calls=run.tool_calls,
+                artifacts=run.artifacts,
             )
             yield ChatStreamEvent("final", completion)
             yield ChatStreamEvent(
                 "done",
-                {"run_id": run_id, "chat_id": persisted_chat_id},
+                {"run_id": run.run_id, "chat_id": persisted_chat_id},
             )
         except Exception as error:
-            logger.exception("Chat run %s failed", run_id)
+            logger.exception("Chat run %s failed", run.run_id)
             persisted_chat_id = persist_turn(
                 "failed",
-                "\n\n".join(part for part in assistant_text_parts if part).strip() or None,
+                run.assistant_text or None,
             )
             yield ChatStreamEvent(
                 "error",
                 {
-                    "run_id": run_id,
+                    "run_id": run.run_id,
                     "chat_id": persisted_chat_id,
                     "message": self._public_error_message(error),
                 },
             )
-            yield ChatStreamEvent("done", {"run_id": run_id, "chat_id": persisted_chat_id})
+            yield ChatStreamEvent(
+                "done",
+                {"run_id": run.run_id, "chat_id": persisted_chat_id},
+            )
         finally:
-            self.run_controls.finish(run_id)
+            self.run_controls.finish(run.run_id)
 
     def complete(self, **kwargs: Any) -> AgentCompletion:
         completion: AgentCompletion | None = None

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -2,4 +2,11 @@ import uvicorn
 
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=5001, log_level="info", reload=True)
+    uvicorn.run(
+        "app.main:app",
+        host="0.0.0.0",
+        port=5001,
+        log_level="info",
+        reload=True,
+        reload_dirs=["adapters", "agents", "app"],
+    )

--- a/client/geist/e2e/chat.spec.ts
+++ b/client/geist/e2e/chat.spec.ts
@@ -1,7 +1,7 @@
 import { expect, Page, test } from '@playwright/test';
 
 const backendFailureMessage =
-  'Error: Chat backend failed to start. Check the configured model, local weights, and required credentials.';
+  'Error: Chat completion failed';
 const consoleErrorsByPage = new WeakMap<Page, string[]>();
 
 test.beforeEach(async ({ page }) => {
@@ -29,7 +29,32 @@ test('completes a chat through the real SSE route', async ({ page }) => {
   await expect(messageInput).toBeEnabled();
 });
 
-test('leaves connecting and surfaces a safe model startup error', async ({ page }) => {
+test('persists a conversation and hydrates structured follow-up context', async ({ page }) => {
+  const messageInput = page.getByPlaceholder('Type your message...');
+  await messageInput.fill('Remember cobalt.');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.locator('.chat-message-ai')).toContainText('I will remember cobalt.');
+  await expect(page).toHaveURL(/\/chat\/\d+$/);
+
+  await messageInput.fill('What should you remember?');
+  await page.getByRole('button', { name: 'Send' }).click();
+  const followUpTurn = page.locator('.chat-turn').filter({
+    hasText: 'What should you remember?',
+  });
+  await expect(followUpTurn.locator('.chat-message-ai')).toContainText('cobalt');
+
+  await page.reload();
+  await expect(
+    page.locator('.chat-message-user').filter({ hasText: 'Remember cobalt.' }),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('.chat-message-user').filter({ hasText: 'What should you remember?' }),
+  ).toHaveCount(1);
+  await expect(followUpTurn.locator('.chat-message-ai')).toContainText('cobalt');
+});
+
+test('leaves connecting and surfaces a safe model failure', async ({ page }) => {
   const messageInput = page.getByPlaceholder('Type your message...');
   await messageInput.fill('Trigger backend failure');
   await page.getByRole('button', { name: 'Send' }).click();

--- a/client/geist/e2e/chat.spec.ts
+++ b/client/geist/e2e/chat.spec.ts
@@ -1,0 +1,41 @@
+import { expect, Page, test } from '@playwright/test';
+
+const backendFailureMessage =
+  'Error: Chat backend failed to start. Check the configured model, local weights, and required credentials.';
+const consoleErrorsByPage = new WeakMap<Page, string[]>();
+
+test.beforeEach(async ({ page }) => {
+  const consoleErrors: string[] = [];
+  consoleErrorsByPage.set(page, consoleErrors);
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  await page.goto('/chat');
+});
+
+test.afterEach(async ({ page }) => {
+  expect(consoleErrorsByPage.get(page) ?? []).toEqual([]);
+});
+
+test('completes a chat through the real SSE route', async ({ page }) => {
+  const messageInput = page.getByPlaceholder('Type your message...');
+  await messageInput.fill('Reply for E2E');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.locator('.chat-message-ai')).toContainText('E2E chat works.');
+  await expect(page.getByRole('status', { name: 'Geist is responding' })).toBeHidden();
+  await expect(messageInput).toBeEnabled();
+});
+
+test('leaves connecting and surfaces a safe model startup error', async ({ page }) => {
+  const messageInput = page.getByPlaceholder('Type your message...');
+  await messageInput.fill('Trigger backend failure');
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText(backendFailureMessage, { exact: true })).toBeVisible();
+  await expect(page.getByText('Turn status: failed', { exact: true })).toBeVisible();
+  await expect(page.getByRole('status', { name: 'Geist is responding' })).toBeHidden();
+  await expect(messageInput).toBeEnabled();
+});

--- a/client/geist/package-lock.json
+++ b/client/geist/package-lock.json
@@ -24,6 +24,9 @@
         "reactflow": "11.11.4",
         "typescript": "4.9.5",
         "web-vitals": "2.1.4"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.61.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3202,6 +3205,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -13427,6 +13445,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -20167,6 +20215,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.61.1"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -27597,6 +27654,22 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.1"
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.24",

--- a/client/geist/package.json
+++ b/client/geist/package.json
@@ -24,6 +24,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "eject": "react-scripts eject"
   },
@@ -52,5 +53,8 @@
     "moduleNameMapper": {
       "\\.(css|less|scss|sass)$": "<rootDir>/src/__mocks__/styleMock.js"
     }
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
   }
 }

--- a/client/geist/playwright.config.ts
+++ b/client/geist/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig } from '@playwright/test';
+
+const backendPort = Number(process.env.GEIST_E2E_BACKEND_PORT ?? 5100);
+const frontendPort = 3100;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  timeout: 30_000,
+  reporter: process.env.CI
+    ? [['line'], ['html', { open: 'never' }]]
+    : 'line',
+  use: {
+    baseURL: `http://127.0.0.1:${frontendPort}`,
+    channel: process.env.GEIST_E2E_USE_BUNDLED_CHROMIUM ? undefined : 'chrome',
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: [
+    ...(process.env.GEIST_E2E_EXTERNAL_BACKEND
+      ? []
+      : [
+          {
+            command: 'uv run python -m tests.e2e_server',
+            cwd: '../..',
+            url: `http://127.0.0.1:${backendPort}/docs`,
+            reuseExistingServer: false,
+            timeout: 120_000,
+            env: {
+              ...process.env,
+              PYTHONPATH: '.',
+              GEIST_DATABASE_PROVIDER: 'sqlite',
+              SQLITE_DATABASE_PATH: `/tmp/geist-playwright-${process.pid}.sqlite3`,
+              GEIST_E2E_BACKEND_PORT: String(backendPort),
+            },
+          },
+        ]),
+    {
+      command: 'npm start',
+      cwd: '.',
+      url: `http://127.0.0.1:${frontendPort}/chat`,
+      reuseExistingServer: false,
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        BROWSER: 'none',
+        HOST: '127.0.0.1',
+        PORT: String(frontendPort),
+        REACT_APP_BACKEND_HOST: '127.0.0.1',
+        REACT_APP_BACKEND_PORT: String(backendPort),
+      },
+    },
+  ],
+});

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -151,7 +151,7 @@ const Chat = () => {
 
   useEffect(() => {
     const container = chatContainerRef.current;
-    if (container && hasMore && !isLoadingHistory && (chatHistory?.chatHistory?.length ?? 0) > 0) {
+    if (container && chatId && hasMore && !isLoadingHistory && (chatHistory?.chatHistory?.length ?? 0) > 0) {
       if (container.scrollHeight <= container.clientHeight) {
         const nextPage = page + 1;
         setPage(nextPage);
@@ -177,8 +177,9 @@ const Chat = () => {
     [isChatSessionLoading, hasMoreSessions, loadMoreSessions, chatSessionError]
   );
 
+  const loadedHistoryLength = chatHistory?.chatHistory?.length ?? 0;
   const handleScroll = useCallback(() => {
-    if (chatContainerRef.current) {
+    if (chatContainerRef.current && chatId && loadedHistoryLength > 0) {
       const { scrollTop, scrollHeight } = chatContainerRef.current;
       if (scrollTop <= 10 && hasMore && !isLoadingHistory) {
         prevScrollHeightRef.current = scrollHeight;
@@ -189,7 +190,7 @@ const Chat = () => {
         }
       }
     }
-  }, [hasMore, isLoadingHistory, page, chatId, fetchHistory]);
+  }, [hasMore, isLoadingHistory, page, chatId, loadedHistoryLength, fetchHistory]);
 
   useEffect(() => {
     const container = chatContainerRef.current;

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -84,6 +84,12 @@ const Chat = () => {
   const { processMessage, isProcessing: isProcessingFiles, error: fileError } = useFileContext();
   const routeChatId = chatId ? parseInt(chatId, 10) : null;
 
+  useEffect(() => {
+    if (!chatId && state_chat_id !== null) {
+      navigate(`/chat/${state_chat_id}`, { replace: true });
+    }
+  }, [chatId, navigate, state_chat_id]);
+
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -342,7 +348,11 @@ const Chat = () => {
     routeChatId,
     state_chat_id,
   );
-  const displayedHistory: ChatPair[] = activeTurnBelongsToCurrentChat
+  const activeTurnAlreadyPersisted = Boolean(
+    activeTurn?.run_id &&
+    (chatHistory?.chatHistory ?? []).some((turn) => turn.run_id === activeTurn.run_id)
+  );
+  const displayedHistory: ChatPair[] = activeTurnBelongsToCurrentChat && !activeTurnAlreadyPersisted
     ? [
         ...(chatHistory?.chatHistory ?? []),
         {

--- a/conftest.py
+++ b/conftest.py
@@ -14,11 +14,20 @@ from app.main import create_app
 
 
 def create_agent_settings(include_world_processing: bool = True):
-    return AgentSettings(name="default agent", version="1.0", description="default", include_world_processing=include_world_processing)
+    return AgentSettings(
+        name="default agent",
+        version="1.0",
+        description="default",
+        include_world_processing=include_world_processing,
+    )
+
 
 openai_key = os.getenv("OPENAI_API_KEY")
-def get_envs() -> dict[str,str]:
+
+
+def get_envs() -> dict[str, str]:
     return load_environment_dictionary()
+
 
 class StubRunner(BaseRunner):
     """Deterministic in-memory runner so LocalAgent tests never load real weights."""
@@ -33,8 +42,15 @@ class StubRunner(BaseRunner):
         # Same shape as the real runners: a list of message dicts (see strings_to_message_dict)
         return [
             {"role": "user", "content": user_prompt},
-            {"role": "assistant", "content": f"Response to: {user_prompt}"}
+            {"role": "assistant", "content": f"Response to: {user_prompt}"},
         ]
+
+    def complete_messages(self, messages, generation_config: GenerationConfig):
+        user_prompt = next(
+            message["content"] for message in reversed(messages) if message["role"] == "user"
+        )
+        return self.complete("", user_prompt, generation_config)
+
 
 @pytest.fixture(scope="module")
 def app():
@@ -42,25 +58,37 @@ def app():
     app = create_app()
     yield app
 
+
 @pytest.fixture(scope="module")
 def client(app):
     # Create a TestClient instance using the app fixture
     with TestClient(app) as client:
         yield client
 
+
 @pytest.fixture(scope="module")
 def online_agent():
     settings = create_agent_settings(include_world_processing=True)
     context = AgentContext(settings=settings, envs=get_envs())
-    return OnlineAgent(agent_context=context, base_url="https://api.openai.com/v1",
-                       model="gpt-4", api_key=None)
+    return OnlineAgent(
+        agent_context=context, base_url="https://api.openai.com/v1", model="gpt-4", api_key=None
+    )
+
 
 @pytest.fixture(scope="module")
 def process_world_variation_online_agents():
-    variant_settings = [create_agent_settings(include_world_processing=True), create_agent_settings(include_world_processing=False)]
+    variant_settings = [
+        create_agent_settings(include_world_processing=True),
+        create_agent_settings(include_world_processing=False),
+    ]
     contexts = [AgentContext(settings=setting, envs=get_envs()) for setting in variant_settings]
-    return [OnlineAgent(agent_context=context, base_url="https://api.openai.com/v1",
-                        model="gpt-4", api_key=None) for context in contexts]
+    return [
+        OnlineAgent(
+            agent_context=context, base_url="https://api.openai.com/v1", model="gpt-4", api_key=None
+        )
+        for context in contexts
+    ]
+
 
 @pytest.fixture(scope="module")
 def local_agent():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - SQLITE_DATABASE_PATH=data/geist.sqlite3
       - DEBUG=${DEBUG:-}
       - HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-}
+      # MLX is a native macOS runtime. Linux containers use Transformers unless
+      # an operator deliberately selects another registered runner.
+      - GEIST_LOCAL_RUNNER=${GEIST_LOCAL_RUNNER:-transformers}
     env_file:
       - path: .env
         required: false

--- a/plans/153-CHAT-STREAM-RECOVERY-AND-E2E.md
+++ b/plans/153-CHAT-STREAM-RECOVERY-AND-E2E.md
@@ -1,0 +1,27 @@
+# Chat Stream Recovery and Browser E2E
+
+## Goal
+
+Prevent chat from remaining in `connecting` when agent or model initialization fails, keep MLX selection explicit to native Apple Silicon runtimes, and cover successful and failed streaming flows in a real browser.
+
+## Implementation
+
+1. Wrap the complete SSE generator boundary so backend exceptions are logged and converted into terminal `error` and `done` events after headers have been sent.
+2. Allow `GEIST_LOCAL_RUNNER` to explicitly select a local runner and configure Linux Docker to use `transformers` instead of the MLX-only default.
+3. Add focused backend tests for pre-stream initialization failures and runner override validation.
+4. Add Playwright browser tests against the real React app and FastAPI stream route using a deterministic test-only agent server.
+5. Run the browser suite in CI with the same lockfile-only dependency installation policy as the existing frontend job.
+
+## Validation
+
+- Ruff, formatting, and mypy for changed Python.
+- Focused backend stream and factory tests.
+- Frontend Jest tests and production build.
+- Playwright browser tests for a successful chat response and a backend initialization failure that must leave `connecting`.
+- Docker startup, logs, and HTTP checks.
+- Native MLX chat using copied `llama_3_1` weights.
+- Python and frontend dependency audits after lockfile changes.
+
+## Runtime Handoff
+
+Copy the Desktop weights into `app/model_weights/llama_3_1`, launch current main natively with `MLX_BACKEND=1`, and leave the UI open for manual retesting.

--- a/plans/154-AGENT-CONVERSATION-RUN-STATE.md
+++ b/plans/154-AGENT-CONVERSATION-RUN-STATE.md
@@ -1,0 +1,51 @@
+# Agent, Conversation, and Run State
+
+## Goal
+
+Use one orchestration path for streaming and non-streaming chat while keeping
+agent-wide state, conversation history, and per-run execution state explicitly
+scoped. Preserve structured message roles through local runners so persisted
+turns become reliable model context.
+
+## Design
+
+1. Keep `AgentContext` limited to agent identity, settings, tools, and durable
+   world/task/execution state.
+2. Add `ConversationState` for one chat session. It owns the structured message
+   view hydrated from persisted history and the persisted chat identifier.
+3. Add `AgentRunContext` for one invocation. It owns the run identifier,
+   transcript, tool trajectory, artifacts, status, cancellation state, and
+   exactly-once terminal persistence bookkeeping.
+4. Keep persistence in the existing SQLAlchemy/helper layer. The state objects
+   provide scoped data and transition methods; no repository abstraction is
+   introduced.
+5. Route both streaming and non-streaming modern completions through
+   `ChatOrchestrator`. Retain legacy agents behind the existing compatibility
+   fallback until their model-turn contract is migrated.
+6. Add a structured runner message method. MLX and Transformers runners must
+   apply their tokenizer chat templates to the original role-preserving message
+   sequence instead of flattening history into one user prompt.
+
+## Tests
+
+- Unit tests for `ConversationState` hydration and `AgentRunContext` transition
+  snapshots.
+- Orchestrator tests proving structured history reaches the backend and one
+  terminal turn is persisted.
+- Local runner tests proving user/assistant roles reach MLX and Transformers
+  chat templates without flattening.
+- Route tests proving streaming and non-streaming modern completions share the
+  orchestrator.
+- Playwright coverage proving a created conversation persists through reload
+  and a follow-up request uses the returned session ID.
+- Native MLX browser smoke proving a follow-up can recall an exact earlier user
+  message.
+
+## Validation
+
+- Ruff, formatting, and mypy for changed Python.
+- Focused state, orchestrator, route, and runner tests.
+- Full backend and frontend test suites when feasible.
+- Frontend production build and Playwright browser suite.
+- Python/frontend dependency audits if dependency manifests change.
+- Native `make run MLX_BACKEND=1` and live browser multi-turn chat.

--- a/tests/agents/test_agent_state.py
+++ b/tests/agents/test_agent_state.py
@@ -1,0 +1,61 @@
+from agents.models.agent_state import ConversationState
+from agents.models.chat_result import ToolCallResult
+from agents.models.tool_calling import ChatMessage
+
+
+def test_conversation_state_keeps_agent_runs_scoped_to_one_chat():
+    conversation = ConversationState(chat_id=12, user_id=7)
+    conversation.add_system_prompt("Be concise.")
+    conversation.hydrate(
+        [
+            ChatMessage(role="user", content="Remember cobalt."),
+            ChatMessage(role="assistant", content="I will remember cobalt."),
+        ]
+    )
+
+    run = conversation.begin_run("What should you remember?")
+
+    assert [message.role for message in run.model_messages] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert run.model_messages[-1].content == "What should you remember?"
+    assert conversation.messages[-1].content == "I will remember cobalt."
+
+
+def test_agent_run_context_snapshots_terminal_execution_state():
+    conversation = ConversationState(chat_id=None, user_id=3)
+    run = conversation.begin_run("Find the file")
+    run.record_assistant(
+        ChatMessage(
+            role="assistant",
+            content="I found it.",
+        )
+    )
+    run.record_tool_call(
+        ToolCallResult.create(
+            id="call_1",
+            name="documents.search",
+            status="succeeded",
+            result_summary="Found the file",
+        )
+    )
+    run.transition("completed")
+
+    snapshot = run.persistence_snapshot()
+
+    assert snapshot["session_id"] is None
+    assert snapshot["run_id"] == run.run_id
+    assert snapshot["status"] == "completed"
+    assert snapshot["new_ai_message"] == "I found it."
+    assert snapshot["transcript"] == [
+        {"role": "user", "content": "Find the file"},
+        {"role": "assistant", "content": "I found it."},
+    ]
+    assert snapshot["tool_calls"][0].id == "call_1"
+
+    run.mark_persisted(41)
+    assert conversation.chat_id == 41
+    assert run.persisted_status == "completed"

--- a/tests/agents/test_history_hydration.py
+++ b/tests/agents/test_history_hydration.py
@@ -1,45 +1,14 @@
-import copy
 from unittest.mock import patch
 
+from agents.models.tool_calling import ModelEvent, ModelTurn
 from app.main import AgentType, agent_cache
 
 
 ASSISTANT_REPLY_1 = "First reply from assistant"
 
-MOCK_COMPLETION_RESPONSE = {
-    "id": "mock-id",
-    "object": "chat.completion",
-    "created": 0,
-    "model": "gpt-4-0613",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": ASSISTANT_REPLY_1,
-                "refusal": None
-            },
-            "logprobs": None,
-            "finish_reason": "stop"
-        }
-    ],
-    "usage": {
-        "prompt_tokens": 10,
-        "completion_tokens": 5,
-        "total_tokens": 15,
-        "prompt_tokens_details": {
-            "cached_tokens": 0
-        },
-        "completion_tokens_details": {
-            "reasoning_tokens": 0
-        }
-    },
-    "system_fingerprint": None
-}
 
-
-@patch('agents.online_agent.OnlineAgent._make_request')
-def test_server_side_history_hydration_in_completion(mock_make_request, online_agent, client):
+@patch("agents.online_agent.OnlineAgent.stream_model_turn")
+def test_server_side_history_hydration_in_completion(stream_model_turn, online_agent, client):
     """
     Verify that when calling /agent/complete_text/{session_id} twice,
     the second call's payload includes the prior user/assistant turns.
@@ -49,26 +18,27 @@ def test_server_side_history_hydration_in_completion(mock_make_request, online_a
 
     captured_payloads = []
 
-    def capture_payload(payload, use_backup=False, backup_index=0):
-        captured_payloads.append(payload)
-        return copy.deepcopy(MOCK_COMPLETION_RESPONSE)
+    def capture_messages(messages, _tools, _config):
+        captured_payloads.append({"messages": [message.to_openai() for message in messages]})
+        yield ModelEvent.text_delta(ASSISTANT_REPLY_1)
+        yield ModelEvent.turn_complete(ModelTurn(text=ASSISTANT_REPLY_1, finish_reason="stop"))
 
-    mock_make_request.side_effect = capture_payload
+    stream_model_turn.side_effect = capture_messages
 
     session_id = 4321
 
     # First turn
-    r1 = client.post(f"/agent/complete_text/{session_id}", json={
-        "prompt": "First message",
-        "agent_type": "GPT4AGENT"
-    })
+    r1 = client.post(
+        f"/agent/complete_text/{session_id}",
+        json={"prompt": "First message", "agent_type": "GPT4AGENT"},
+    )
     assert r1.status_code == 200
 
     # Second turn
-    r2 = client.post(f"/agent/complete_text/{session_id}", json={
-        "prompt": "Second message",
-        "agent_type": "GPT4AGENT"
-    })
+    r2 = client.post(
+        f"/agent/complete_text/{session_id}",
+        json={"prompt": "Second message", "agent_type": "GPT4AGENT"},
+    )
     assert r2.status_code == 200
 
     # Ensure we captured both payloads sent to the provider
@@ -90,10 +60,10 @@ def test_server_side_history_hydration_in_completion(mock_make_request, online_a
     assert second_messages[-1]["content"] == "Second message"
 
     # Prior two should be the previous user and assistant reply
-    assert len(second_messages) >= 3, f"Expected at least 3 messages in second call, got {len(second_messages)}"
+    assert (
+        len(second_messages) >= 3
+    ), f"Expected at least 3 messages in second call, got {len(second_messages)}"
     assert second_messages[-3]["role"] == "user"
     assert second_messages[-3]["content"] == "First message"
     assert second_messages[-2]["role"] == "assistant"
     assert second_messages[-2]["content"] == ASSISTANT_REPLY_1
-
-

--- a/tests/agents/test_local_agent_routes.py
+++ b/tests/agents/test_local_agent_routes.py
@@ -8,7 +8,7 @@ runner (registered in conftest) so no model weights are loaded.
 from unittest.mock import patch
 
 from agents.models.agent_completion import AgentCompletion
-from app.main import AgentType, agent_cache, stream_chat_completion
+from app.main import AgentType, agent_cache, run_chat_completion, stream_chat_completion
 from app.models.completion import CompleteTextParams
 from tests.agents.test_online_agent_routes import (
     completions_generator,
@@ -70,6 +70,27 @@ def test_stream_emits_terminal_error_when_agent_initialization_fails():
     assert '"code": "chat_backend_error"' in events[0]
     assert "private initialization detail" not in events[0]
     assert events[1] == 'event: done\ndata: {"run_id": null, "chat_id": null}\n\n'
+
+
+def test_modern_non_streaming_completion_uses_orchestrator_without_tools():
+    class ModernAgent:
+        def stream_model_turn(self, *_args, **_kwargs):
+            raise AssertionError("orchestrator is mocked")
+
+    completion = AgentCompletion(
+        message=["orchestrated"],
+        id="completion",
+        chat_id=8,
+        run_id="run",
+    )
+    params = CompleteTextParams(prompt="continue this chat", enable_tools=False)
+
+    with patch("app.main.chat_orchestrator.complete", return_value=completion) as complete:
+        result = run_chat_completion(params, chat_id=8, agent=ModernAgent())
+
+    assert result == completion
+    assert complete.call_args.kwargs["chat_id"] == 8
+    assert complete.call_args.kwargs["enable_tools"] is False
 
 
 @patch("adapters.log_adapter.LogAdapter.log", autospec=True)

--- a/tests/agents/test_local_agent_routes.py
+++ b/tests/agents/test_local_agent_routes.py
@@ -56,6 +56,22 @@ def test_legacy_stream_generates_completion_once():
     assert events[-1] == ('event: done\ndata: {"run_id": "legacy-run", "chat_id": 14}\n\n')
 
 
+def test_stream_emits_terminal_error_when_agent_initialization_fails():
+    params = CompleteTextParams(prompt="request with unavailable model")
+
+    with patch(
+        "app.main.get_active_agent",
+        side_effect=ValueError("private initialization detail"),
+    ):
+        events = list(stream_chat_completion(params))
+
+    assert len(events) == 2
+    assert "event: error\n" in events[0]
+    assert '"code": "chat_backend_error"' in events[0]
+    assert "private initialization detail" not in events[0]
+    assert events[1] == 'event: done\ndata: {"run_id": null, "chat_id": null}\n\n'
+
+
 @patch("adapters.log_adapter.LogAdapter.log", autospec=True)
 def test_completion(log, local_agent, client):
     log.side_effect = lambda self, output: print(output)

--- a/tests/agents/test_mlx_llama_runner.py
+++ b/tests/agents/test_mlx_llama_runner.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agents.architectures.base_runner import GenerationConfig
+from agents.architectures.llama.mlx_lm_backend import MLXLMBackend
 from agents.architectures.mlx_llama_runner import MLXLlamaRunner
 
 
@@ -90,4 +91,45 @@ def test_generation_config_and_response_contract():
     runner.llama.complete.assert_called_once_with(
         system_prompt="system",
         user_prompt="hello",
+    )
+
+
+def test_structured_messages_reach_mlx_backend_unchanged():
+    runner = MLXLlamaRunner()
+    runner.llama = MagicMock()
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Remember cobalt."},
+        {"role": "assistant", "content": "I will remember cobalt."},
+        {"role": "user", "content": "What should you remember?"},
+    ]
+    runner.llama.complete_messages.return_value = [
+        {"role": "user", "content": messages[-1]["content"]},
+        {"role": "assistant", "content": "cobalt"},
+    ]
+
+    result = runner.complete_messages(messages, GenerationConfig(max_tokens=12))
+
+    assert result[-1]["content"] == "cobalt"
+    runner.llama.complete_messages.assert_called_once_with(messages)
+
+
+def test_mlx_lm_prompt_uses_native_roles_for_conversation_history():
+    backend = MLXLMBackend.__new__(MLXLMBackend)
+    backend.tokenizer = MagicMock()
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Remember cobalt."},
+        {"role": "assistant", "content": "I will remember cobalt."},
+        {"role": "user", "content": "What should you remember?"},
+    ]
+    backend.tokenizer.apply_chat_template.return_value = "rendered prompt"
+
+    prompt = backend._build_messages_prompt(messages)
+
+    assert prompt == "rendered prompt"
+    backend.tokenizer.apply_chat_template.assert_called_once_with(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
     )

--- a/tests/agents/test_model_catalog.py
+++ b/tests/agents/test_model_catalog.py
@@ -98,6 +98,37 @@ def test_explicit_runner_override_allows_large_local_model():
     assert local_agent.call_args.kwargs["device_config"]["allow_server_backed"] is True
 
 
+def test_environment_runner_override_precedes_catalog_inference():
+    context = MagicMock()
+    with (
+        patch.dict(os.environ, {"GEIST_LOCAL_RUNNER": "transformers"}),
+        patch("agents.local_agent.LocalAgent") as local_agent,
+    ):
+        AgentFactory.create_agent(
+            "local",
+            context,
+            model="meta-llama/Meta-Llama-3.1-8B-Instruct",
+        )
+
+    assert local_agent.call_args.kwargs["runner_type"] == "transformers"
+
+
+def test_explicit_runner_argument_precedes_environment_override():
+    context = MagicMock()
+    with (
+        patch.dict(os.environ, {"GEIST_LOCAL_RUNNER": "transformers"}),
+        patch("agents.local_agent.LocalAgent") as local_agent,
+    ):
+        AgentFactory.create_agent(
+            "local",
+            context,
+            model="meta-llama/Meta-Llama-3.1-8B-Instruct",
+            runner_type="mlx_llama",
+        )
+
+    assert local_agent.call_args.kwargs["runner_type"] == "mlx_llama"
+
+
 def test_existing_llama_id_preserves_optimized_runner():
     assert AgentFactory._infer_runner_type(
         "meta-llama/Meta-Llama-3.1-8B-Instruct"

--- a/tests/agents/test_native_tool_turns.py
+++ b/tests/agents/test_native_tool_turns.py
@@ -406,9 +406,19 @@ def test_native_tool_capability_is_known_provider_or_explicit_override():
 
 
 class LocalRunner:
+    def __init__(self):
+        self.messages = None
+
     def complete(self, system_prompt, user_prompt, generation_config):
         return [
             {"role": "user", "content": user_prompt},
+            {"role": "assistant", "content": "local answer"},
+        ]
+
+    def complete_messages(self, messages, generation_config):
+        self.messages = messages
+        return [
+            {"role": "user", "content": messages[-1]["content"]},
             {"role": "assistant", "content": "local answer"},
         ]
 
@@ -443,3 +453,22 @@ def test_local_runner_can_complete_persistence_free_without_tools():
     )
     assert events[0].text == "local answer"
     assert events[-1].turn.text == "local answer"
+
+
+def test_local_runner_preserves_structured_conversation_roles():
+    agent = local_agent_without_loading_model()
+    messages = [
+        ChatMessage(role="system", content="Be concise."),
+        ChatMessage(role="user", content="Remember cobalt."),
+        ChatMessage(role="assistant", content="I will remember cobalt."),
+        ChatMessage(role="user", content="What should you remember?"),
+    ]
+
+    list(agent.stream_model_turn(messages, [], ModelRequestConfig()))
+
+    assert agent.runner.messages == [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Remember cobalt."},
+        {"role": "assistant", "content": "I will remember cobalt."},
+        {"role": "user", "content": "What should you remember?"},
+    ]

--- a/tests/agents/test_online_agent_routes.py
+++ b/tests/agents/test_online_agent_routes.py
@@ -5,86 +5,88 @@ These cover the behavior formerly exercised through GPT4Agent: text completion
 via /agent/complete_text, and the OODA tick loop (task expansion + adapter
 function dispatch) via /agent/initialize_task_and_tick.
 """
+
 from unittest.mock import patch
 
 from agents.base_agent import EXECUTION_TICK_PROMPT, TASK_TICK_PROMPT, WORLD_TICK_PROMPT
+from agents.models.tool_calling import ModelEvent, ModelTurn
 from app.main import AgentType, agent_cache
 
 
 HAIKU_COMPLETION = {
-  "id": "chatcmpl-AHZzoFcxDG62aTvWx1jS0a2VGkitH",
-  "object": "chat.completion",
-  "created": 1728753308,
-  "model": "gpt-4-0613",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "Silent orb of night,\nGlowing in soft silver light,\nGuiding",
-        "refusal": None
-      },
-      "logprobs": None,
-      "finish_reason": "length"
-    }
-  ],
-  "usage": {
-    "prompt_tokens": 14,
-    "completion_tokens": 16,
-    "total_tokens": 30,
-    "prompt_tokens_details": {
-      "cached_tokens": 0
+    "id": "chatcmpl-AHZzoFcxDG62aTvWx1jS0a2VGkitH",
+    "object": "chat.completion",
+    "created": 1728753308,
+    "model": "gpt-4-0613",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Silent orb of night,\nGlowing in soft silver light,\nGuiding",
+                "refusal": None,
+            },
+            "logprobs": None,
+            "finish_reason": "length",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 14,
+        "completion_tokens": 16,
+        "total_tokens": 30,
+        "prompt_tokens_details": {"cached_tokens": 0},
+        "completion_tokens_details": {"reasoning_tokens": 0},
     },
-    "completion_tokens_details": {
-      "reasoning_tokens": 0
-    }
-  },
-  "system_fingerprint": None
+    "system_fingerprint": None,
 }
 
-#by convention, if EXISTS is set for a key, existence is checked but not equivalence
+# by convention, if EXISTS is set for a key, existence is checked but not equivalence
 agent_completion = {
-    "chat_id" : "EXISTS",
-    "message" : ["Silent orb of night,\nGlowing in soft silver light,\nGuiding"],
-    "id" : "EXISTS",
+    "chat_id": "EXISTS",
+    "message": ["Silent orb of night,\nGlowing in soft silver light,\nGuiding"],
+    "id": "EXISTS",
 }
+
 
 def is_function_prompt(prompt: str) -> bool:
-    return 'Only call functions that are listed in our adapter list.' in prompt
+    return "Only call functions that are listed in our adapter list." in prompt
+
 
 def is_task_prompt(prompt: str) -> bool:
-    return 'actionable tasks' in prompt
+    return "actionable tasks" in prompt
+
 
 def completions_generator(prompt: str) -> dict:
-    '''
+    """
     Trivial mock completions function that outputs a modified version of the prompt for the output.
-    '''
+    """
     is_function_prompt_flag = is_function_prompt(prompt)
     is_task_prompt_flag = is_task_prompt(prompt)
     base_completion = {
-        "choices":
-        [
-            {"message": {'content': f"{prompt}:completion1"}},
-            {"message": {'content': f"{prompt}:completion2"}}
+        "choices": [
+            {"message": {"content": f"{prompt}:completion1"}},
+            {"message": {"content": f"{prompt}:completion2"}},
         ]
     }
     task_completion = {
-        "choices":
-        [
-            {"message" : {'content': "log the beginning of a haiku"}},
-            {"message" : {'content': "log the end of a haiku"}}
+        "choices": [
+            {"message": {"content": "log the beginning of a haiku"}},
+            {"message": {"content": "log the end of a haiku"}},
         ]
     }
     function_completion = {
-        "choices":
-        [
-            {"message": {'content': """{
+        "choices": [
+            {
+                "message": {
+                    "content": """{
     \"class\" : \"LogAdapter\",
     \"function\": \"log\",
     \"parameters\": {
         \"output\": \"logging a haiku!\"
     }
-}"""}}
+}"""
+                }
+            }
         ]
     }
     if is_function_prompt_flag:
@@ -108,10 +110,16 @@ def test_assert_prompt_invariants():
     assert not is_task_prompt(EXECUTION_TICK_PROMPT) and is_function_prompt(EXECUTION_TICK_PROMPT)
 
 
-@patch('agents.online_agent.OnlineAgent._make_request')
-@patch('adapters.log_adapter.LogAdapter.log', autospec=True)
-def test_completion(log, make_request, online_agent, client):
-    make_request.return_value = HAIKU_COMPLETION
+@patch("agents.online_agent.OnlineAgent.stream_model_turn")
+@patch("adapters.log_adapter.LogAdapter.log", autospec=True)
+def test_completion(log, stream_model_turn, online_agent, client):
+    response_text = HAIKU_COMPLETION["choices"][0]["message"]["content"]
+    stream_model_turn.return_value = iter(
+        [
+            ModelEvent.text_delta(response_text),
+            ModelEvent.turn_complete(ModelTurn(text=response_text, finish_reason="length")),
+        ]
+    )
     log.side_effect = lambda self, output: print(output)
     agent_cache[AgentType.GPT4AGENT] = online_agent
     try:
@@ -120,20 +128,16 @@ def test_completion(log, make_request, online_agent, client):
             "prompt": "write a haiku about the moon",
             "max_tokens": 1024,
             "n": 1,
-            "stop": [
-                "string"
-            ],
+            "stop": ["string"],
             "temperature": 1,
             "top_p": 1,
             "frequency_penalty": 0,
             "presence_penalty": 0,
             "echo": False,
             "best_of": 0,
-            "prompt_tokens": [
-                0
-            ],
+            "prompt_tokens": [0],
             "response_format": "text",
-            "agent_type": "GPT4AGENT"
+            "agent_type": "GPT4AGENT",
         }
 
         # send the request
@@ -151,17 +155,14 @@ def test_completion(log, make_request, online_agent, client):
         agent_cache[AgentType.GPT4AGENT] = None
 
 
-@patch('agents.online_agent.OnlineAgent.complete_text')
-@patch('adapters.log_adapter.LogAdapter.log', autospec=True)
+@patch("agents.online_agent.OnlineAgent.complete_text")
+@patch("adapters.log_adapter.LogAdapter.log", autospec=True)
 def test_tick_with_prompt_and_world_processing(log, complete_text, online_agent, client):
     complete_text.side_effect = lambda prompt: completions_generator(prompt=prompt)
     log.side_effect = lambda self, output: print(output)
     agent_cache[AgentType.GPT4AGENT] = online_agent
     try:
-        payload = {
-            "prompt": "Write a haiku",
-            "agent_type": "GPT4AGENT"
-        }
+        payload = {"prompt": "Write a haiku", "agent_type": "GPT4AGENT"}
 
         response = client.post("agent/initialize_task_and_tick", json=payload)
 
@@ -172,40 +173,37 @@ def test_tick_with_prompt_and_world_processing(log, complete_text, online_agent,
         # the world context; the task is popped and expanded, and both resulting
         # subtasks are executed as LogAdapter.log function calls.
         assert response_payload == {
-            'world_context': expected_world_context("Write a haiku"),
-            'task_context': [],
-            'execution_context': []
+            "world_context": expected_world_context("Write a haiku"),
+            "task_context": [],
+            "execution_context": [],
         }
         assert log.call_count == 2
     finally:
         agent_cache[AgentType.GPT4AGENT] = None
 
 
-@patch('agents.online_agent.OnlineAgent.complete_text')
-@patch('adapters.log_adapter.LogAdapter.log', autospec=True)
-def test_tick_with_prompt_without_world_processing(log, complete_text, process_world_variation_online_agents, client):
+@patch("agents.online_agent.OnlineAgent.complete_text")
+@patch("adapters.log_adapter.LogAdapter.log", autospec=True)
+def test_tick_with_prompt_without_world_processing(
+    log, complete_text, process_world_variation_online_agents, client
+):
     complete_text.side_effect = lambda prompt: completions_generator(prompt=prompt)
     log.side_effect = lambda self, output: print(output)
     no_world_agent = next(
-        agent for agent in process_world_variation_online_agents
-        if not agent._agent_context.settings.include_world_processing)
+        agent
+        for agent in process_world_variation_online_agents
+        if not agent._agent_context.settings.include_world_processing
+    )
     agent_cache[AgentType.GPT4AGENT] = no_world_agent
     try:
-        payload = {
-            "prompt": "Write a haiku",
-            "agent_type": "GPT4AGENT"
-        }
+        payload = {"prompt": "Write a haiku", "agent_type": "GPT4AGENT"}
 
         response = client.post("agent/initialize_task_and_tick", json=payload)
 
         assert response.status_code == 200
         # Without world processing the world tick is skipped entirely, the task
         # is consumed, and execution drains the generated subtasks.
-        assert response.json() == {
-            'world_context': [],
-            'task_context': [],
-            'execution_context': []
-        }
+        assert response.json() == {"world_context": [], "task_context": [], "execution_context": []}
         assert log.call_count == 2
     finally:
         agent_cache[AgentType.GPT4AGENT] = None

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -1,4 +1,5 @@
 """Unit tests for the generic Transformers causal-LM runner."""
+
 import os
 from collections import UserDict
 from unittest.mock import MagicMock, patch
@@ -65,6 +66,28 @@ def test_load_and_generate_uses_direct_suffix_decode(
     assert result[1]["content"] == "fast response"
 
 
+def test_complete_messages_preserves_structured_conversation_roles():
+    runner = TransformersRunner()
+    runner.model_id = "test/model"
+    runner.model = _model()
+    runner.tokenizer = _tokenizer()
+    runner.config = MagicMock(max_position_embeddings=64)
+    messages = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Remember cobalt."},
+        {"role": "assistant", "content": "I will remember cobalt."},
+        {"role": "user", "content": "What should you remember?"},
+    ]
+
+    runner.complete_messages(
+        messages,
+        GenerationConfig(max_tokens=8, temperature=0.0),
+    )
+
+    applied_messages = runner.tokenizer.apply_chat_template.call_args.args[0]
+    assert applied_messages == messages
+
+
 @patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
 @patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
 @patch("agents.architectures.transformers_runner.AutoTokenizer")
@@ -118,23 +141,21 @@ def test_mapping_like_batch_encoding_and_system_role_fallback():
     runner.model = _model()
     runner.tokenizer = _tokenizer()
     runner.config = MagicMock(max_position_embeddings=64)
-    encoded = UserDict({
-        "input_ids": torch.tensor([[1, 2, 3]]),
-        "attention_mask": torch.tensor([[1, 1, 1]]),
-    })
+    encoded = UserDict(
+        {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "attention_mask": torch.tensor([[1, 1, 1]]),
+        }
+    )
     runner.tokenizer.apply_chat_template.side_effect = [
         ValueError("system role unsupported"),
         encoded,
     ]
 
-    runner.complete(
-        "Be concise", "hello", GenerationConfig(max_tokens=4, temperature=0.0)
-    )
+    runner.complete("Be concise", "hello", GenerationConfig(max_tokens=4, temperature=0.0))
 
     fallback_messages = runner.tokenizer.apply_chat_template.call_args.args[0]
-    assert fallback_messages == [
-        {"role": "user", "content": "Be concise\n\nhello"}
-    ]
+    assert fallback_messages == [{"role": "user", "content": "Be concise\n\nhello"}]
     kwargs = runner.model.generate.call_args.kwargs
     assert {"input_ids", "attention_mask"}.issubset(kwargs)
 
@@ -168,9 +189,7 @@ def test_cuda_uses_accelerate_without_duplicate_device_copy(
     model.hf_device_map = {"": 0}
     model_cls.from_pretrained.return_value = model
 
-    with patch.object(
-        TransformersRunner, "_select_device", return_value=torch.device("cuda")
-    ):
+    with patch.object(TransformersRunner, "_select_device", return_value=torch.device("cuda")):
         TransformersRunner().load("Qwen/Qwen2.5-3B-Instruct")
 
     kwargs = model_cls.from_pretrained.call_args.kwargs
@@ -183,9 +202,7 @@ def test_cuda_uses_accelerate_without_duplicate_device_copy(
 @patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
 @patch("agents.architectures.transformers_runner.AutoTokenizer")
 @patch("agents.architectures.transformers_runner.AutoConfig")
-def test_mps_defaults_to_stable_eager_attention(
-    config_cls, tokenizer_cls, model_cls, _find_spec
-):
+def test_mps_defaults_to_stable_eager_attention(config_cls, tokenizer_cls, model_cls, _find_spec):
     config_cls.from_pretrained.return_value = MagicMock(architectures=["SmolLMForCausalLM"])
     tokenizer_cls.from_pretrained.return_value = _tokenizer()
     model_cls.from_pretrained.return_value = _model()
@@ -218,9 +235,7 @@ def test_server_backed_model_fails_before_loading():
 def test_explicit_override_can_load_server_backed_text_model(
     config_cls, tokenizer_cls, model_cls, _find_spec
 ):
-    config_cls.from_pretrained.return_value = MagicMock(
-        architectures=["Glm4MoeLiteForCausalLM"]
-    )
+    config_cls.from_pretrained.return_value = MagicMock(architectures=["Glm4MoeLiteForCausalLM"])
     tokenizer_cls.from_pretrained.return_value = _tokenizer()
     model_cls.from_pretrained.return_value = _model()
 

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -1,4 +1,5 @@
 """Unit tests for the generic Transformers causal-LM runner."""
+import os
 from collections import UserDict
 from unittest.mock import MagicMock, patch
 
@@ -62,6 +63,33 @@ def test_load_and_generate_uses_direct_suffix_decode(
     decoded_ids = tokenizer.decode.call_args.args[0]
     assert decoded_ids.tolist() == [8, 9]
     assert result[1]["content"] == "fast response"
+
+
+@patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)
+@patch("agents.architectures.transformers_runner.AutoModelForCausalLM")
+@patch("agents.architectures.transformers_runner.AutoTokenizer")
+@patch("agents.architectures.transformers_runner.AutoConfig")
+def test_default_llama_uses_existing_legacy_weights_directory(
+    config_cls, tokenizer_cls, model_cls, _find_spec, tmp_path, monkeypatch
+):
+    weights_dir = tmp_path / "app" / "model_weights" / "llama_3_1"
+    weights_dir.mkdir(parents=True)
+    (weights_dir / "config.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+    config_cls.from_pretrained.return_value = MagicMock(architectures=["LlamaForCausalLM"])
+    tokenizer_cls.from_pretrained.return_value = _tokenizer()
+    model_cls.from_pretrained.return_value = _model()
+
+    TransformersRunner().load(
+        "meta-llama/Meta-Llama-3.1-8B-Instruct",
+        {"device": "cpu"},
+    )
+
+    expected_source = os.path.join("app", "model_weights", "llama_3_1")
+    config_cls.from_pretrained.assert_called_once_with(
+        expected_source,
+        trust_remote_code=False,
+    )
 
 
 @patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)

--- a/tests/e2e_server.py
+++ b/tests/e2e_server.py
@@ -1,0 +1,44 @@
+"""Run Geist with a deterministic chat agent for browser end-to-end tests."""
+
+import os
+from typing import Any
+
+import uvicorn
+
+from agents.models.agent_completion import AgentCompletion
+from initdb import main as initialize_database
+
+
+class BrowserE2EAgent:
+    """Exercise the production legacy-agent SSE adapter without loading a model."""
+
+    def complete_text(self, **kwargs: Any) -> AgentCompletion:
+        if kwargs["prompt"] == "Trigger backend failure":
+            raise RuntimeError("browser e2e injected failure")
+        return AgentCompletion(
+            message=["E2E chat works."],
+            id="e2e-completion",
+            chat_id=101,
+            run_id="e2e-run",
+        )
+
+
+def run_server() -> None:
+    initialize_database()
+
+    import app.main as geist_main
+
+    def get_e2e_agent(_agent_type: Any) -> BrowserE2EAgent:
+        return BrowserE2EAgent()
+
+    geist_main.get_active_agent = get_e2e_agent
+    uvicorn.run(
+        geist_main.app,
+        host=os.getenv("GEIST_E2E_BACKEND_HOST", "127.0.0.1"),
+        port=int(os.getenv("GEIST_E2E_BACKEND_PORT", "5100")),
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    run_server()

--- a/tests/e2e_server.py
+++ b/tests/e2e_server.py
@@ -5,22 +5,37 @@ from typing import Any
 
 import uvicorn
 
-from agents.models.agent_completion import AgentCompletion
+from agents.models.tool_calling import ChatMessage, ModelEvent, ModelTurn
 from initdb import main as initialize_database
 
 
 class BrowserE2EAgent:
-    """Exercise the production legacy-agent SSE adapter without loading a model."""
+    """Exercise the production orchestrator without loading a model."""
 
-    def complete_text(self, **kwargs: Any) -> AgentCompletion:
-        if kwargs["prompt"] == "Trigger backend failure":
-            raise RuntimeError("browser e2e injected failure")
-        return AgentCompletion(
-            message=["E2E chat works."],
-            id="e2e-completion",
-            chat_id=101,
-            run_id="e2e-run",
+    supports_native_tool_calling = False
+
+    def stream_model_turn(
+        self,
+        messages: list[ChatMessage],
+        _tools: list[Any],
+        _config: Any,
+    ):
+        prompt = next(
+            message.content or "" for message in reversed(messages) if message.role == "user"
         )
+        if prompt == "Trigger backend failure":
+            raise RuntimeError("browser e2e injected failure")
+        if prompt == "Remember cobalt.":
+            response = "I will remember cobalt."
+        elif prompt == "What should you remember?":
+            prior_user_messages = [
+                message.content for message in messages[:-1] if message.role == "user"
+            ]
+            response = "cobalt" if "Remember cobalt." in prior_user_messages else "missing context"
+        else:
+            response = "E2E chat works."
+        yield ModelEvent.text_delta(response)
+        yield ModelEvent.turn_complete(ModelTurn(text=response, finish_reason="stop"))
 
 
 def run_server() -> None:


### PR DESCRIPTION
## Summary

- Emit terminal, sanitized `error` and `done` SSE events when chat agent/model startup fails, so the UI cannot remain stuck in `connecting`.
- Introduce scoped `ConversationState` and `AgentRunContext` objects while keeping `AgentContext` agent-wide and retaining the existing SQLAlchemy chat-history persistence helpers (no new repository layer).
- Route modern streaming and non-streaming agents through the same chat orchestrator, including when tools are disabled.
- Preserve structured system/user/assistant/tool roles through LocalAgent, MLX, mlx-lm, and Transformers runners instead of flattening history into prompt text.
- Navigate newly persisted chats to `/chat/{id}`, prevent the active turn from being rendered twice after history refresh, and extend Playwright coverage for success, persisted follow-up context, reload, and failure recovery.
- Make local-runner selection explicit in Docker, reuse the existing `llama_3_1` weight directory for Transformers, constrain native reload watching to source directories, and run the browser suite in CI.

## Root cause

The streaming response headers were sent before model initialization completed, so a generator exception could terminate the connection without a terminal SSE event. Conversation history was also flattened at the LocalAgent boundary, while streaming and non-streaming requests could take different persistence paths. That discarded native role structure and made run/tool/persistence state live as unrelated local variables rather than one snapshot-friendly run object. The frontend then had no route transition for a newly created chat and could briefly render the same persisted run twice.

## Validation

- `PYTHONPATH=/tmp/geist-main-ui .venv/bin/pytest -q` — 423 passed, 4 skipped
- Focused state/orchestrator/runner/route tests — 53 passed
- `CI=true npm test -- --watchAll=false --passWithNoTests` — 13 suites / 55 tests passed
- `GEIST_E2E_USE_BUNDLED_CHROMIUM=1 npm run test:e2e` — 3 passed with zero console errors
- `npm run build` — passed (existing `useVoiceChat.tsx` hook warning remains)
- Ruff and mypy on changed Python — passed
- Docker Compose startup — backend healthy; frontend `/` and backend settings endpoint returned 200
- Native `make run MLX_BACKEND=1` chat — persisted `/chat/4356`, returned `STORED`, recalled `NEBULA_731` on the second turn, and retained both turns after reload

## Security

- Staged private-key and secret scans passed.
- Diff review found no new injection, credential exposure, unsafe deserialization, access-control, or XSS path.
- Detailed backend exceptions remain server-side while the client receives a generic completion error.
- No dependency or lockfile changes were added by the state refactor. `npm audit --package-lock-only` still reports the same 72 pre-existing transitive findings (15 low, 22 moderate, 31 high, 4 critical).
- Repository-wide pre-commit still reports unrelated existing mypy, Bandit bind-all-interfaces, and legacy frontend-test lint debt; change-scoped lint/type/tests pass.