### PR TITLE
Add provider API key management and UI-driven model downloads

### DIFF
--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -121,7 +121,12 @@ class OnlineAgent(BaseAgent):
         )
 
     def _get_api_key_from_env(self) -> str | None:
-        """Get provider-specific API key from environment variables based on the endpoint."""
+        """Resolve the endpoint's API key: stored credential first, then environment."""
+        provider_id = self._provider_id_for_base_url()
+        if provider_id:
+            stored = self._get_stored_api_key(provider_id)
+            if stored:
+                return stored
         for provider in PROVIDERS.values():
             if provider.base_url and provider.base_url.rstrip("/") in self.base_url:
                 return os.getenv(provider.api_key_env)
@@ -134,6 +139,38 @@ class OnlineAgent(BaseAgent):
         elif "x.ai" in self.base_url:  # Grok
             return os.getenv("GROK_API_KEY")
         return None
+
+    def _provider_id_for_base_url(self) -> str | None:
+        """Map this agent's endpoint to a managed provider ID."""
+        for provider in PROVIDERS.values():
+            if provider.base_url and provider.base_url.rstrip("/") in self.base_url:
+                return provider.id
+        if "openai.com" in self.base_url:
+            return "openai"
+        if "anthropic" in self.base_url:
+            return "anthropic"
+        if "groq.com" in self.base_url:
+            return "groq"
+        if "x.ai" in self.base_url:
+            return "xai"
+        return None
+
+    @staticmethod
+    def _get_stored_api_key(provider_id: str) -> str | None:
+        """
+        Look up a key saved through the Settings UI.
+
+        Imported lazily and swallowed on failure so agents constructed without
+        an application database (unit tests, scripts) keep working.
+        """
+        try:
+            from app.models.database.geist_user import get_default_user
+            from app.models.database.provider_credential import get_provider_credential
+
+            credential = get_provider_credential(get_default_user().user_id, provider_id)
+            return credential.api_key if credential else None
+        except Exception:
+            return None
 
     def _make_request(
         self, payload: dict[str, Any], use_backup: bool = False, backup_index: int = 0

--- a/app/api/v1/endpoints/models.py
+++ b/app/api/v1/endpoints/models.py
@@ -4,8 +4,8 @@ API endpoints for model discovery and listing.
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 
 from agents.architectures.registry import (
     get_all_models,
@@ -16,6 +16,8 @@ from agents.architectures.registry import (
     provider_from_string,
     provider_to_string,
 )
+from app.models.database.geist_user import get_default_user
+from app.services.model_downloads import enqueue_model_download, local_model_statuses
 
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,59 @@ class ModelsListResponse(BaseModel):
     last_updated: datetime | None
 
 
+class LocalModelStatus(BaseModel):
+    """Download state of one catalog model in the packed weights folder."""
+    id: str
+    name: str
+    family: str | None
+    backend: str | None
+    gated: bool
+    parameter_count: str | None
+    downloaded: bool
+    weights_path: str
+    size_bytes: int
+    download_status: str | None = None
+    download_job_id: int | None = None
+    download_error: str | None = None
+
+
+class DetectedWeightsDirectory(BaseModel):
+    """A weights directory present on disk but not mapped to a catalog model."""
+    directory: str
+    weights_path: str
+    size_bytes: int
+
+
+class LocalModelsResponse(BaseModel):
+    """Local weight inventory for the packed weights folder."""
+    models: list[LocalModelStatus]
+    detected_directories: list[DetectedWeightsDirectory]
+    weights_root: str
+
+
+class ModelDownloadRequest(BaseModel):
+    """Request body for queueing a model weight download."""
+    model_id: str = Field(min_length=1, max_length=512)
+    revision: str | None = Field(default=None, max_length=256)
+    force: bool = False
+
+
+class ModelDownloadResponse(BaseModel):
+    """The queued (or already active) download job."""
+    job_id: int
+    model_id: str
+    status: str
+    error: str | None = None
+
+
+def get_current_user():
+    """
+    Get current user (placeholder - should integrate with actual auth system).
+    For now, returns the default user.
+    """
+    return get_default_user()
+
+
 @router.get("/", response_model=ModelsListResponse)
 async def get_available_models():
     """
@@ -78,6 +133,49 @@ async def get_available_models():
     except Exception as e:
         logger.error(f"Error getting available models: {e}")
         raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get("/local", response_model=LocalModelsResponse)
+async def get_local_models(current_user = Depends(get_current_user)):
+    """
+    Get downloadable catalog models with their packed-weights state, plus any
+    extra weight directories detected on disk.
+    """
+    try:
+        return local_model_statuses(user_id=current_user.user_id)
+    except Exception as e:
+        logger.error(f"Error getting local model statuses: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/download", response_model=ModelDownloadResponse, status_code=202)
+async def download_model(
+    request: ModelDownloadRequest,
+    current_user = Depends(get_current_user),
+):
+    """
+    Queue a background download of one local catalog model from Hugging Face
+    into the packed weights folder. Poll /local for progress.
+    """
+    try:
+        job = enqueue_model_download(
+            request.model_id,
+            user_id=current_user.user_id,
+            revision=request.revision,
+            force=request.force,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"Error queueing download for '{request.model_id}': {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+    return ModelDownloadResponse(
+        job_id=job["job_id"],
+        model_id=(job.get("payload") or {}).get("model_id", request.model_id),
+        status=job["status"],
+        error=job.get("error"),
+    )
 
 
 @router.get("/provider/{provider}", response_model=list[ModelResponse])

--- a/app/api/v1/endpoints/providers.py
+++ b/app/api/v1/endpoints/providers.py
@@ -1,0 +1,109 @@
+"""
+API endpoints for managing provider API keys.
+
+Keys are write-only over HTTP: responses carry configuration state and a
+masked hint, never the stored key itself.
+"""
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.models.database.geist_user import get_default_user
+from app.services.provider_keys import (
+    provider_key_statuses,
+    remove_provider_key,
+    store_provider_key,
+)
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def get_current_user():
+    """
+    Get current user (placeholder - should integrate with actual auth system).
+    For now, returns the default user.
+    """
+    return get_default_user()
+
+
+class ProviderKeyStatus(BaseModel):
+    """Key configuration state for one provider; never includes the raw key."""
+    id: str
+    name: str
+    description: str
+    api_key_env: str
+    env_configured: bool
+    has_stored_key: bool
+    key_hint: str | None = None
+    supports_base_url: bool = False
+    base_url: str | None = None
+    updated_at: str | None = None
+
+
+class ProviderKeyUpdate(BaseModel):
+    """Request body for storing a provider API key."""
+    api_key: str = Field(min_length=1, max_length=4096)
+    base_url: str | None = Field(default=None, max_length=2048)
+
+
+@router.get("/", response_model=list[ProviderKeyStatus])
+async def list_providers(current_user = Depends(get_current_user)):
+    """List managed providers with their key configuration state."""
+    try:
+        return provider_key_statuses(current_user.user_id)
+    except Exception as e:
+        logger.error(f"Error listing provider key statuses: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.put("/{provider_id}/key", response_model=ProviderKeyStatus)
+async def put_provider_key(
+    provider_id: str,
+    update: ProviderKeyUpdate,
+    current_user = Depends(get_current_user),
+):
+    """Store or replace the API key for one provider."""
+    try:
+        store_provider_key(
+            current_user.user_id,
+            provider_id,
+            update.api_key,
+            base_url=update.base_url,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"Error storing provider key for '{provider_id}': {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+    for status in provider_key_statuses(current_user.user_id):
+        if status["id"] == provider_id.strip().lower():
+            return status
+    raise HTTPException(status_code=404, detail=f"Unknown provider: {provider_id}")
+
+
+@router.delete("/{provider_id}/key", response_model=ProviderKeyStatus)
+async def delete_provider_key(
+    provider_id: str,
+    current_user = Depends(get_current_user),
+):
+    """Remove the stored API key for one provider."""
+    try:
+        removed = remove_provider_key(current_user.user_id, provider_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error(f"Error removing provider key for '{provider_id}': {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+    if not removed:
+        raise HTTPException(status_code=404, detail="No stored key for this provider")
+
+    for status in provider_key_statuses(current_user.user_id):
+        if status["id"] == provider_id.strip().lower():
+            return status
+    raise HTTPException(status_code=404, detail=f"Unknown provider: {provider_id}")

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.api.v1.endpoints.files import router as files_router
 from app.api.v1.endpoints.jobs import router as jobs_router
 from app.api.v1.endpoints.memory import router as memory_router
 from app.api.v1.endpoints.models import router as models_router
+from app.api.v1.endpoints.providers import router as providers_router
 from app.api.v1.endpoints.user_settings import router as user_settings_router
 from app.api.v1.endpoints.voice import router as voice_router
 from app.api.v1.endpoints.workflows import router as workflow_router
@@ -46,6 +47,7 @@ from app.services.job_queue import start_worker, stop_worker
 from app.services.memory_context import build_memory_context
 from app.services.memory_scheduler import MEMORY_JOB_KIND  # noqa: F401
 from app.services.memory_service import get_chat_memory_settings
+from app.services.model_downloads import DOWNLOAD_JOB_KIND  # noqa: F401  (registers handler)
 from app.services.tool_registry import build_default_tool_registry
 from app.services.user_settings_service import UserSettingsService
 
@@ -456,6 +458,7 @@ def create_app():
     app.include_router(user_settings_router, prefix="/api/v1/user-settings", tags=["user-settings"])
     app.include_router(voice_router, prefix="/api/v1/voice", tags=["voice"])
     app.include_router(models_router, prefix="/api/v1/models", tags=["models"])
+    app.include_router(providers_router, prefix="/api/v1/providers", tags=["providers"])
     app.include_router(jobs_router, prefix="/api/v1/jobs", tags=["jobs"])
     app.include_router(memory_router, prefix="/api/v1/memory", tags=["memory"])
 

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -6,5 +6,6 @@ from app.models.database.file_upload import FileUpload
 from app.models.database.geist_user import GeistUser
 from app.models.database.job import Job
 from app.models.database.memory import MemoryEmbedding, MemoryFolder, MemoryRecord
+from app.models.database.provider_credential import ProviderCredential
 from app.models.database.user_settings import UserSettings
 from app.models.database.workflow import Workflow, WorkflowRun, WorkflowStep, WorkflowStepResult

--- a/app/models/database/provider_credential.py
+++ b/app/models/database/provider_credential.py
@@ -1,0 +1,126 @@
+"""
+ProviderCredential database model for storing per-provider API keys.
+
+Keys entered through the UI land here so online providers and gated
+Hugging Face downloads work without editing the server's .env file.
+Raw keys never leave the backend: API responses only carry a masked hint.
+"""
+import datetime
+from dataclasses import dataclass
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+
+from app.models.database.database import Base, SessionLocal
+
+
+class ProviderCredential(Base):
+    """
+    One stored API key (and optional base URL) per user and provider.
+    """
+    __tablename__ = 'provider_credential'
+    __table_args__ = (
+        UniqueConstraint('user_id', 'provider_id', name='uq_provider_credential_user_provider'),
+    )
+
+    provider_credential_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('geist_user.user_id'), nullable=False, index=True)
+    provider_id = Column(String, nullable=False)
+    api_key = Column(String, nullable=False)
+    base_url = Column(String, nullable=True)
+
+    create_date = Column(DateTime, default=datetime.datetime.utcnow)
+    update_date = Column(
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+    )
+
+
+@dataclass
+class ProviderCredentialModel:
+    """
+    Data model for a stored provider credential.
+    """
+    provider_credential_id: int
+    user_id: int
+    provider_id: str
+    api_key: str
+    base_url: str | None
+    create_date: datetime.datetime
+    update_date: datetime.datetime
+
+
+def _to_model(credential: ProviderCredential) -> ProviderCredentialModel:
+    return ProviderCredentialModel(
+        provider_credential_id=credential.provider_credential_id,
+        user_id=credential.user_id,
+        provider_id=credential.provider_id,
+        api_key=credential.api_key,
+        base_url=credential.base_url,
+        create_date=credential.create_date,
+        update_date=credential.update_date,
+    )
+
+
+def upsert_provider_credential(
+    user_id: int,
+    provider_id: str,
+    api_key: str,
+    base_url: str | None = None,
+) -> ProviderCredentialModel:
+    """Create or replace the stored key for one user/provider pair."""
+    normalized_provider = provider_id.strip().lower()
+    with SessionLocal() as session:
+        credential = (
+            session.query(ProviderCredential)
+            .filter_by(user_id=user_id, provider_id=normalized_provider)
+            .first()
+        )
+        if credential is None:
+            credential = ProviderCredential(
+                user_id=user_id,
+                provider_id=normalized_provider,
+                api_key=api_key,
+                base_url=base_url,
+            )
+            session.add(credential)
+        else:
+            credential.api_key = api_key
+            credential.base_url = base_url
+            credential.update_date = datetime.datetime.utcnow()
+        session.commit()
+        session.refresh(credential)
+        return _to_model(credential)
+
+
+def get_provider_credential(user_id: int, provider_id: str) -> ProviderCredentialModel | None:
+    """Return the stored credential for one user/provider pair, if any."""
+    with SessionLocal() as session:
+        credential = (
+            session.query(ProviderCredential)
+            .filter_by(user_id=user_id, provider_id=provider_id.strip().lower())
+            .first()
+        )
+        return _to_model(credential) if credential else None
+
+
+def list_provider_credentials(user_id: int) -> list[ProviderCredentialModel]:
+    """Return all stored credentials for a user."""
+    with SessionLocal() as session:
+        credentials = (
+            session.query(ProviderCredential)
+            .filter_by(user_id=user_id)
+            .order_by(ProviderCredential.provider_id)
+            .all()
+        )
+        return [_to_model(credential) for credential in credentials]
+
+
+def delete_provider_credential(user_id: int, provider_id: str) -> bool:
+    """Delete the stored credential for one user/provider pair."""
+    with SessionLocal() as session:
+        deleted = (
+            session.query(ProviderCredential)
+            .filter_by(user_id=user_id, provider_id=provider_id.strip().lower())
+            .delete()
+        )
+        session.commit()
+        return deleted > 0

--- a/app/services/model_downloads.py
+++ b/app/services/model_downloads.py
@@ -1,0 +1,250 @@
+"""
+Local model weight downloads and detection.
+
+Downloads run as durable `model.download` jobs on the existing job queue and
+land in the packed weights folder (`app/model_weights`, or `LOCAL_WEIGHTS_DIR`
+when set) using the same directory naming the runners resolve at load time.
+Detection scans that folder so the UI can show which catalog models are
+already present and surface any extra weight directories it finds.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from agents.model_catalog import MODEL_SPECS, ModelSpec, get_model_spec
+from app.services.job_queue import job_handler
+from app.services.provider_keys import resolve_huggingface_token
+
+
+logger = logging.getLogger(__name__)
+
+DOWNLOAD_JOB_KIND = "model.download"
+
+# Catalog IDs whose Hugging Face repository differs from the ID itself.
+HF_REPO_OVERRIDES: dict[str, str] = {
+    "Meta-Llama-3.1-8B-Instruct": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+}
+
+# Directories that predate per-model naming: both Llama 3.1 IDs load from the
+# packed llama_3_1 folder (see mlx_llama_runner and transformers_runner).
+WEIGHTS_DIR_OVERRIDES: dict[str, str] = {
+    "Meta-Llama-3.1-8B-Instruct": "llama_3_1",
+    "meta-llama/Meta-Llama-3.1-8B-Instruct": "llama_3_1",
+}
+
+_WEIGHT_MARKERS = ("config.json", "params.json", "tokenizer.json")
+
+
+def weights_root() -> str:
+    """The packed weights folder runners load from."""
+    local_root = os.environ.get("LOCAL_WEIGHTS_DIR")
+    if local_root:
+        return os.path.expanduser(local_root)
+    return os.path.join("app", "model_weights")
+
+
+def model_dir_name(model_id: str) -> str:
+    """Directory component for a model ID, matching runner conventions."""
+    override = WEIGHTS_DIR_OVERRIDES.get(model_id)
+    if override:
+        return override
+    directory_name = re.sub(r"[\\/]+", "_", model_id.strip()).strip(".")
+    if not directory_name:
+        raise ValueError("Model ID must contain a directory-safe name")
+    return directory_name
+
+
+def model_weights_dir(model_id: str) -> str:
+    return os.path.join(weights_root(), model_dir_name(model_id))
+
+
+def hf_repo_id(model_id: str) -> str:
+    """Hugging Face repository to download for a catalog model ID."""
+    return HF_REPO_OVERRIDES.get(model_id, model_id)
+
+
+def is_model_downloaded(model_id: str) -> bool:
+    return _dir_has_weights(model_weights_dir(model_id))
+
+
+def _dir_has_weights(path: str) -> bool:
+    if not os.path.isdir(path):
+        return False
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return False
+    if any(marker in entries for marker in _WEIGHT_MARKERS):
+        return True
+    return any(entry.endswith((".safetensors", ".gguf", ".pth")) for entry in entries)
+
+
+def _dir_size_bytes(path: str) -> int:
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                continue
+    return total
+
+
+def downloadable_model_specs() -> list[ModelSpec]:
+    """Catalog models that can be downloaded into the packed weights folder."""
+    return [spec for spec in MODEL_SPECS if spec.provider == "offline" and spec.local]
+
+
+def _latest_download_jobs(user_id: int | None) -> dict[str, dict[str, Any]]:
+    """Newest download job per model ID, keyed by dedupe model ID."""
+    from app.models.database.database import SessionLocal
+    from app.models.database.job import Job
+
+    jobs: dict[str, dict[str, Any]] = {}
+    try:
+        with SessionLocal() as session:
+            query = session.query(Job).filter(Job.kind == DOWNLOAD_JOB_KIND)
+            if user_id is not None:
+                query = query.filter(Job.user_id == user_id)
+            for job in query.order_by(Job.job_id.asc()).all():
+                job_dict = job.to_dict()
+                model_id = (job_dict.get("payload") or {}).get("model_id")
+                if model_id:
+                    jobs[model_id] = job_dict
+    except Exception:
+        logger.warning("Could not read model download jobs", exc_info=True)
+    return jobs
+
+
+def local_model_statuses(user_id: int | None = None) -> dict[str, Any]:
+    """
+    Describe downloadable catalog models plus any extra weight directories.
+
+    Returns {"models": [...], "detected_directories": [...], "weights_root": str}.
+    """
+    root = weights_root()
+    jobs = _latest_download_jobs(user_id)
+
+    models = []
+    known_dirs = set()
+    for spec in downloadable_model_specs():
+        directory = model_weights_dir(spec.id)
+        known_dirs.add(os.path.basename(directory))
+        downloaded = _dir_has_weights(directory)
+        job = jobs.get(spec.id)
+        models.append({
+            "id": spec.id,
+            "name": spec.name,
+            "family": spec.family,
+            "backend": spec.backend,
+            "gated": spec.gated,
+            "parameter_count": spec.parameter_count,
+            "downloaded": downloaded,
+            "weights_path": directory,
+            "size_bytes": _dir_size_bytes(directory) if downloaded else 0,
+            "download_status": job.get("status") if job else None,
+            "download_job_id": job.get("job_id") if job else None,
+            "download_error": job.get("error") if job else None,
+        })
+
+    detected = []
+    if os.path.isdir(root):
+        for entry in sorted(os.listdir(root)):
+            path = os.path.join(root, entry)
+            if entry in known_dirs or not _dir_has_weights(path):
+                continue
+            detected.append({
+                "directory": entry,
+                "weights_path": path,
+                "size_bytes": _dir_size_bytes(path),
+            })
+
+    return {"models": models, "detected_directories": detected, "weights_root": root}
+
+
+def enqueue_model_download(
+    model_id: str,
+    user_id: int,
+    revision: str | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """
+    Validate and queue one model download; returns the queued job as a dict.
+
+    Only catalog models marked offline/local can be queued, so heavyweight
+    server-backed IDs can never be pulled onto the local disk by the UI.
+    """
+    from app.models.database.database import SessionLocal
+    from app.models.database.job import Job, JobStatus
+    from app.services.job_queue import enqueue
+
+    spec = get_model_spec(model_id)
+    if spec is None or spec.provider != "offline" or not spec.local:
+        raise ValueError(f"'{model_id}' is not a downloadable local catalog model")
+    if is_model_downloaded(spec.id) and not force:
+        raise ValueError(f"'{spec.id}' is already downloaded")
+    if spec.gated and not resolve_huggingface_token(user_id):
+        raise ValueError(
+            f"'{spec.id}' is a gated model: add a Hugging Face token under "
+            "Settings > Providers first"
+        )
+
+    dedupe_key = f"{DOWNLOAD_JOB_KIND}:{spec.id}"
+    with SessionLocal() as session:
+        active = (
+            session.query(Job)
+            .filter(
+                Job.dedupe_key == dedupe_key,
+                Job.status.in_([JobStatus.QUEUED.value, JobStatus.RUNNING.value]),
+            )
+            .first()
+        )
+        if active is not None:
+            return active.to_dict()
+
+    job = enqueue(
+        DOWNLOAD_JOB_KIND,
+        payload={"model_id": spec.id, "revision": revision, "user_id": user_id},
+        max_attempts=2,
+        user_id=user_id,
+        dedupe_key=dedupe_key,
+    )
+    return job.to_dict()
+
+
+@job_handler(DOWNLOAD_JOB_KIND)
+def _run_model_download_job(payload: dict[str, Any]) -> dict[str, Any]:
+    """
+    Download one model's weights from Hugging Face into the packed folder.
+
+    Payload: {"model_id": str, "revision": str | None, "user_id": int | None},
+    enqueued exclusively by enqueue_model_download after catalog validation.
+    """
+    # Imported here so the API process never pays the huggingface_hub import.
+    from huggingface_hub import snapshot_download
+
+    model_id = payload["model_id"]
+    revision = payload.get("revision")
+    user_id = payload.get("user_id")
+
+    spec = get_model_spec(model_id)
+    if spec is None or spec.provider != "offline" or not spec.local:
+        raise ValueError(f"'{model_id}' is not a downloadable local catalog model")
+
+    destination = model_weights_dir(spec.id)
+    token = resolve_huggingface_token(user_id)
+    logger.info("Downloading %s to %s", hf_repo_id(spec.id), destination)
+    snapshot_download(
+        repo_id=hf_repo_id(spec.id),
+        local_dir=destination,
+        token=token,
+        revision=revision,
+    )
+    return {
+        "model_id": spec.id,
+        "weights_path": destination,
+        "size_bytes": _dir_size_bytes(destination),
+    }

--- a/app/services/provider_keys.py
+++ b/app/services/provider_keys.py
@@ -1,0 +1,223 @@
+"""
+Provider API key management and resolution.
+
+Stored credentials (entered through the Settings UI) take precedence over
+environment variables so a key can be rotated without restarting the server.
+Environment variables remain the fallback so existing .env-based deployments
+keep working unchanged.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from agents.model_catalog import PROVIDERS
+from app.models.database.provider_credential import (
+    delete_provider_credential,
+    get_provider_credential,
+    list_provider_credentials,
+    upsert_provider_credential,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ManagedProvider:
+    """One provider whose API key can be entered in the UI."""
+
+    id: str
+    name: str
+    api_key_env: str
+    description: str
+    supports_base_url: bool = False
+    base_url_env: str | None = None
+
+
+def _managed_providers() -> dict[str, ManagedProvider]:
+    providers: dict[str, ManagedProvider] = {}
+    for spec in PROVIDERS.values():
+        providers[spec.id] = ManagedProvider(
+            id=spec.id,
+            name=spec.name,
+            api_key_env=spec.api_key_env,
+            description=f"API key for {spec.name} chat completions.",
+            supports_base_url=spec.base_url_env is not None,
+            base_url_env=spec.base_url_env,
+        )
+    # Providers used by the app but not represented in the catalog's
+    # OpenAI-compatible PROVIDERS map.
+    providers["anthropic"] = ManagedProvider(
+        id="anthropic",
+        name="Anthropic",
+        api_key_env="ANTHROPIC_API_KEY",
+        description="API key for Anthropic chat completions.",
+    )
+    providers["huggingface"] = ManagedProvider(
+        id="huggingface",
+        name="Hugging Face",
+        api_key_env="HUGGING_FACE_HUB_TOKEN",
+        description=(
+            "Access token used to download model weights; required for gated "
+            "repositories such as Llama and Gemma."
+        ),
+    )
+    return providers
+
+
+MANAGED_PROVIDERS: dict[str, ManagedProvider] = _managed_providers()
+
+
+def is_managed_provider(provider_id: str) -> bool:
+    return provider_id.strip().lower() in MANAGED_PROVIDERS
+
+
+def _mask_key(api_key: str) -> str:
+    """Return a display hint that never reveals the key body."""
+    tail = api_key[-4:] if len(api_key) >= 8 else ""
+    return f"****{tail}"
+
+
+def resolve_api_key(provider_id: str, user_id: int | None = None) -> str | None:
+    """
+    Resolve the API key for a provider: stored credential first, env second.
+
+    Falls back cleanly when the database is unavailable (e.g. unit tests that
+    construct agents without configuring a database).
+    """
+    provider = MANAGED_PROVIDERS.get(provider_id.strip().lower())
+    if provider is None:
+        return None
+
+    if user_id is None:
+        user_id = _default_user_id()
+    if user_id is not None:
+        try:
+            credential = get_provider_credential(user_id, provider.id)
+        except Exception:
+            logger.debug(
+                "Stored credential lookup failed for provider '%s'; using environment",
+                provider.id,
+                exc_info=True,
+            )
+            credential = None
+        if credential and credential.api_key:
+            return credential.api_key
+
+    env_value = os.getenv(provider.api_key_env)
+    if env_value:
+        return env_value
+    if provider.id == "huggingface":
+        return os.getenv("HF_TOKEN")
+    return None
+
+
+def resolve_base_url(provider_id: str, user_id: int | None = None) -> str | None:
+    """Resolve a stored or environment-configured base URL override."""
+    provider = MANAGED_PROVIDERS.get(provider_id.strip().lower())
+    if provider is None or not provider.supports_base_url:
+        return None
+
+    if user_id is None:
+        user_id = _default_user_id()
+    if user_id is not None:
+        try:
+            credential = get_provider_credential(user_id, provider.id)
+        except Exception:
+            credential = None
+        if credential and credential.base_url:
+            return credential.base_url.rstrip("/")
+
+    if provider.base_url_env:
+        configured = os.getenv(provider.base_url_env)
+        if configured:
+            return configured.rstrip("/")
+    return None
+
+
+def resolve_huggingface_token(user_id: int | None = None) -> str | None:
+    """Convenience wrapper used by model downloads and gated weight loading."""
+    return resolve_api_key("huggingface", user_id=user_id)
+
+
+def provider_key_statuses(user_id: int) -> list[dict]:
+    """
+    Describe every managed provider's key state for the Settings UI.
+
+    Raw keys are never included: stored keys surface only as a masked hint.
+    """
+    stored = {}
+    try:
+        stored = {credential.provider_id: credential for credential in
+                  list_provider_credentials(user_id)}
+    except Exception:
+        logger.warning("Could not list stored provider credentials", exc_info=True)
+
+    statuses = []
+    for provider in MANAGED_PROVIDERS.values():
+        credential = stored.get(provider.id)
+        env_configured = bool(os.getenv(provider.api_key_env)) or (
+            provider.id == "huggingface" and bool(os.getenv("HF_TOKEN"))
+        )
+        statuses.append({
+            "id": provider.id,
+            "name": provider.name,
+            "description": provider.description,
+            "api_key_env": provider.api_key_env,
+            "env_configured": env_configured,
+            "has_stored_key": credential is not None,
+            "key_hint": _mask_key(credential.api_key) if credential else None,
+            "supports_base_url": provider.supports_base_url,
+            "base_url": credential.base_url if credential else None,
+            "updated_at": credential.update_date.isoformat() if credential else None,
+        })
+    return statuses
+
+
+def store_provider_key(
+    user_id: int,
+    provider_id: str,
+    api_key: str,
+    base_url: str | None = None,
+) -> dict:
+    """Store one provider key and return its masked status entry."""
+    normalized = provider_id.strip().lower()
+    provider = MANAGED_PROVIDERS.get(normalized)
+    if provider is None:
+        raise ValueError(f"Unknown provider: {provider_id}")
+    api_key = api_key.strip()
+    if not api_key:
+        raise ValueError("API key must not be empty")
+    if base_url is not None:
+        base_url = base_url.strip() or None
+    if base_url and not provider.supports_base_url:
+        raise ValueError(f"Provider '{provider.id}' does not accept a base URL")
+
+    credential = upsert_provider_credential(user_id, provider.id, api_key, base_url=base_url)
+    return {
+        "id": provider.id,
+        "name": provider.name,
+        "has_stored_key": True,
+        "key_hint": _mask_key(credential.api_key),
+        "base_url": credential.base_url,
+    }
+
+
+def remove_provider_key(user_id: int, provider_id: str) -> bool:
+    """Delete a stored provider key; returns False when none existed."""
+    normalized = provider_id.strip().lower()
+    if normalized not in MANAGED_PROVIDERS:
+        raise ValueError(f"Unknown provider: {provider_id}")
+    return delete_provider_credential(user_id, normalized)
+
+
+def _default_user_id() -> int | None:
+    """Resolve the default user without failing when the DB is unavailable."""
+    try:
+        from app.models.database.geist_user import get_default_user
+
+        return get_default_user().user_id
+    except Exception:
+        return None

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -2305,3 +2305,27 @@ select.form-control {
     flex-direction: column;
   }
 }
+
+.local-weights-panel {
+  margin-bottom: 16px;
+}
+
+.local-weights-panel .notice {
+  margin-bottom: 10px;
+}
+
+.downloaded-pill {
+  border-color: var(--geist-color-accent);
+  color: var(--geist-color-text);
+}
+
+.detected-weights {
+  margin-top: 12px;
+}
+
+.detected-weights h4 {
+  margin: 0 0 8px;
+  color: var(--geist-color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 650;
+}

--- a/client/geist/src/Components/AgentConfigSection.tsx
+++ b/client/geist/src/Components/AgentConfigSection.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import SettingsSelect from './SettingsSelect';
 import { useAvailableModels } from '../Hooks/useAvailableModels';
+import { useLocalModels } from '../Hooks/useLocalModels';
 
 interface AgentConfigSectionProps {
   agentType: string;
@@ -41,11 +42,25 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
     loading: modelsLoading,
     providers,
   } = useAvailableModels();
+  const { localModels } = useLocalModels();
+
+  const downloadedModelIds = useMemo(
+    () => new Set(localModels.filter(m => m.downloaded).map(m => m.id)),
+    [localModels]
+  );
 
   const localModelOptions = useMemo(() => {
     const offlineModels = getModelsForProvider('offline');
     if (offlineModels.length > 0) {
-      return offlineModels.map(m => ({ value: m.id, label: m.name }));
+      const options = offlineModels.map(m => ({
+        value: m.id,
+        label: downloadedModelIds.has(m.id) ? `${m.name} • downloaded` : m.name,
+        downloaded: downloadedModelIds.has(m.id)
+      }));
+      // Surface models already present in the weights folder first.
+      return options
+        .sort((a, b) => Number(b.downloaded) - Number(a.downloaded))
+        .map(({ value, label }) => ({ value, label }));
     }
 
     return [
@@ -53,7 +68,7 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
       { value: 'Meta-Llama-3.1-8B', label: 'Meta-Llama-3.1-8B' },
       { value: 'Meta-Llama-3-8B-Instruct', label: 'Meta-Llama-3-8B-Instruct' }
     ];
-  }, [getModelsForProvider]);
+  }, [getModelsForProvider, downloadedModelIds]);
 
   const onlineProviderOptions = useMemo(() => {
     const onlineProviders = providers.filter(p => p !== 'offline');
@@ -99,8 +114,10 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
           options={localModelOptions}
           onChange={onLocalModelChange}
           description={
-            getModelById(localModel)?.performance_note ||
-            'Select which local model to use for generation'
+            localModels.length > 0 && !downloadedModelIds.has(localModel)
+              ? 'Weights not downloaded yet - download them from the Models page.'
+              : getModelById(localModel)?.performance_note ||
+                'Select which local model to use for generation'
           }
         />
       ) : (

--- a/client/geist/src/Components/ProviderKeysSection.tsx
+++ b/client/geist/src/Components/ProviderKeysSection.tsx
@@ -1,0 +1,157 @@
+import React, { useState } from 'react';
+import useProviderKeys, { ProviderKeyStatus } from '../Hooks/useProviderKeys';
+
+interface ProviderKeyRowProps {
+  provider: ProviderKeyStatus;
+  onSave: (providerId: string, apiKey: string, baseUrl?: string) => Promise<void>;
+  onRemove: (providerId: string) => Promise<void>;
+}
+
+function statusLabel(provider: ProviderKeyStatus): string {
+  if (provider.has_stored_key) {
+    return `Stored key ${provider.key_hint ?? ''}`.trim();
+  }
+  if (provider.env_configured) {
+    return `From environment (${provider.api_key_env})`;
+  }
+  return 'Not configured';
+}
+
+const ProviderKeyRow: React.FC<ProviderKeyRowProps> = ({ provider, onSave, onRemove }) => {
+  const [apiKey, setApiKey] = useState('');
+  const [baseUrl, setBaseUrl] = useState(provider.base_url ?? '');
+  const [busy, setBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
+  const [rowSuccess, setRowSuccess] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (!apiKey.trim()) {
+      setRowError('Enter an API key before saving.');
+      return;
+    }
+    try {
+      setBusy(true);
+      setRowError(null);
+      setRowSuccess(null);
+      await onSave(provider.id, apiKey.trim(), provider.supports_base_url ? baseUrl.trim() : undefined);
+      setApiKey('');
+      setRowSuccess('Key saved.');
+    } catch (err) {
+      setRowError(err instanceof Error ? err.message : 'Failed to save key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    try {
+      setBusy(true);
+      setRowError(null);
+      setRowSuccess(null);
+      await onRemove(provider.id);
+      setRowSuccess('Stored key removed.');
+    } catch (err) {
+      setRowError(err instanceof Error ? err.message : 'Failed to remove key');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const configured = provider.has_stored_key || provider.env_configured;
+
+  return (
+    <div className="provider-key-row" data-testid={`provider-key-row-${provider.id}`}>
+      <div className="provider-key-heading">
+        <div>
+          <span className="settings-label">{provider.name}</span>
+          <p className="settings-description">{provider.description}</p>
+        </div>
+        <span className={`provider-key-status ${configured ? 'configured' : ''}`}>
+          {statusLabel(provider)}
+        </span>
+      </div>
+
+      <div className="provider-key-controls">
+        <input
+          type="password"
+          className="form-control provider-key-input"
+          placeholder={provider.has_stored_key ? 'Replace stored key' : 'Enter API key'}
+          value={apiKey}
+          autoComplete="off"
+          aria-label={`${provider.name} API key`}
+          onChange={(e) => {
+            setApiKey(e.target.value);
+            setRowError(null);
+            setRowSuccess(null);
+          }}
+        />
+        {provider.supports_base_url && (
+          <input
+            type="text"
+            className="form-control provider-key-input"
+            placeholder="Base URL (e.g. http://localhost:8000/v1)"
+            value={baseUrl}
+            aria-label={`${provider.name} base URL`}
+            onChange={(e) => setBaseUrl(e.target.value)}
+          />
+        )}
+        <div className="settings-inline-actions">
+          <button className="button button-small" type="button" onClick={handleSave} disabled={busy}>
+            {busy ? 'Saving...' : 'Save Key'}
+          </button>
+          {provider.has_stored_key && (
+            <button
+              className="button button-secondary button-small"
+              type="button"
+              onClick={handleRemove}
+              disabled={busy}
+            >
+              Remove
+            </button>
+          )}
+        </div>
+      </div>
+
+      {rowError && <p className="provider-key-message error">{rowError}</p>}
+      {rowSuccess && <p className="provider-key-message success">{rowSuccess}</p>}
+    </div>
+  );
+};
+
+const ProviderKeysSection: React.FC = () => {
+  const { providers, loading, error, saveKey, removeKey, refetch } = useProviderKeys();
+
+  return (
+    <section className="settings-section">
+      <header className="settings-section-header">
+        <h3>Provider API Keys</h3>
+        <p>
+          Store keys for online providers and Hugging Face downloads. Saved keys take
+          precedence over environment variables and are never shown again after saving.
+        </p>
+      </header>
+
+      {loading && <div className="empty-state compact">Loading providers...</div>}
+
+      {error && !loading && (
+        <div className="notice notice-error">
+          <span>Could not load providers: {error}</span>
+          <button className="button button-small" type="button" onClick={() => void refetch()}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && providers.map((provider) => (
+        <ProviderKeyRow
+          key={provider.id}
+          provider={provider}
+          onSave={saveKey}
+          onRemove={removeKey}
+        />
+      ))}
+    </section>
+  );
+};
+
+export default ProviderKeysSection;

--- a/client/geist/src/Components/__tests__/ProviderKeysSection.test.tsx
+++ b/client/geist/src/Components/__tests__/ProviderKeysSection.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProviderKeysSection from '../ProviderKeysSection';
+
+const openaiStatus = {
+  id: 'openai',
+  name: 'OpenAI',
+  description: 'API key for OpenAI chat completions.',
+  api_key_env: 'OPENAI_API_KEY',
+  env_configured: false,
+  has_stored_key: false,
+  key_hint: null,
+  supports_base_url: false,
+  base_url: null,
+  updated_at: null,
+};
+
+const selfHostedStatus = {
+  id: 'self-hosted',
+  name: 'Self-hosted OpenAI-compatible',
+  description: 'API key for Self-hosted OpenAI-compatible chat completions.',
+  api_key_env: 'API_KEY',
+  env_configured: true,
+  has_stored_key: false,
+  key_hint: null,
+  supports_base_url: true,
+  base_url: null,
+  updated_at: null,
+};
+
+describe('ProviderKeysSection', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  const mockFetch = (handlers: Record<string, (init?: RequestInit) => any>) => {
+    global.fetch = jest.fn(async (url: any, init?: RequestInit) => {
+      const key = `${init?.method || 'GET'} ${url}`;
+      const handler = handlers[key];
+      if (!handler) {
+        throw new Error(`Unexpected fetch: ${key}`);
+      }
+      return handler(init);
+    }) as any;
+  };
+
+  const okJson = (body: any) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  });
+
+  it('lists providers with their configuration state', async () => {
+    mockFetch({
+      'GET /api/v1/providers/': () => okJson([openaiStatus, selfHostedStatus]),
+    });
+
+    render(<ProviderKeysSection />);
+
+    expect(await screen.findByText('OpenAI')).toBeInTheDocument();
+    expect(screen.getByText('Not configured')).toBeInTheDocument();
+    expect(screen.getByText('From environment (API_KEY)')).toBeInTheDocument();
+    // Self-hosted rows expose a base URL field.
+    expect(
+      screen.getByLabelText('Self-hosted OpenAI-compatible base URL')
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('OpenAI base URL')).not.toBeInTheDocument();
+  });
+
+  it('saves a key and shows the masked stored state', async () => {
+    const storedStatus = {
+      ...openaiStatus,
+      has_stored_key: true,
+      key_hint: '****1234',
+    };
+    mockFetch({
+      'GET /api/v1/providers/': () => okJson([openaiStatus]),
+      'PUT /api/v1/providers/openai/key': (init) => {
+        expect(JSON.parse(String(init?.body))).toEqual({
+          api_key: 'sk-test-key-1234',
+          base_url: null,
+        });
+        return okJson(storedStatus);
+      },
+    });
+
+    render(<ProviderKeysSection />);
+
+    const input = await screen.findByLabelText('OpenAI API key');
+    fireEvent.change(input, { target: { value: 'sk-test-key-1234' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Key' }));
+
+    expect(await screen.findByText('Key saved.')).toBeInTheDocument();
+    expect(screen.getByText('Stored key ****1234')).toBeInTheDocument();
+    // The password input clears after a successful save.
+    expect((screen.getByLabelText('OpenAI API key') as HTMLInputElement).value).toBe('');
+  });
+
+  it('surfaces backend validation errors without clearing the input', async () => {
+    mockFetch({
+      'GET /api/v1/providers/': () => okJson([openaiStatus]),
+      'PUT /api/v1/providers/openai/key': () => ({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({ detail: 'API key must not be empty' }),
+      }),
+    });
+
+    render(<ProviderKeysSection />);
+
+    const input = await screen.findByLabelText('OpenAI API key');
+    fireEvent.change(input, { target: { value: 'bad-key' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Key' }));
+
+    expect(await screen.findByText('API key must not be empty')).toBeInTheDocument();
+  });
+
+  it('removes a stored key', async () => {
+    const storedStatus = { ...openaiStatus, has_stored_key: true, key_hint: '****5678' };
+    mockFetch({
+      'GET /api/v1/providers/': () => okJson([storedStatus]),
+      'DELETE /api/v1/providers/openai/key': () => okJson(openaiStatus),
+    });
+
+    render(<ProviderKeysSection />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Not configured')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+  });
+});

--- a/client/geist/src/Hooks/useLocalModels.tsx
+++ b/client/geist/src/Hooks/useLocalModels.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface LocalModelStatus {
+  id: string;
+  name: string;
+  family: string | null;
+  backend: string | null;
+  gated: boolean;
+  parameter_count: string | null;
+  downloaded: boolean;
+  weights_path: string;
+  size_bytes: number;
+  download_status: string | null;
+  download_job_id: number | null;
+  download_error: string | null;
+}
+
+export interface DetectedWeightsDirectory {
+  directory: string;
+  weights_path: string;
+  size_bytes: number;
+}
+
+export interface LocalModelsResponse {
+  models: LocalModelStatus[];
+  detected_directories: DetectedWeightsDirectory[];
+  weights_root: string;
+}
+
+interface UseLocalModelsReturn {
+  localModels: LocalModelStatus[];
+  detectedDirectories: DetectedWeightsDirectory[];
+  weightsRoot: string | null;
+  loading: boolean;
+  error: string | null;
+  startDownload: (modelId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+const ACTIVE_STATUSES = ['queued', 'running'];
+const POLL_INTERVAL_MS = 4000;
+
+export const useLocalModels = (): UseLocalModelsReturn => {
+  const [localModels, setLocalModels] = useState<LocalModelStatus[]>([]);
+  const [detectedDirectories, setDetectedDirectories] = useState<DetectedWeightsDirectory[]>([]);
+  const [weightsRoot, setWeightsRoot] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchLocalModels = useCallback(async () => {
+    try {
+      setError(null);
+
+      const response = await fetch('/api/v1/models/local', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch local models: ${response.statusText}`);
+      }
+      const data: LocalModelsResponse = await response.json();
+      setLocalModels(data.models);
+      setDetectedDirectories(data.detected_directories);
+      setWeightsRoot(data.weights_root);
+
+      const hasActiveDownload = data.models.some(
+        (model) => model.download_status && ACTIVE_STATUSES.includes(model.download_status)
+      );
+      if (pollTimer.current) {
+        clearTimeout(pollTimer.current);
+        pollTimer.current = null;
+      }
+      if (hasActiveDownload) {
+        pollTimer.current = setTimeout(() => void fetchLocalModels(), POLL_INTERVAL_MS);
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch local models';
+      setError(errorMessage);
+      console.error('Error fetching local models:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const startDownload = useCallback(async (modelId: string) => {
+    const response = await fetch('/api/v1/models/download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model_id: modelId }),
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => null);
+      throw new Error(detail?.detail || `Failed to start download: ${response.statusText}`);
+    }
+    await fetchLocalModels();
+  }, [fetchLocalModels]);
+
+  useEffect(() => {
+    fetchLocalModels();
+    return () => {
+      if (pollTimer.current) {
+        clearTimeout(pollTimer.current);
+      }
+    };
+  }, [fetchLocalModels]);
+
+  return {
+    localModels,
+    detectedDirectories,
+    weightsRoot,
+    loading,
+    error,
+    startDownload,
+    refetch: fetchLocalModels,
+  };
+};
+
+export default useLocalModels;

--- a/client/geist/src/Hooks/useProviderKeys.tsx
+++ b/client/geist/src/Hooks/useProviderKeys.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface ProviderKeyStatus {
+  id: string;
+  name: string;
+  description: string;
+  api_key_env: string;
+  env_configured: boolean;
+  has_stored_key: boolean;
+  key_hint: string | null;
+  supports_base_url: boolean;
+  base_url: string | null;
+  updated_at: string | null;
+}
+
+interface UseProviderKeysReturn {
+  providers: ProviderKeyStatus[];
+  loading: boolean;
+  error: string | null;
+  saveKey: (providerId: string, apiKey: string, baseUrl?: string) => Promise<void>;
+  removeKey: (providerId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useProviderKeys = (): UseProviderKeysReturn => {
+  const [providers, setProviders] = useState<ProviderKeyStatus[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProviders = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const response = await fetch('/api/v1/providers/', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch providers: ${response.statusText}`);
+      }
+      setProviders(await response.json());
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch providers';
+      setError(errorMessage);
+      console.error('Error fetching providers:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const applyUpdatedStatus = (updated: ProviderKeyStatus) => {
+    setProviders((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+  };
+
+  const saveKey = useCallback(async (providerId: string, apiKey: string, baseUrl?: string) => {
+    const response = await fetch(`/api/v1/providers/${encodeURIComponent(providerId)}/key`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, base_url: baseUrl || null }),
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => null);
+      throw new Error(detail?.detail || `Failed to save key: ${response.statusText}`);
+    }
+    applyUpdatedStatus(await response.json());
+  }, []);
+
+  const removeKey = useCallback(async (providerId: string) => {
+    const response = await fetch(`/api/v1/providers/${encodeURIComponent(providerId)}/key`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => null);
+      throw new Error(detail?.detail || `Failed to remove key: ${response.statusText}`);
+    }
+    applyUpdatedStatus(await response.json());
+  }, []);
+
+  useEffect(() => {
+    fetchProviders();
+  }, [fetchProviders]);
+
+  return { providers, loading, error, saveKey, removeKey, refetch: fetchProviders };
+};
+
+export default useProviderKeys;

--- a/client/geist/src/Models.test.tsx
+++ b/client/geist/src/Models.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Models from './Models';
+
+const mockStartDownload = jest.fn();
+const mockLocalModelsState: any = {
+  localModels: [],
+  detectedDirectories: [],
+  weightsRoot: '/srv/geist/app/model_weights',
+  loading: false,
+  error: null,
+  startDownload: mockStartDownload,
+  refetch: jest.fn(),
+};
+
+jest.mock('./Hooks/useLocalModels', () => ({
+  __esModule: true,
+  useLocalModels: () => mockLocalModelsState,
+  default: () => mockLocalModelsState,
+}));
+
+jest.mock('./Hooks/useAvailableModels', () => ({
+  __esModule: true,
+  useAvailableModels: () => ({
+    models: { providers: {} },
+    providers: [],
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+    getModelById: () => undefined,
+    getModelsForProvider: () => [],
+  }),
+  default: () => ({
+    models: { providers: {} },
+    providers: [],
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+    getModelById: () => undefined,
+    getModelsForProvider: () => [],
+  }),
+}));
+
+jest.mock('./Hooks/useUserSettings', () => ({
+  __esModule: true,
+  useUserSettings: () => ({ settings: null, loading: false, error: null }),
+  default: () => ({ settings: null, loading: false, error: null }),
+}));
+
+const baseModel = {
+  family: 'qwen',
+  backend: 'transformers',
+  gated: false,
+  parameter_count: '4B',
+  weights_path: '/srv/geist/app/model_weights/Qwen_Qwen3-4B',
+  size_bytes: 0,
+  download_status: null,
+  download_job_id: null,
+  download_error: null,
+};
+
+describe('Models local weights panel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocalModelsState.localModels = [];
+    mockLocalModelsState.detectedDirectories = [];
+  });
+
+  it('shows download state and weights root', () => {
+    mockLocalModelsState.localModels = [
+      {
+        ...baseModel,
+        id: 'Qwen/Qwen3-4B',
+        name: 'Qwen 3 4B (Local)',
+        downloaded: true,
+        size_bytes: 8_000_000_000,
+      },
+      {
+        ...baseModel,
+        id: 'Qwen/Qwen3-8B',
+        name: 'Qwen 3 8B (Local)',
+        downloaded: false,
+      },
+    ];
+    mockLocalModelsState.detectedDirectories = [
+      {
+        directory: 'my_custom_finetune',
+        weights_path: '/srv/geist/app/model_weights/my_custom_finetune',
+        size_bytes: 123456789,
+      },
+    ];
+
+    render(<Models />);
+
+    expect(
+      screen.getByText(/Download models from Hugging Face into \/srv\/geist\/app\/model_weights/)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('local-status-Qwen/Qwen3-4B')).toHaveTextContent('Downloaded');
+    expect(screen.getByTestId('local-status-Qwen/Qwen3-8B')).toHaveTextContent('Not downloaded');
+    expect(screen.getByText('my_custom_finetune')).toBeInTheDocument();
+    expect(screen.getByText('Unmanaged')).toBeInTheDocument();
+    // Downloaded models have no download button.
+    expect(screen.getAllByRole('button', { name: 'Download' })).toHaveLength(1);
+  });
+
+  it('starts a download for a missing model', async () => {
+    mockStartDownload.mockResolvedValue(undefined);
+    mockLocalModelsState.localModels = [
+      { ...baseModel, id: 'Qwen/Qwen3-8B', name: 'Qwen 3 8B (Local)', downloaded: false },
+    ];
+
+    render(<Models />);
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    await waitFor(() => {
+      expect(mockStartDownload).toHaveBeenCalledWith('Qwen/Qwen3-8B');
+    });
+  });
+
+  it('shows failed downloads with a retry action and surfaces errors', async () => {
+    mockStartDownload.mockRejectedValue(new Error('gated model: add a Hugging Face token'));
+    mockLocalModelsState.localModels = [
+      {
+        ...baseModel,
+        id: 'google/gemma-3-1b-it',
+        name: 'Gemma 3 1B IT (Local)',
+        gated: true,
+        downloaded: false,
+        download_status: 'failed',
+        download_error: 'boom',
+      },
+    ];
+
+    render(<Models />);
+
+    expect(screen.getByTestId('local-status-google/gemma-3-1b-it')).toHaveTextContent(
+      'Download failed'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(
+      await screen.findByText('gated model: add a Hugging Face token')
+    ).toBeInTheDocument();
+  });
+});

--- a/client/geist/src/Models.tsx
+++ b/client/geist/src/Models.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import useAvailableModels, { ModelInfo } from './Hooks/useAvailableModels';
+import useLocalModels, { LocalModelStatus } from './Hooks/useLocalModels';
 import useUserSettings from './Hooks/useUserSettings';
 
 function formatNumber(value: number | null): string {
@@ -7,6 +8,36 @@ function formatNumber(value: number | null): string {
     return 'Unknown';
   }
   return new Intl.NumberFormat().format(value);
+}
+
+function formatSize(bytes: number): string {
+  if (!bytes) {
+    return '—';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function downloadStateLabel(model: LocalModelStatus): string {
+  if (model.downloaded) {
+    return `Downloaded (${formatSize(model.size_bytes)})`;
+  }
+  if (model.download_status === 'queued') {
+    return 'Queued...';
+  }
+  if (model.download_status === 'running') {
+    return 'Downloading...';
+  }
+  if (model.download_status === 'failed') {
+    return 'Download failed';
+  }
+  return 'Not downloaded';
 }
 
 function capabilityLabels(model: ModelInfo): string[] {
@@ -18,8 +49,129 @@ function capabilityLabels(model: ModelInfo): string[] {
   return labels;
 }
 
+interface LocalWeightsPanelProps {
+  localModels: LocalModelStatus[];
+  detectedDirectories: { directory: string; weights_path: string; size_bytes: number }[];
+  weightsRoot: string | null;
+  localError: string | null;
+  onDownload: (modelId: string) => Promise<void>;
+}
+
+function LocalWeightsPanel({
+  localModels,
+  detectedDirectories,
+  weightsRoot,
+  localError,
+  onDownload,
+}: LocalWeightsPanelProps): JSX.Element {
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [pendingModel, setPendingModel] = useState<string | null>(null);
+
+  const handleDownload = async (modelId: string) => {
+    try {
+      setPendingModel(modelId);
+      setActionError(null);
+      await onDownload(modelId);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to start download');
+    } finally {
+      setPendingModel(null);
+    }
+  };
+
+  return (
+    <section className="provider-panel local-weights-panel">
+      <div className="provider-panel-header">
+        <div>
+          <h3>Local weights</h3>
+          <p>
+            {weightsRoot
+              ? `Download models from Hugging Face into ${weightsRoot}.`
+              : 'Download models from Hugging Face into the packed weights folder.'}
+          </p>
+        </div>
+      </div>
+
+      {localError && (
+        <div className="notice notice-warning">Local weight scan failed. {localError}</div>
+      )}
+      {actionError && <div className="notice notice-error">{actionError}</div>}
+
+      <div className="model-table">
+        <div className="model-table-row model-table-heading">
+          <span>Model</span>
+          <span>Params</span>
+          <span>Status</span>
+          <span>Action</span>
+        </div>
+        {localModels.map((model) => {
+          const active =
+            model.download_status === 'queued' || model.download_status === 'running';
+          return (
+            <div className="model-table-row" key={`local-${model.id}`}>
+              <span>
+                <strong>{model.name}</strong>
+                <small>{model.id}</small>
+              </span>
+              <span>{model.parameter_count ?? 'Unknown'}</span>
+              <span className="capability-list">
+                <span
+                  className={`capability-pill ${model.downloaded ? 'downloaded-pill' : ''}`}
+                  data-testid={`local-status-${model.id}`}
+                >
+                  {downloadStateLabel(model)}
+                </span>
+                {model.gated && <span className="capability-pill">Gated</span>}
+              </span>
+              <span>
+                {!model.downloaded && (
+                  <button
+                    className="button button-secondary button-small"
+                    type="button"
+                    disabled={active || pendingModel === model.id}
+                    onClick={() => void handleDownload(model.id)}
+                  >
+                    {active ? 'In progress' : model.download_status === 'failed' ? 'Retry' : 'Download'}
+                  </button>
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {detectedDirectories.length > 0 && (
+        <div className="detected-weights">
+          <h4>Also detected in the weights folder</h4>
+          {detectedDirectories.map((entry) => (
+            <div className="model-table-row" key={`detected-${entry.directory}`}>
+              <span>
+                <strong>{entry.directory}</strong>
+                <small>{entry.weights_path}</small>
+              </span>
+              <span>{formatSize(entry.size_bytes)}</span>
+              <span className="capability-list">
+                <span className="capability-pill">Unmanaged</span>
+              </span>
+              <span />
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export default function Models(): JSX.Element {
   const { models, loading, error, refetch, providers } = useAvailableModels();
+  const {
+    localModels,
+    detectedDirectories,
+    weightsRoot,
+    error: localError,
+    startDownload,
+    refetch: refetchLocal,
+  } = useLocalModels();
   const { settings } = useUserSettings();
 
   const activeModel = settings?.default_agent_type === 'online'
@@ -48,7 +200,13 @@ export default function Models(): JSX.Element {
             Review available models and the current default runtime without leaving the workbench.
           </p>
         </div>
-        <button className="button button-secondary" onClick={() => void refetch()}>
+        <button
+          className="button button-secondary"
+          onClick={() => {
+            void refetch();
+            void refetchLocal();
+          }}
+        >
           Refresh
         </button>
       </div>
@@ -73,6 +231,14 @@ export default function Models(): JSX.Element {
           <strong>{providers.length}</strong>
         </article>
       </div>
+
+      <LocalWeightsPanel
+        localModels={localModels}
+        detectedDirectories={detectedDirectories}
+        weightsRoot={weightsRoot}
+        localError={localError}
+        onDownload={startDownload}
+      />
 
       <div className="model-inventory-scroll" role="region" aria-label="Model inventory">
         <div className="provider-stack">

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -381,3 +381,61 @@
     grid-template-columns: 1fr;
   }
 }
+
+.provider-key-row {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  background: var(--geist-color-surface-muted);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
+  margin-bottom: 12px;
+}
+
+.provider-key-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.provider-key-status {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--geist-color-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 650;
+  color: var(--geist-color-text-muted);
+  white-space: nowrap;
+}
+
+.provider-key-status.configured {
+  color: var(--geist-color-text);
+  border-color: var(--geist-color-accent);
+}
+
+.provider-key-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.provider-key-input {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.provider-key-message {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.provider-key-message.error {
+  color: var(--geist-color-danger, #c0392b);
+}
+
+.provider-key-message.success {
+  color: var(--geist-color-success, #1e8e5a);
+}

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -3,11 +3,12 @@ import './Settings.css';
 import { useUserSettings, UserSettingsUpdate } from './Hooks/useUserSettings';
 import AgentConfigSection from './Components/AgentConfigSection';
 import GenerationParamsSection from './Components/GenerationParamsSection';
+import ProviderKeysSection from './Components/ProviderKeysSection';
 import RAGSettingsSection from './Components/RAGSettingsSection';
 import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
 
-type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer';
+type Tab = 'general' | 'models' | 'providers' | 'generation' | 'rag' | 'ui' | 'developer';
 
 const agentTypeOptions = [
   { value: 'local', label: 'Local Model' },
@@ -110,6 +111,7 @@ const Settings: React.FC = () => {
   const tabs = [
     { id: 'general' as Tab, label: 'General' },
     { id: 'models' as Tab, label: 'Models and Providers' },
+    { id: 'providers' as Tab, label: 'API Keys' },
     { id: 'generation' as Tab, label: 'Generation' },
     { id: 'rag' as Tab, label: 'Files and RAG' },
     { id: 'ui' as Tab, label: 'Appearance' },
@@ -216,6 +218,8 @@ const Settings: React.FC = () => {
             }}
           />
         )}
+
+        {activeTab === 'providers' && <ProviderKeysSection />}
 
         {activeTab === 'generation' && (
           <GenerationParamsSection

--- a/migrations/versions/a7c9e1f3b5d8_add_provider_credential_table.py
+++ b/migrations/versions/a7c9e1f3b5d8_add_provider_credential_table.py
@@ -1,0 +1,43 @@
+"""add provider credential table
+
+Revision ID: a7c9e1f3b5d8
+Revises: e4b7a9c2d1f0
+Create Date: 2026-07-23
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7c9e1f3b5d8'
+down_revision: str | None = 'e4b7a9c2d1f0'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'provider_credential',
+        sa.Column('provider_credential_id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('provider_id', sa.String(), nullable=False),
+        sa.Column('api_key', sa.String(), nullable=False),
+        sa.Column('base_url', sa.String(), nullable=True),
+        sa.Column('create_date', sa.DateTime(), nullable=True),
+        sa.Column('update_date', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['geist_user.user_id']),
+        sa.PrimaryKeyConstraint('provider_credential_id'),
+        sa.UniqueConstraint(
+            'user_id', 'provider_id', name='uq_provider_credential_user_provider'
+        ),
+    )
+    op.create_index(
+        op.f('ix_provider_credential_user_id'), 'provider_credential', ['user_id'], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_provider_credential_user_id'), table_name='provider_credential')
+    op.drop_table('provider_credential')

--- a/tests/api/test_providers_api.py
+++ b/tests/api/test_providers_api.py
@@ -1,0 +1,150 @@
+"""Tests for provider key management endpoints and stored-key resolution."""
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.database.database import (
+    DATABASE_CONFIG,
+    Base,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+from app.models.database.geist_user import GeistUser
+
+
+@pytest.fixture()
+def providers_client(tmp_path, monkeypatch):
+    original_config = DATABASE_CONFIG
+    engine = configure_database(
+        DatabaseConfig(
+            provider="sqlite",
+            database_url=f"sqlite:///{tmp_path / 'providers-api.sqlite3'}",
+        )
+    )
+    importlib.import_module("app.models.database")
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setenv("GEIST_JOB_WORKER_ENABLED", "false")
+    with SessionLocal() as session:
+        session.add(
+            GeistUser(
+                user_id=1,
+                username="ddworetzky",
+                name="David Dworetzky",
+                email="david@phantasmal.ai",
+                password="",
+            )
+        )
+        session.commit()
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        yield client
+    Session.remove()
+    Base.metadata.drop_all(bind=engine)
+    configure_database(original_config)
+
+
+def test_list_providers_reports_env_and_stored_state(providers_client, monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "gsk_env_configured")
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+
+    response = providers_client.get("/api/v1/providers/")
+    assert response.status_code == 200
+    providers = {entry["id"]: entry for entry in response.json()}
+
+    assert providers["groq"]["env_configured"] is True
+    assert providers["groq"]["has_stored_key"] is False
+    assert providers["moonshot"]["env_configured"] is False
+    assert providers["huggingface"]["api_key_env"] == "HUGGING_FACE_HUB_TOKEN"
+    assert providers["self-hosted"]["supports_base_url"] is True
+    # Raw keys must never appear anywhere in the listing.
+    assert "gsk_env_configured" not in response.text
+
+
+def test_put_key_stores_masked_and_delete_removes(providers_client):
+    put_response = providers_client.put(
+        "/api/v1/providers/openai/key",
+        json={"api_key": "sk-super-secret-value-1234"},
+    )
+    assert put_response.status_code == 200
+    body = put_response.json()
+    assert body["has_stored_key"] is True
+    assert body["key_hint"] == "****1234"
+    assert "sk-super-secret-value-1234" not in put_response.text
+
+    delete_response = providers_client.delete("/api/v1/providers/openai/key")
+    assert delete_response.status_code == 200
+    assert delete_response.json()["has_stored_key"] is False
+
+    missing_delete = providers_client.delete("/api/v1/providers/openai/key")
+    assert missing_delete.status_code == 404
+
+
+def test_put_key_validates_provider_and_payload(providers_client):
+    unknown = providers_client.put(
+        "/api/v1/providers/not-a-provider/key", json={"api_key": "abc12345"}
+    )
+    assert unknown.status_code == 400
+
+    blank = providers_client.put("/api/v1/providers/openai/key", json={"api_key": "   "})
+    assert blank.status_code == 400
+
+    base_url_rejected = providers_client.put(
+        "/api/v1/providers/openai/key",
+        json={"api_key": "sk-abc12345", "base_url": "http://localhost:8000/v1"},
+    )
+    assert base_url_rejected.status_code == 400
+
+
+def test_self_hosted_key_accepts_base_url(providers_client):
+    response = providers_client.put(
+        "/api/v1/providers/self-hosted/key",
+        json={"api_key": "local-key-9876", "base_url": "http://localhost:8000/v1"},
+    )
+    assert response.status_code == 200
+    assert response.json()["base_url"] == "http://localhost:8000/v1"
+
+    from app.services.provider_keys import resolve_base_url
+
+    assert resolve_base_url("self-hosted", user_id=1) == "http://localhost:8000/v1"
+
+
+def test_resolve_api_key_prefers_stored_over_env(providers_client, monkeypatch):
+    from app.services.provider_keys import resolve_api_key
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "env-key")
+    assert resolve_api_key("deepseek", user_id=1) == "env-key"
+
+    providers_client.put(
+        "/api/v1/providers/deepseek/key", json={"api_key": "stored-key-5678"}
+    )
+    assert resolve_api_key("deepseek", user_id=1) == "stored-key-5678"
+
+    providers_client.delete("/api/v1/providers/deepseek/key")
+    assert resolve_api_key("deepseek", user_id=1) == "env-key"
+
+
+def test_online_agent_uses_stored_key(providers_client):
+    providers_client.put(
+        "/api/v1/providers/openai/key", json={"api_key": "sk-stored-agent-key"}
+    )
+
+    from agents.online_agent import OnlineAgent
+
+    assert OnlineAgent._get_stored_api_key("openai") == "sk-stored-agent-key"
+
+
+def test_huggingface_token_resolution(providers_client, monkeypatch):
+    from app.services.provider_keys import resolve_huggingface_token
+
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_env_fallback")
+    assert resolve_huggingface_token(user_id=1) == "hf_env_fallback"
+
+    providers_client.put(
+        "/api/v1/providers/huggingface/key", json={"api_key": "hf_stored_token"}
+    )
+    assert resolve_huggingface_token(user_id=1) == "hf_stored_token"

--- a/tests/api/test_providers_api.py
+++ b/tests/api/test_providers_api.py
@@ -2,6 +2,7 @@
 import importlib
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.models.database.database import (
@@ -13,6 +14,15 @@ from app.models.database.database import (
 )
 from app.models.database.database_config import DatabaseConfig
 from app.models.database.geist_user import GeistUser
+
+
+def _providers_app() -> FastAPI:
+    """Mount just the providers router so tests run without torch-heavy app.main."""
+    from app.api.v1.endpoints.providers import router as providers_router
+
+    app = FastAPI()
+    app.include_router(providers_router, prefix="/api/v1/providers", tags=["providers"])
+    return app
 
 
 @pytest.fixture()
@@ -38,9 +48,8 @@ def providers_client(tmp_path, monkeypatch):
             )
         )
         session.commit()
-    from app.main import create_app
 
-    with TestClient(create_app()) as client:
+    with TestClient(_providers_app()) as client:
         yield client
     Session.remove()
     Base.metadata.drop_all(bind=engine)

--- a/tests/services/test_model_downloads.py
+++ b/tests/services/test_model_downloads.py
@@ -3,6 +3,7 @@ import importlib
 import os
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.models.database.database import (
@@ -53,9 +54,12 @@ def downloads_env(tmp_path, monkeypatch):
 
 @pytest.fixture()
 def downloads_client(downloads_env):
-    from app.main import create_app
+    # Mount just the models router so tests run without torch-heavy app.main.
+    from app.api.v1.endpoints.models import router as models_router
 
-    with TestClient(create_app()) as client:
+    app = FastAPI()
+    app.include_router(models_router, prefix="/api/v1/models", tags=["models"])
+    with TestClient(app) as client:
         yield client
 
 

--- a/tests/services/test_model_downloads.py
+++ b/tests/services/test_model_downloads.py
@@ -1,0 +1,186 @@
+"""Tests for local model weight downloads and packed-folder detection."""
+import importlib
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.database.database import (
+    DATABASE_CONFIG,
+    Base,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+from app.models.database.geist_user import GeistUser
+from app.services import model_downloads
+from app.services.job_queue import JobWorker
+
+
+@pytest.fixture()
+def downloads_env(tmp_path, monkeypatch):
+    """SQLite database plus an isolated packed weights folder."""
+    original_config = DATABASE_CONFIG
+    engine = configure_database(
+        DatabaseConfig(
+            provider="sqlite",
+            database_url=f"sqlite:///{tmp_path / 'downloads.sqlite3'}",
+        )
+    )
+    importlib.import_module("app.models.database")
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setenv("GEIST_JOB_WORKER_ENABLED", "false")
+    weights_root = tmp_path / "model_weights"
+    weights_root.mkdir()
+    monkeypatch.setenv("LOCAL_WEIGHTS_DIR", str(weights_root))
+    with SessionLocal() as session:
+        session.add(
+            GeistUser(
+                user_id=1,
+                username="ddworetzky",
+                name="David Dworetzky",
+                email="david@phantasmal.ai",
+                password="",
+            )
+        )
+        session.commit()
+    yield weights_root
+    Session.remove()
+    Base.metadata.drop_all(bind=engine)
+    configure_database(original_config)
+
+
+@pytest.fixture()
+def downloads_client(downloads_env):
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        yield client
+
+
+def _fake_weights(weights_root, directory: str, size: int = 16) -> None:
+    model_dir = weights_root / directory
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text("{}")
+    (model_dir / "model.safetensors").write_bytes(b"0" * size)
+
+
+def test_model_dir_name_conventions():
+    assert model_downloads.model_dir_name("Qwen/Qwen3-4B") == "Qwen_Qwen3-4B"
+    # Both Llama 3.1 IDs must land in the legacy packed folder runners load.
+    assert model_downloads.model_dir_name("Meta-Llama-3.1-8B-Instruct") == "llama_3_1"
+    assert (
+        model_downloads.model_dir_name("meta-llama/Meta-Llama-3.1-8B-Instruct") == "llama_3_1"
+    )
+    assert (
+        model_downloads.hf_repo_id("Meta-Llama-3.1-8B-Instruct")
+        == "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    )
+
+
+def test_local_statuses_detect_downloaded_and_extra_dirs(downloads_env):
+    weights_root = downloads_env
+    _fake_weights(weights_root, "Qwen_Qwen3-4B")
+    _fake_weights(weights_root, "some_custom_finetune")
+    # Directories without weight files are ignored.
+    (weights_root / "empty_dir").mkdir()
+
+    statuses = model_downloads.local_model_statuses(user_id=1)
+    by_id = {entry["id"]: entry for entry in statuses["models"]}
+
+    assert by_id["Qwen/Qwen3-4B"]["downloaded"] is True
+    assert by_id["Qwen/Qwen3-4B"]["size_bytes"] > 0
+    assert by_id["Qwen/Qwen3-8B"]["downloaded"] is False
+    # Server-backed heavyweights never appear as downloadable local models.
+    assert "meta-llama/Llama-3.3-70B-Instruct" not in by_id
+
+    detected = [entry["directory"] for entry in statuses["detected_directories"]]
+    assert detected == ["some_custom_finetune"]
+
+
+def test_enqueue_validates_model_and_dedupes(downloads_env):
+    with pytest.raises(ValueError, match="not a downloadable"):
+        model_downloads.enqueue_model_download("glm-5.2", user_id=1)
+    with pytest.raises(ValueError, match="not a downloadable"):
+        model_downloads.enqueue_model_download("no-such-model", user_id=1)
+
+    first = model_downloads.enqueue_model_download("Qwen/Qwen3-4B", user_id=1)
+    assert first["status"] == "queued"
+    second = model_downloads.enqueue_model_download("Qwen/Qwen3-4B", user_id=1)
+    assert second["job_id"] == first["job_id"]
+
+
+def test_enqueue_rejects_downloaded_and_gated_without_token(downloads_env, monkeypatch):
+    weights_root = downloads_env
+    _fake_weights(weights_root, "Qwen_Qwen3-4B")
+    with pytest.raises(ValueError, match="already downloaded"):
+        model_downloads.enqueue_model_download("Qwen/Qwen3-4B", user_id=1)
+
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="gated"):
+        model_downloads.enqueue_model_download("google/gemma-3-1b-it", user_id=1)
+
+    monkeypatch.setenv("HF_TOKEN", "hf_token_present")
+    gated_job = model_downloads.enqueue_model_download("google/gemma-3-1b-it", user_id=1)
+    assert gated_job["status"] == "queued"
+
+
+def test_download_job_handler_runs_snapshot_download(downloads_env, monkeypatch):
+    weights_root = downloads_env
+    calls = {}
+
+    def fake_snapshot_download(repo_id, local_dir, token=None, revision=None):
+        calls["repo_id"] = repo_id
+        calls["local_dir"] = local_dir
+        calls["token"] = token
+        calls["revision"] = revision
+        os.makedirs(local_dir, exist_ok=True)
+        with open(os.path.join(local_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "huggingface_hub",
+        type("FakeHub", (), {"snapshot_download": staticmethod(fake_snapshot_download)}),
+    )
+    monkeypatch.setenv("HF_TOKEN", "hf_worker_token")
+
+    model_downloads.enqueue_model_download("Qwen/Qwen3-1.7B", user_id=1, revision="abc123")
+    worker = JobWorker(poll_interval=0.01)
+    assert worker.run_once() is True
+
+    assert calls["repo_id"] == "Qwen/Qwen3-1.7B"
+    assert calls["local_dir"] == os.path.join(str(weights_root), "Qwen_Qwen3-1.7B")
+    assert calls["token"] == "hf_worker_token"
+    assert calls["revision"] == "abc123"
+    assert model_downloads.is_model_downloaded("Qwen/Qwen3-1.7B")
+
+    statuses = model_downloads.local_model_statuses(user_id=1)
+    entry = next(e for e in statuses["models"] if e["id"] == "Qwen/Qwen3-1.7B")
+    assert entry["downloaded"] is True
+    assert entry["download_status"] == "succeeded"
+
+
+def test_download_api_roundtrip(downloads_client, downloads_env):
+    response = downloads_client.post(
+        "/api/v1/models/download", json={"model_id": "Qwen/Qwen3-4B"}
+    )
+    assert response.status_code == 202
+    body = response.json()
+    assert body["model_id"] == "Qwen/Qwen3-4B"
+    assert body["status"] == "queued"
+
+    invalid = downloads_client.post(
+        "/api/v1/models/download", json={"model_id": "glm-5.2"}
+    )
+    assert invalid.status_code == 400
+
+    local = downloads_client.get("/api/v1/models/local")
+    assert local.status_code == 200
+    local_body = local.json()
+    entry = next(e for e in local_body["models"] if e["id"] == "Qwen/Qwen3-4B")
+    assert entry["download_status"] == "queued"
+    assert entry["downloaded"] is False
+    assert local_body["weights_root"] == str(downloads_env)


### PR DESCRIPTION
- add a provider_credential table with an Alembic migration so per-provider
  API keys entered in the UI persist; stored keys take precedence over
  environment variables and raw keys are never returned over HTTP
- add /api/v1/providers endpoints for masked key status, save, and remove,
  covering catalog providers plus Anthropic and Hugging Face tokens
- resolve OnlineAgent keys from stored credentials first with a safe
  environment fallback
- add a model.download job on the existing queue that snapshot-downloads
  offline catalog models into the packed weights folder using the runners'
  directory naming, with gated-model token validation and dedupe
- add /api/v1/models/local to detect downloaded catalog models and
  unmanaged weight directories, and /api/v1/models/download to queue pulls
- add a Settings "API Keys" tab, a Local weights panel on the Models page
  with download/retry actions and polling, and downloaded-first labeling in
  the local model picker
- add backend tests for credentials, key resolution, downloads, and
  detection plus frontend tests for the new key and download UI

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UWU2gfHKsEW8r6GaLNxEVx