### PR TITLE
Add expandable voice model settings dropdown and voice model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Tests and alternate application entry points can inject `DatabaseConfig(provider
     - Currently supported Models: llama_3_1
     - This can be run from python scripts/download_models.py 
     - If the download script doesn't work, direct download links can be found at : https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/tree/main
+    - Voice (STT/TTS) models can be pre-fetched into the Hugging Face cache with
+      `python scripts/download_models.py --voice_model <name|all>`; list the
+      available names with `--list_voice_models`.
 
 
 client/geist/.env settings:

--- a/app/services/memory_service.py
+++ b/app/services/memory_service.py
@@ -27,7 +27,9 @@ from app.services.memory_scheduler import schedule_chat_memory
 FOLDER_COLORS = {"violet", "blue", "mint", "amber", "rose", "slate"}
 
 
-def _folder_dict(folder: MemoryFolder, chat_count: int = 0, summary: str | None = None):
+def _folder_dict(
+    folder: MemoryFolder, chat_count: int = 0, summary: str | None = None
+) -> dict[str, Any]:
     return {
         "folder_id": folder.folder_id,
         "name": folder.name,
@@ -277,7 +279,7 @@ def update_chat_memory_settings(
         if chat.memory_enabled and int(chat.memory_revision or 0) > int(
             chat.memory_processed_revision or 0
         ):
-            schedule = (user_id, chat_session_id, int(chat.memory_revision))
+            schedule = (user_id, chat_session_id, int(chat.memory_revision or 0))
     if schedule is not None:
         schedule_chat_memory(*schedule)
     return result
@@ -439,8 +441,10 @@ def update_memory_record(
             return None
         record.content = clean_content
         record.content_hash = hashlib.sha256(clean_content.encode("utf-8")).hexdigest()
-        record.importance = 1.0
-        record.confidence = 1.0
+        # RATCHET: old-style Column(Float) attributes reject plain float
+        # assignments under mypy until models move to Mapped[] declarations.
+        record.importance = 1.0  # type: ignore[assignment]
+        record.confidence = 1.0  # type: ignore[assignment]
         embedding = (
             session.query(MemoryEmbedding)
             .filter(MemoryEmbedding.memory_id == memory_id)

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -1773,6 +1773,82 @@ ul.relative {
   font-weight: 720;
 }
 
+.voice-settings {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+}
+
+.voice-settings-toggle {
+  display: grid;
+  place-items: center;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 40px;
+  color: var(--geist-color-text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: var(--geist-radius-md);
+  cursor: pointer;
+}
+
+.voice-settings-toggle:hover:not(:disabled),
+.voice-settings-toggle.expanded {
+  color: var(--geist-color-text);
+  background: var(--geist-color-surface-strong);
+}
+
+.voice-settings-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.voice-settings-panel {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  display: grid;
+  gap: 8px;
+  width: 260px;
+  padding: 12px;
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-lg);
+  box-shadow: var(--geist-shadow-panel);
+}
+
+.voice-settings-title {
+  color: var(--geist-color-text);
+  font-size: 0.78rem;
+  font-weight: 720;
+}
+
+.voice-settings-field {
+  display: grid;
+  gap: 4px;
+  color: var(--geist-color-text-muted);
+  font-size: 0.72rem;
+}
+
+.voice-settings-field select {
+  width: 100%;
+  padding: 6px 8px;
+  color: var(--geist-color-text);
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
+}
+
+.voice-settings-status {
+  color: var(--geist-color-text-muted);
+  font-size: 0.72rem;
+}
+
+.voice-settings-error {
+  color: var(--geist-color-danger);
+}
+
 .suggestion-menu {
   position: absolute;
   right: 0;

--- a/client/geist/src/Components/EnhancedChatInput.tsx
+++ b/client/geist/src/Components/EnhancedChatInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, KeyboardEvent } from 'react';
 import { fileReferenceParser, FileItem } from '../Utils/fileReferenceParser';
 import VoiceButton from './VoiceButton';
+import VoiceSettings, { DEFAULT_VOICE_SELECTION, VoiceSelection } from './VoiceSettings';
 import useVoiceChat from '../Hooks/useVoiceChat';
 
 interface EnhancedChatInputProps {
@@ -36,6 +37,8 @@ const EnhancedChatInput: React.FC<EnhancedChatInputProps> = ({
   const [currentAtPosition, setCurrentAtPosition] = useState(-1);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const [voiceSelection, setVoiceSelection] = useState<VoiceSelection>(DEFAULT_VOICE_SELECTION);
+
   const {
     isRecording,
     isProcessing,
@@ -43,6 +46,11 @@ const EnhancedChatInput: React.FC<EnhancedChatInputProps> = ({
     toggleRecording
   } = useVoiceChat({
     sessionId,
+    sttProvider: voiceSelection.sttProvider,
+    ttsProvider: voiceSelection.ttsProvider,
+    ttsModel: voiceSelection.ttsModel,
+    ttsVoice: voiceSelection.ttsVoice,
+    ttsLanguage: voiceSelection.ttsLanguage,
     onTranscriptFinal: (text) => {
       onChange(text);
     },
@@ -184,12 +192,19 @@ const EnhancedChatInput: React.FC<EnhancedChatInputProps> = ({
         />
 
         {enableVoice && (
-          <VoiceButton
-            isRecording={isRecording}
-            isProcessing={isProcessing}
-            onClick={toggleRecording}
-            disabled={disabled}
-          />
+          <>
+            <VoiceSettings
+              selection={voiceSelection}
+              onChange={setVoiceSelection}
+              disabled={disabled || isRecording}
+            />
+            <VoiceButton
+              isRecording={isRecording}
+              isProcessing={isProcessing}
+              onClick={toggleRecording}
+              disabled={disabled}
+            />
+          </>
         )}
 
         <button

--- a/client/geist/src/Components/VoiceSettings.tsx
+++ b/client/geist/src/Components/VoiceSettings.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import useVoiceModels, { TTSModelInfo, TTSProviderInfo } from '../Hooks/useVoiceModels';
+
+export interface VoiceSelection {
+  sttProvider: string;
+  ttsProvider: string;
+  ttsModel?: string;
+  ttsVoice?: string;
+  ttsLanguage?: string;
+}
+
+// Matches the backend defaults in app/api/v1/endpoints/voice.py, so leaving
+// the panel untouched keeps today's behavior (local MMS STT + Sesame CSM TTS).
+export const DEFAULT_VOICE_SELECTION: VoiceSelection = {
+  sttProvider: 'mms',
+  ttsProvider: 'sesame'
+};
+
+const STT_PROVIDERS = [
+  { id: 'mms', display_name: 'MMS (local)' },
+  { id: 'whisper', display_name: 'Whisper (OpenAI API)' }
+];
+
+interface VoiceSettingsProps {
+  selection: VoiceSelection;
+  onChange: (selection: VoiceSelection) => void;
+  disabled?: boolean;
+}
+
+const VoiceSettings: React.FC<VoiceSettingsProps> = ({
+  selection,
+  onChange,
+  disabled = false
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const { data, loading, error } = useVoiceModels(expanded);
+
+  const providerInfo: TTSProviderInfo | undefined = data?.providers.find(
+    p => p.provider === selection.ttsProvider
+  );
+  const activeModelId = selection.ttsModel || providerInfo?.default_model;
+  const modelInfo: TTSModelInfo | undefined = providerInfo?.models.find(
+    m => m.id === activeModelId
+  );
+
+  const selectionForModel = (
+    provider: TTSProviderInfo,
+    model: TTSModelInfo | undefined
+  ): VoiceSelection => ({
+    ...selection,
+    ttsProvider: provider.provider,
+    ttsModel: model?.id,
+    ttsVoice: model?.voices[0]?.id,
+    ttsLanguage: model?.languages[0]?.code
+  });
+
+  const handleProviderChange = (providerId: string) => {
+    const provider = data?.providers.find(p => p.provider === providerId);
+    if (!provider) {
+      return;
+    }
+    const model = provider.models.find(m => m.id === provider.default_model) || provider.models[0];
+    onChange(selectionForModel(provider, model));
+  };
+
+  const handleModelChange = (modelId: string) => {
+    if (!providerInfo) {
+      return;
+    }
+    const model = providerInfo.models.find(m => m.id === modelId);
+    onChange(selectionForModel(providerInfo, model));
+  };
+
+  return (
+    <div className="voice-settings">
+      <button
+        type="button"
+        className={`voice-settings-toggle${expanded ? ' expanded' : ''}`}
+        onClick={() => setExpanded(prev => !prev)}
+        disabled={disabled}
+        aria-expanded={expanded}
+        aria-label="Voice settings"
+        title={disabled ? 'Stop recording to change voice settings' : 'Voice settings'}
+      >
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          {expanded ? (
+            <path d="M10 6l6 8H4l6-8z" />
+          ) : (
+            <path d="M10 14l-6-8h12l-6 8z" />
+          )}
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="voice-settings-panel">
+          <div className="voice-settings-title">Voice settings</div>
+
+          <label className="voice-settings-field">
+            Speech to text
+            <select
+              value={selection.sttProvider}
+              onChange={e => onChange({ ...selection, sttProvider: e.target.value })}
+            >
+              {STT_PROVIDERS.map(provider => (
+                <option key={provider.id} value={provider.id}>
+                  {provider.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {loading && <div className="voice-settings-status">Loading voice models...</div>}
+          {error && <div className="voice-settings-status voice-settings-error">{error}</div>}
+
+          {data && (
+            <>
+              <label className="voice-settings-field">
+                Voice provider
+                <select
+                  value={selection.ttsProvider}
+                  onChange={e => handleProviderChange(e.target.value)}
+                >
+                  {data.providers.map(provider => (
+                    <option key={provider.provider} value={provider.provider}>
+                      {provider.display_name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {providerInfo && providerInfo.models.length > 1 && (
+                <label className="voice-settings-field">
+                  Model
+                  <select
+                    value={activeModelId || ''}
+                    onChange={e => handleModelChange(e.target.value)}
+                  >
+                    {providerInfo.models.map(model => (
+                      <option key={model.id} value={model.id}>
+                        {model.display_name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              {modelInfo && modelInfo.voices.length > 1 && (
+                <label className="voice-settings-field">
+                  Voice
+                  <select
+                    value={selection.ttsVoice || modelInfo.voices[0].id}
+                    onChange={e => onChange({ ...selection, ttsVoice: e.target.value })}
+                  >
+                    {modelInfo.voices.map(voice => (
+                      <option key={voice.id} value={voice.id}>
+                        {voice.display_name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              {modelInfo && modelInfo.languages.length > 1 && (
+                <label className="voice-settings-field">
+                  Language
+                  <select
+                    value={selection.ttsLanguage || modelInfo.languages[0].code}
+                    onChange={e => onChange({ ...selection, ttsLanguage: e.target.value })}
+                  >
+                    {modelInfo.languages.map(language => (
+                      <option key={language.code} value={language.code}>
+                        {language.display_name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VoiceSettings;

--- a/client/geist/src/Components/__tests__/VoiceSettings.test.tsx
+++ b/client/geist/src/Components/__tests__/VoiceSettings.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import VoiceSettings, { DEFAULT_VOICE_SELECTION } from '../VoiceSettings';
+
+const voiceModelsResponse = {
+  default_provider: 'sesame',
+  providers: [
+    {
+      provider: 'sesame',
+      display_name: 'Sesame CSM',
+      type: 'local',
+      default_model: 'sesame/csm-1b',
+      models: [
+        {
+          id: 'sesame/csm-1b',
+          display_name: 'Sesame CSM 1B',
+          sample_rate: 24000,
+          supports_streaming: false,
+          streaming_mode: 'chunked_full_audio',
+          supports_instruction_control: false,
+          supports_voice_cloning: false,
+          voices: [{ id: '0', display_name: 'Default Speaker' }],
+          languages: [{ code: 'en', display_name: 'English' }],
+        },
+      ],
+    },
+    {
+      provider: 'qwen3',
+      display_name: 'Qwen3 TTS',
+      type: 'local',
+      default_model: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice',
+      models: [
+        {
+          id: 'Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice',
+          display_name: 'Qwen3 TTS 0.6B Custom Voice',
+          sample_rate: 24000,
+          supports_streaming: true,
+          streaming_mode: 'native_or_chunked',
+          supports_instruction_control: true,
+          supports_voice_cloning: false,
+          voices: [
+            { id: 'Cherry', display_name: 'Cherry' },
+            { id: 'Ethan', display_name: 'Ethan' },
+          ],
+          languages: [
+            { code: 'en', display_name: 'English' },
+            { code: 'ja', display_name: 'Japanese' },
+          ],
+        },
+        {
+          id: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice',
+          display_name: 'Qwen3 TTS 1.7B Custom Voice',
+          sample_rate: 24000,
+          supports_streaming: true,
+          streaming_mode: 'native_or_chunked',
+          supports_instruction_control: true,
+          supports_voice_cloning: false,
+          voices: [
+            { id: 'Cherry', display_name: 'Cherry' },
+            { id: 'Ethan', display_name: 'Ethan' },
+          ],
+          languages: [
+            { code: 'en', display_name: 'English' },
+            { code: 'ja', display_name: 'Japanese' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('VoiceSettings', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  it('renders collapsed without fetching voice models', () => {
+    render(
+      <VoiceSettings selection={DEFAULT_VOICE_SELECTION} onChange={() => {}} />
+    );
+
+    expect(screen.getByLabelText('Voice settings')).toBeInTheDocument();
+    expect(screen.queryByText('Speech to text')).not.toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('expands, fetches the catalog, and preselects the defaults', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => voiceModelsResponse,
+    });
+
+    render(
+      <VoiceSettings selection={DEFAULT_VOICE_SELECTION} onChange={() => {}} />
+    );
+
+    fireEvent.click(screen.getByLabelText('Voice settings'));
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/v1/voice/models');
+    expect(screen.getByLabelText(/Speech to text/i)).toHaveValue('mms');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Voice provider/i)).toHaveValue('sesame');
+    });
+
+    // Sesame has a single model/voice/language, so those selects stay hidden
+    expect(screen.queryByLabelText(/Model/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Voice$/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Language/)).not.toBeInTheDocument();
+  });
+
+  it('selecting a provider resets model, voice, and language to its defaults', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => voiceModelsResponse,
+    });
+    const onChange = jest.fn();
+
+    render(<VoiceSettings selection={DEFAULT_VOICE_SELECTION} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText('Voice settings'));
+    await waitFor(() => screen.getByLabelText(/Voice provider/i));
+
+    fireEvent.change(screen.getByLabelText(/Voice provider/i), {
+      target: { value: 'qwen3' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      sttProvider: 'mms',
+      ttsProvider: 'qwen3',
+      ttsModel: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice',
+      ttsVoice: 'Cherry',
+      ttsLanguage: 'en',
+    });
+  });
+
+  it('shows model, voice, and language selects for multi-option providers', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => voiceModelsResponse,
+    });
+    const onChange = jest.fn();
+
+    render(
+      <VoiceSettings
+        selection={{
+          sttProvider: 'mms',
+          ttsProvider: 'qwen3',
+          ttsModel: 'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice',
+          ttsVoice: 'Cherry',
+          ttsLanguage: 'en',
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Voice settings'));
+    await waitFor(() => screen.getByLabelText(/Voice provider/i));
+
+    expect(screen.getByLabelText(/Model/)).toHaveValue(
+      'Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice'
+    );
+
+    fireEvent.change(screen.getByLabelText(/^Voice$/), { target: { value: 'Ethan' } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsVoice: 'Ethan' })
+    );
+
+    fireEvent.change(screen.getByLabelText(/Language/), { target: { value: 'ja' } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsLanguage: 'ja' })
+    );
+  });
+
+  it('surfaces an error when the catalog fails to load', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Internal Server Error',
+    });
+
+    render(
+      <VoiceSettings selection={DEFAULT_VOICE_SELECTION} onChange={() => {}} />
+    );
+
+    fireEvent.click(screen.getByLabelText('Voice settings'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to load voice models/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/client/geist/src/Hooks/useVoiceModels.tsx
+++ b/client/geist/src/Hooks/useVoiceModels.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface VoiceOption {
+  id: string;
+  display_name: string;
+}
+
+export interface LanguageOption {
+  code: string;
+  display_name: string;
+}
+
+export interface TTSModelInfo {
+  id: string;
+  display_name: string;
+  sample_rate: number;
+  supports_streaming: boolean;
+  streaming_mode: string;
+  supports_instruction_control: boolean;
+  supports_voice_cloning: boolean;
+  voices: VoiceOption[];
+  languages: LanguageOption[];
+}
+
+export interface TTSProviderInfo {
+  provider: string;
+  display_name: string;
+  type: string;
+  default_model: string;
+  models: TTSModelInfo[];
+}
+
+export interface VoiceModelsResponse {
+  default_provider: string;
+  providers: TTSProviderInfo[];
+}
+
+interface UseVoiceModelsReturn {
+  data: VoiceModelsResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetches the supported voice/TTS provider catalog from the backend.
+ * The fetch is deferred until `enabled` is true so the chat input does not
+ * hit the API unless the user actually opens the voice settings panel.
+ */
+const useVoiceModels = (enabled: boolean): UseVoiceModelsReturn => {
+  const [data, setData] = useState<VoiceModelsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || requestedRef.current) {
+      return;
+    }
+    requestedRef.current = true;
+
+    let cancelled = false;
+    setLoading(true);
+
+    fetch('/api/v1/voice/models')
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to load voice models: ${response.statusText}`);
+        }
+        return response.json();
+      })
+      .then((json: VoiceModelsResponse) => {
+        if (!cancelled) {
+          setData(json);
+          setError(null);
+        }
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load voice models');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { data, loading, error };
+};
+
+export default useVoiceModels;

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -3,10 +3,46 @@ import os
 import re
 import subprocess
 
-from huggingface_hub import snapshot_download
+from huggingface_hub import hf_hub_download, snapshot_download
 
 
 DEFAULT_MODEL_ID = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+# Voice models load through the Hugging Face cache (`from_pretrained` /
+# `hf_hub_download`) rather than app/model_weights, so they are pre-fetched
+# into the cache instead of a local_dir. Each entry lists the repos to fetch;
+# "allow_patterns" limits a fetch to the files the runtime actually loads.
+VOICE_MODELS: dict[str, dict] = {
+    "sesame-csm-1b": {
+        "description": "Sesame CSM 1B TTS (+ Mimi audio codec and Llama tokenizer)",
+        "downloads": [
+            {"repo_id": "sesame/csm-1b"},
+            # Mimi codec weights used by agents/architectures/sesame/generator.py
+            # (see MIMI_NAME in agents/architectures/moshi/models/loaders.py).
+            {
+                "repo_id": "kyutai/moshiko-pytorch-bf16",
+                "allow_patterns": ["tokenizer-e351c8d8-checkpoint125.safetensors"],
+            },
+            # Gated repo: only the tokenizer files are needed for CSM text input.
+            {
+                "repo_id": "meta-llama/Llama-3.2-1B",
+                "allow_patterns": ["tokenizer*", "special_tokens_map.json"],
+            },
+        ],
+    },
+    "qwen3-tts-0.6b": {
+        "description": "Qwen3 TTS 0.6B Custom Voice",
+        "downloads": [{"repo_id": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"}],
+    },
+    "qwen3-tts-1.7b": {
+        "description": "Qwen3 TTS 1.7B Custom Voice",
+        "downloads": [{"repo_id": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"}],
+    },
+    "mms-1b-all": {
+        "description": "Meta MMS 1B speech-to-text (adapters/mms_adapter.py)",
+        "downloads": [{"repo_id": "facebook/mms-1b-all"}],
+    },
+}
 
 
 def model_dir_name(model_id):
@@ -47,6 +83,31 @@ def download_model_weights(model_id, weights_dir=None, use_cli=False, revision=N
     print("Download complete!")
 
 
+def download_voice_model_weights(voice_model):
+    """Pre-fetch a voice (STT/TTS) model into the Hugging Face cache."""
+    if voice_model not in VOICE_MODELS:
+        raise ValueError(
+            f"Unknown voice model '{voice_model}'. "
+            f"Available: {', '.join(sorted(VOICE_MODELS))}"
+        )
+
+    token = os.environ.get("HUGGING_FACE_HUB_TOKEN") or os.environ.get("HF_TOKEN")
+    spec = VOICE_MODELS[voice_model]
+    print(f"Downloading {voice_model}: {spec['description']}")
+
+    for download in spec["downloads"]:
+        repo_id = download["repo_id"]
+        allow_patterns = download.get("allow_patterns")
+        if allow_patterns and len(allow_patterns) == 1 and "*" not in allow_patterns[0]:
+            print(f"Fetching {allow_patterns[0]} from {repo_id}")
+            hf_hub_download(repo_id=repo_id, filename=allow_patterns[0], token=token)
+        else:
+            print(f"Fetching {repo_id} into the Hugging Face cache")
+            snapshot_download(repo_id=repo_id, token=token, allow_patterns=allow_patterns)
+
+    print("Download complete!")
+
+
 # Backward-compatible import for existing scripts.
 download_llama_weights = download_model_weights
 
@@ -60,7 +121,22 @@ if __name__ == "__main__":
                         help="Optional immutable model revision")
     parser.add_argument("--use_cli", action="store_true",
                         help="Use huggingface-cli for downloading instead of transformers")
+    parser.add_argument("--voice_model", type=str, default=None,
+                        choices=[*sorted(VOICE_MODELS), "all"],
+                        help="Pre-fetch a voice (STT/TTS) model into the Hugging Face "
+                             "cache instead of downloading an LLM. Use 'all' for every "
+                             "voice model. Gated repos need HUGGING_FACE_HUB_TOKEN.")
+    parser.add_argument("--list_voice_models", action="store_true",
+                        help="List downloadable voice models and exit")
 
     args = parser.parse_args()
 
-    download_model_weights(args.model_id, args.weights_dir, args.use_cli, args.revision)
+    if args.list_voice_models:
+        for name in sorted(VOICE_MODELS):
+            print(f"{name}: {VOICE_MODELS[name]['description']}")
+    elif args.voice_model:
+        names = sorted(VOICE_MODELS) if args.voice_model == "all" else [args.voice_model]
+        for name in names:
+            download_voice_model_weights(name)
+    else:
+        download_model_weights(args.model_id, args.weights_dir, args.use_cli, args.revision)

--- a/tests/scripts/test_download_models.py
+++ b/tests/scripts/test_download_models.py
@@ -1,8 +1,15 @@
 """Tests for model-specific weight download locations."""
 import os
 
+import pytest
+
 from scripts.copy_weights import model_dir_name as copy_model_dir_name
-from scripts.download_models import DEFAULT_MODEL_ID, default_weights_dir
+from scripts.download_models import (
+    DEFAULT_MODEL_ID,
+    VOICE_MODELS,
+    default_weights_dir,
+    download_voice_model_weights,
+)
 
 
 def test_default_llama_download_preserves_legacy_mlx_directory():
@@ -19,3 +26,57 @@ def test_model_directories_cannot_escape_on_windows_or_posix():
 
     assert os.path.dirname(download_path) == "app/model_weights"
     assert copy_model_dir_name(hostile_model_id) == "_.._private_model"
+
+
+def test_unknown_voice_model_is_rejected():
+    with pytest.raises(ValueError, match="Unknown voice model"):
+        download_voice_model_weights("not-a-voice-model")
+
+
+def test_voice_models_download_into_hugging_face_cache(monkeypatch):
+    """Voice runtimes load via from_pretrained/hf_hub_download, so voice
+    downloads must go to the HF cache (no local_dir) to be found offline."""
+    snapshot_calls = []
+    file_calls = []
+
+    monkeypatch.setattr(
+        "scripts.download_models.snapshot_download",
+        lambda **kwargs: snapshot_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "scripts.download_models.hf_hub_download",
+        lambda **kwargs: file_calls.append(kwargs),
+    )
+
+    for name in VOICE_MODELS:
+        download_voice_model_weights(name)
+
+    assert all("local_dir" not in call for call in snapshot_calls)
+    fetched_repos = {call["repo_id"] for call in snapshot_calls + file_calls}
+    assert "sesame/csm-1b" in fetched_repos
+    assert "facebook/mms-1b-all" in fetched_repos
+    # Sesame needs the Mimi codec weights alongside the CSM checkpoint
+    assert any(
+        call["repo_id"] == "kyutai/moshiko-pytorch-bf16" for call in file_calls
+    )
+
+
+def test_voice_registry_covers_local_tts_provider_models():
+    """Every locally-run TTS model published to the frontend should be
+    downloadable through the voice model registry."""
+    tts = pytest.importorskip("app.services.tts")
+
+    registry_repos = {
+        download["repo_id"]
+        for spec in VOICE_MODELS.values()
+        for download in spec["downloads"]
+    }
+
+    for provider in tts.SUPPORTED_TTS_PROVIDERS:
+        if provider["type"] != "local":
+            continue
+        for model in provider["models"]:
+            assert model["id"] in registry_repos, (
+                f"Local TTS model {model['id']} is not downloadable via "
+                "scripts/download_models.py VOICE_MODELS"
+            )


### PR DESCRIPTION
## Description

Surfaces the backend's voice provider catalog in the chat UI and makes the voice models downloadable ahead of time.

**Expandable voice settings dropdown (unobtrusive by default)**
- New `VoiceSettings` component: a small chevron toggle next to the mic button in `EnhancedChatInput`. Collapsed, it adds no visual noise and makes no network calls; the defaults (local MMS speech-to-text + Sesame CSM text-to-speech) stay exactly as today.
- On first expand, a new `useVoiceModels` hook lazily fetches `/api/v1/voice/models` and the panel offers selects for STT provider (MMS / Whisper), TTS provider (Sesame CSM / OpenAI TTS / Qwen3 TTS), and — when the chosen provider has more than one option — model, voice, and language.
- Switching provider or model resets the dependent voice/language selections to that provider's defaults.
- Selections thread through `useVoiceChat` into the voice WebSocket query parameters (`stt_provider`, `tts_provider`, `tts_model`, `tts_voice`, `tts_language`) that the backend already validates against its published model lists. The toggle is disabled mid-recording since settings apply when a session connects.

**Voice model downloads**
- `scripts/download_models.py` gains a voice model registry with `--voice_model <name|all>` and `--list_voice_models`. Registered: `sesame-csm-1b` (plus its Mimi codec weights and the Llama-3.2-1B tokenizer files), `qwen3-tts-0.6b`, `qwen3-tts-1.7b`, and `mms-1b-all`.
- Unlike LLM weights, these are pre-fetched into the Hugging Face cache (no `local_dir`) because the voice runtimes load via `from_pretrained` / `hf_hub_download`, so a cache pre-fetch is what actually makes the first voice session start without a blocking download.
- README documents the new flags.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Added `VoiceSettings.test.tsx`: collapsed state makes no fetch; expanding fetches the catalog and preselects defaults; provider changes reset model/voice/language; single-option selects stay hidden; fetch errors surface in the panel.
- Added download-script tests: unknown voice model rejected; voice downloads go to the HF cache (never `local_dir`); registry stays in sync with every local model published in `SUPPORTED_TTS_PROVIDERS`.
- Verified the script CLI end-to-end locally with a stubbed `huggingface_hub`; `ruff check` passes on the touched Python files.
- Frontend/backend test suites were not run locally (dependency installation is gated in this environment) — relying on CI for the full run.

- [x] Added new tests for new functionality
- [x] Updated existing tests

## Security Checklist

- [x] No secrets or credentials committed
- [x] Input validation added where necessary (TTS model ids remain validated server-side against the published provider lists; the dropdown only submits catalog values)

## Code Quality

- [x] Code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## CI/CD Pipeline

- [ ] All CI checks pass (pending)

## Additional Notes

The dropdown intentionally reuses the existing `/api/v1/voice/models` metadata endpoint added with the Qwen3 TTS work, closing the "full voice settings UI" non-goal left open in `plans/151-QWEN3-VOICE-TTS.md`. `tts_instruct` and `tts_speed` are already plumbed through the hook and WebSocket and can be added to the panel later without API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RLcpsBsEhCNHJuqors2V

---
_Generated by [Claude Code](https://claude.ai/code/session_0135RLcpsBsEhCNHJuqors2V)_