### PR TITLE
Add SOTA local voice models: Parakeet/faster-whisper STT, Kokoro/CosyVoice2 TTS, Silero VAD

### DIFF
--- a/adapters/faster_whisper_adapter.py
+++ b/adapters/faster_whisper_adapter.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+import numpy as np
+
+from adapters.inert_adapter import InertAdapter
+
+
+DEFAULT_FASTER_WHISPER_MODEL = "large-v3-turbo"
+
+
+class FasterWhisperAdapter(InertAdapter):
+    '''
+    FasterWhisperAdapter runs OpenAI Whisper models locally via the
+    faster-whisper (CTranslate2) runtime. Requires the optional
+    'faster-whisper' package.
+    '''
+
+    def __init__(
+        self,
+        model: str = DEFAULT_FASTER_WHISPER_MODEL,
+        device: str | None = None,
+        compute_type: str = "auto",
+        **kwargs,
+    ):
+        self.model_id = model
+        self.device = device
+        self.compute_type = compute_type
+        self._model: Any = None
+
+    def enumerate_actions(self) -> list[str]:
+        return ["transcribe"]
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError as e:
+            raise RuntimeError(
+                "The faster_whisper STT provider requires the optional "
+                "'faster-whisper' package (pip install faster-whisper==1.2.1). "
+                "Install it or select another stt_provider. "
+                f"Import failed with: {e}"
+            ) from e
+
+        if self.device is None:
+            import torch
+
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        self._model = WhisperModel(
+            self.model_id, device=self.device, compute_type=self.compute_type
+        )
+
+    def transcribe(self, audio_data, language: str = "en") -> str:
+        self._ensure_model()
+
+        audio = np.asarray(audio_data, dtype=np.float32)
+        segments, _info = self._model.transcribe(
+            audio, language=language or None, beam_size=5
+        )
+        return " ".join(segment.text.strip() for segment in segments).strip()

--- a/adapters/parakeet_adapter.py
+++ b/adapters/parakeet_adapter.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import numpy as np
+
+from adapters.inert_adapter import InertAdapter
+
+
+DEFAULT_PARAKEET_MODEL = "nvidia/parakeet-tdt-0.6b-v3"
+
+
+class ParakeetAdapter(InertAdapter):
+    '''
+    ParakeetAdapter runs NVIDIA Parakeet ASR models locally via the NeMo
+    toolkit. Requires the optional 'nemo-toolkit[asr]' package, which is
+    intentionally not a declared dependency (heavy dependency tree); the
+    adapter fails loudly if it is missing.
+    '''
+
+    def __init__(self, model: str = DEFAULT_PARAKEET_MODEL, **kwargs):
+        self.model_id = model
+        self._model: Any = None
+
+    def enumerate_actions(self) -> list[str]:
+        return ["transcribe"]
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+
+        try:
+            import nemo.collections.asr as nemo_asr
+        except ImportError as e:
+            raise RuntimeError(
+                "The parakeet STT provider requires the optional "
+                "'nemo-toolkit[asr]' package (pip install 'nemo-toolkit[asr]'). "
+                "Install it or select another stt_provider. "
+                f"Import failed with: {e}"
+            ) from e
+
+        model = nemo_asr.models.ASRModel.from_pretrained(model_name=self.model_id)
+        model.eval()
+        self._model = model
+
+    @staticmethod
+    def _extract_text(result) -> str:
+        # NeMo returns a list per input; entries are strings, Hypothesis
+        # objects with .text, or (best, all) tuples depending on version.
+        if isinstance(result, tuple):
+            result = result[0]
+        if isinstance(result, list):
+            if not result:
+                return ""
+            result = result[0]
+        text = getattr(result, "text", result)
+        return str(text).strip()
+
+    def transcribe(self, audio_data, language: str = "en") -> str:
+        self._ensure_model()
+
+        audio = np.asarray(audio_data, dtype=np.float32)
+        outputs = self._model.transcribe([audio])
+        return self._extract_text(outputs)

--- a/app/api/v1/endpoints/voice.py
+++ b/app/api/v1/endpoints/voice.py
@@ -17,6 +17,7 @@ from agents.base_agent import BaseAgent
 from agents.prompt.prompt import AGENT_PROMPTS
 from app.models.user_settings import AgentConfigRequest
 from app.services.agent_context_provider import get_default_agent_context
+from app.services.stt import get_supported_stt_providers
 from app.services.tts import get_supported_tts_providers
 from app.services.user_settings_service import UserSettingsService
 from app.services.voice_session import VoiceSessionService
@@ -64,6 +65,7 @@ async def get_agent_for_session(
 def _build_provider_kwargs(
     stt_provider: str,
     tts_provider: str,
+    stt_model: str | None = None,
     tts_model: str | None = None,
     tts_voice: str | None = None,
     tts_language: str | None = None,
@@ -76,6 +78,7 @@ def _build_provider_kwargs(
     Args:
         stt_provider: Selected STT provider name.
         tts_provider: Selected TTS provider name.
+        stt_model: Optional STT model override.
         tts_model: Optional TTS model override.
         tts_voice: Optional TTS voice override.
         tts_language: Optional language code override.
@@ -93,6 +96,8 @@ def _build_provider_kwargs(
     if tts_provider == "openai":
         provider_kwargs["api_key"] = os.getenv("OPENAI_API_KEY")
 
+    if stt_model:
+        provider_kwargs["stt_model"] = stt_model
     if tts_model:
         provider_kwargs["model"] = tts_model
     if tts_voice:
@@ -113,6 +118,8 @@ async def list_voice_models():
     return {
         "default_provider": "sesame",
         "providers": get_supported_tts_providers(),
+        "default_stt_provider": "mms",
+        "stt_providers": get_supported_stt_providers(),
     }
 
 
@@ -121,8 +128,13 @@ async def voice_stream_websocket(
     websocket: WebSocket,
     session_id: int = Query(..., description="Chat session ID"),
     agent_type: str = Query("online", description="Agent type (online or local)"),
-    stt_provider: str = Query("mms", description="STT provider (mms or whisper)"),
-    tts_provider: str = Query("sesame", description="TTS provider (sesame, openai, or qwen3)"),
+    stt_provider: str = Query(
+        "mms", description="STT provider (mms, whisper, faster_whisper, or parakeet)"
+    ),
+    tts_provider: str = Query(
+        "sesame", description="TTS provider (sesame, openai, qwen3, kokoro, or cosyvoice2)"
+    ),
+    stt_model: str | None = Query(None, description="STT model ID override"),
     tts_model: str | None = Query(None, description="TTS model ID override"),
     tts_voice: str | None = Query(None, description="TTS voice override"),
     tts_language: str | None = Query(None, description="TTS language code override"),
@@ -165,6 +177,7 @@ async def voice_stream_websocket(
         provider_kwargs = _build_provider_kwargs(
             stt_provider=stt_provider,
             tts_provider=tts_provider,
+            stt_model=stt_model,
             tts_model=tts_model,
             tts_voice=tts_voice,
             tts_language=tts_language,
@@ -264,6 +277,7 @@ async def voice_upload(
     agent_type: str = Query("online"),
     stt_provider: str = Query("mms"),
     tts_provider: str = Query("sesame"),
+    stt_model: str | None = Query(None),
     tts_model: str | None = Query(None),
     tts_voice: str | None = Query(None),
     tts_language: str | None = Query(None),
@@ -284,6 +298,7 @@ async def voice_upload(
         provider_kwargs = _build_provider_kwargs(
             stt_provider=stt_provider,
             tts_provider=tts_provider,
+            stt_model=stt_model,
             tts_model=tts_model,
             tts_voice=tts_voice,
             tts_language=tts_language,

--- a/app/services/stt.py
+++ b/app/services/stt.py
@@ -1,0 +1,176 @@
+"""
+Speech-to-Text (STT) provider catalog and factory.
+
+Mirrors the TTS provider pattern in app/services/tts.py: published metadata
+for the frontend, a model-id allowlist (the model string is client-controlled
+and reaches model loaders), and a string-keyed factory.
+"""
+
+import logging
+from typing import Any, Protocol
+
+from adapters.faster_whisper_adapter import (
+    DEFAULT_FASTER_WHISPER_MODEL,
+    FasterWhisperAdapter,
+)
+from adapters.mms_adapter import MMSAdapter
+from adapters.parakeet_adapter import DEFAULT_PARAKEET_MODEL, ParakeetAdapter
+from adapters.whisper_adapter import WhisperAdapter
+
+
+logger = logging.getLogger(__name__)
+
+
+class STTAdapter(Protocol):
+    """Structural type for STT adapters: anything with a transcribe method."""
+
+    def transcribe(self, audio_data: Any, language: str = "en") -> str: ...
+
+
+SUPPORTED_STT_PROVIDERS: list[dict[str, Any]] = [
+    {
+        "provider": "mms",
+        "display_name": "Meta MMS",
+        "type": "local",
+        "default_model": "facebook/mms-1b-all",
+        "models": [
+            {
+                "id": "facebook/mms-1b-all",
+                "display_name": "MMS 1B (all languages)",
+                "sample_rate": 16000,
+            }
+        ],
+    },
+    {
+        "provider": "whisper",
+        "display_name": "OpenAI Whisper API",
+        "type": "api",
+        "default_model": "whisper-1",
+        "models": [
+            {
+                "id": "whisper-1",
+                "display_name": "Whisper (OpenAI API)",
+                "sample_rate": 16000,
+            }
+        ],
+    },
+    {
+        "provider": "faster_whisper",
+        "display_name": "Whisper (local, faster-whisper)",
+        "type": "local",
+        "default_model": DEFAULT_FASTER_WHISPER_MODEL,
+        "models": [
+            {
+                "id": "large-v3-turbo",
+                "display_name": "Whisper large-v3-turbo",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "large-v3",
+                "display_name": "Whisper large-v3",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "distil-large-v3",
+                "display_name": "Distil-Whisper large-v3",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "medium",
+                "display_name": "Whisper medium",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "small",
+                "display_name": "Whisper small",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "base",
+                "display_name": "Whisper base",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "tiny",
+                "display_name": "Whisper tiny",
+                "sample_rate": 16000,
+            },
+        ],
+    },
+    {
+        "provider": "parakeet",
+        "display_name": "NVIDIA Parakeet",
+        "type": "local",
+        "default_model": DEFAULT_PARAKEET_MODEL,
+        "models": [
+            {
+                "id": DEFAULT_PARAKEET_MODEL,
+                "display_name": "Parakeet TDT 0.6B v3",
+                "sample_rate": 16000,
+            },
+            {
+                "id": "nvidia/parakeet-tdt-0.6b-v2",
+                "display_name": "Parakeet TDT 0.6B v2",
+                "sample_rate": 16000,
+            },
+        ],
+    },
+]
+
+
+def get_supported_stt_providers() -> list[dict[str, Any]]:
+    """Return frontend-consumable metadata for supported STT providers."""
+    return SUPPORTED_STT_PROVIDERS
+
+
+def allowed_models_for_stt_provider(provider_type: str) -> list[str]:
+    for entry in SUPPORTED_STT_PROVIDERS:
+        if entry["provider"] == provider_type:
+            return [model["id"] for model in entry.get("models", [])]
+    return []
+
+
+def _validate_stt_model(provider_type: str, model: str) -> str:
+    """
+    Reject model ids that are not in the provider's published list.
+
+    The model string is client-controlled and reaches model loaders
+    (e.g. from_pretrained), so it must never be an arbitrary repo id or
+    filesystem path.
+    """
+    allowed = allowed_models_for_stt_provider(provider_type)
+    if allowed and model not in allowed:
+        raise ValueError(
+            f"Model '{model}' is not a supported {provider_type} STT model. "
+            f"Supported models: {allowed}"
+        )
+    return model
+
+
+def create_stt_adapter(provider_type: str = "mms", **kwargs) -> STTAdapter:
+    """
+    Factory function to create an STT adapter.
+
+    Args:
+        provider_type: "mms", "whisper", "faster_whisper", or "parakeet"
+        **kwargs: Provider-specific arguments (whisper_api_key, stt_model,
+            stt_device)
+    """
+    provider = provider_type.lower().replace("-", "_")
+
+    if provider == "mms":
+        return MMSAdapter()
+    if provider == "whisper":
+        return WhisperAdapter(api_key=kwargs.get("whisper_api_key"))
+    if provider == "faster_whisper":
+        model = _validate_stt_model(
+            "faster_whisper", kwargs.get("stt_model") or DEFAULT_FASTER_WHISPER_MODEL
+        )
+        return FasterWhisperAdapter(model=model, device=kwargs.get("stt_device"))
+    if provider == "parakeet":
+        model = _validate_stt_model(
+            "parakeet", kwargs.get("stt_model") or DEFAULT_PARAKEET_MODEL
+        )
+        return ParakeetAdapter(model=model)
+
+    raise ValueError(f"Unknown STT provider: {provider_type}")

--- a/app/services/tts.py
+++ b/app/services/tts.py
@@ -19,6 +19,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_QWEN3_TTS_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+DEFAULT_KOKORO_MODEL = "hexgrad/Kokoro-82M"
+DEFAULT_COSYVOICE2_MODEL = "FunAudioLLM/CosyVoice2-0.5B"
+
+# Kokoro selects its G2P pipeline by single-letter language code.
+KOKORO_LANG_CODES = {
+    "en": "a",
+    "en-us": "a",
+    "en-gb": "b",
+    "es": "e",
+    "fr": "f",
+    "hi": "h",
+    "it": "i",
+    "ja": "j",
+    "pt": "p",
+    "zh": "z",
+}
 
 SUPPORTED_TTS_PROVIDERS: list[dict[str, Any]] = [
     {
@@ -144,6 +160,70 @@ SUPPORTED_TTS_PROVIDERS: list[dict[str, Any]] = [
                     {"code": "it", "display_name": "Italian"},
                 ],
             },
+        ],
+    },
+    {
+        "provider": "kokoro",
+        "display_name": "Kokoro",
+        "type": "local",
+        "default_model": DEFAULT_KOKORO_MODEL,
+        "models": [
+            {
+                "id": DEFAULT_KOKORO_MODEL,
+                "display_name": "Kokoro 82M",
+                "sample_rate": 24000,
+                "supports_streaming": True,
+                "streaming_mode": "segment_streaming",
+                "supports_instruction_control": False,
+                "supports_voice_cloning": False,
+                "voices": [
+                    {"id": "af_heart", "display_name": "Heart (US female)"},
+                    {"id": "af_bella", "display_name": "Bella (US female)"},
+                    {"id": "af_nicole", "display_name": "Nicole (US female)"},
+                    {"id": "af_sky", "display_name": "Sky (US female)"},
+                    {"id": "am_adam", "display_name": "Adam (US male)"},
+                    {"id": "am_michael", "display_name": "Michael (US male)"},
+                    {"id": "bf_emma", "display_name": "Emma (UK female)"},
+                    {"id": "bf_isabella", "display_name": "Isabella (UK female)"},
+                    {"id": "bm_george", "display_name": "George (UK male)"},
+                    {"id": "bm_lewis", "display_name": "Lewis (UK male)"},
+                ],
+                "languages": [
+                    {"code": "en", "display_name": "English (US)"},
+                    {"code": "en-gb", "display_name": "English (UK)"},
+                    {"code": "es", "display_name": "Spanish"},
+                    {"code": "fr", "display_name": "French"},
+                    {"code": "hi", "display_name": "Hindi"},
+                    {"code": "it", "display_name": "Italian"},
+                    {"code": "ja", "display_name": "Japanese"},
+                    {"code": "pt", "display_name": "Portuguese"},
+                    {"code": "zh", "display_name": "Chinese"},
+                ],
+            }
+        ],
+    },
+    {
+        "provider": "cosyvoice2",
+        "display_name": "CosyVoice2",
+        "type": "local",
+        "default_model": DEFAULT_COSYVOICE2_MODEL,
+        "models": [
+            {
+                "id": DEFAULT_COSYVOICE2_MODEL,
+                "display_name": "CosyVoice2 0.5B",
+                "sample_rate": 24000,
+                "supports_streaming": True,
+                "streaming_mode": "native",
+                "supports_instruction_control": False,
+                "supports_voice_cloning": True,
+                "voices": [{"id": "default", "display_name": "Default"}],
+                "languages": [
+                    {"code": "en", "display_name": "English"},
+                    {"code": "zh", "display_name": "Chinese"},
+                    {"code": "ja", "display_name": "Japanese"},
+                    {"code": "ko", "display_name": "Korean"},
+                ],
+            }
         ],
     },
 ]
@@ -572,12 +652,210 @@ class Qwen3TTSProvider(TTSProvider):
         return self._sample_rate
 
 
+class KokoroTTSProvider(TTSProvider):
+    """
+    TTS provider using the Kokoro-82M model (optional 'kokoro' package).
+
+    Lightweight enough for CPU; streams audio per text segment as the
+    pipeline produces it.
+    """
+
+    def __init__(
+        self,
+        voice: str = "af_heart",
+        language: str = "en",
+        speed: float = 1.0,
+        device: str | None = None,
+    ):
+        self.voice = voice
+        self.language = language
+        self.speed = speed
+        self.device = device
+        self._pipeline = None
+        self._sample_rate = 24000
+        self.logger = logging.getLogger(__name__)
+
+    def _ensure_initialized(self):
+        if self._pipeline is not None:
+            return
+
+        try:
+            from kokoro import KPipeline
+        except ImportError as e:
+            raise RuntimeError(
+                "The kokoro TTS provider requires the optional 'kokoro' "
+                "package (pip install kokoro==0.9.4). Install it or select "
+                "another tts_provider. "
+                f"Import failed with: {e}"
+            ) from e
+
+        lang_code = KOKORO_LANG_CODES.get(self.language.lower(), "a")
+        self.logger.info(f"Initializing Kokoro TTS (lang_code={lang_code})")
+        self._pipeline = KPipeline(
+            lang_code=lang_code, repo_id=DEFAULT_KOKORO_MODEL, device=self.device
+        )
+
+    @staticmethod
+    def _segment_audio(item: Any) -> torch.Tensor:
+        audio = getattr(item, "audio", None)
+        if audio is None and isinstance(item, tuple | list) and len(item) >= 3:
+            audio = item[2]
+        if audio is None:
+            raise RuntimeError("Kokoro pipeline returned a segment with no audio")
+        if isinstance(audio, np.ndarray):
+            audio = torch.from_numpy(audio)
+        return cast(torch.Tensor, audio.detach().cpu().float().squeeze())
+
+    def _segments(self, text: str) -> Iterator[torch.Tensor]:
+        self._ensure_initialized()
+        pipeline = self._pipeline
+        if pipeline is None:
+            raise RuntimeError("Kokoro TTS pipeline failed to initialize")
+
+        for item in pipeline(text, voice=self.voice, speed=self.speed):
+            yield self._segment_audio(item)
+
+    def synthesize(self, text: str, speaker: int = 0) -> torch.Tensor:
+        segments = list(self._segments(text))
+        if not segments:
+            return torch.zeros(0)
+        return torch.cat(segments)
+
+    def synthesize_streaming(
+        self, text: str, speaker: int = 0, chunk_size_ms: int = 100
+    ) -> Iterator[bytes]:
+        chunk_samples = int(self._sample_rate * chunk_size_ms / 1000)
+
+        for segment in self._segments(text):
+            audio_np = np.clip(segment.numpy(), -1.0, 1.0)
+            audio_int16 = (audio_np * 32767).astype(np.int16)
+            for i in range(0, len(audio_int16), chunk_samples):
+                yield audio_int16[i : i + chunk_samples].tobytes()
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+
+class CosyVoice2TTSProvider(TTSProvider):
+    """
+    TTS provider using CosyVoice2 with native low-latency streaming.
+
+    Experimental: requires the 'cosyvoice' package from the FunAudioLLM
+    CosyVoice repository, which is intentionally not a declared dependency.
+    CosyVoice2-0.5B is a zero-shot model, so a reference voice is required:
+    set COSYVOICE2_PROMPT_AUDIO (path to a short wav of the target voice)
+    and COSYVOICE2_PROMPT_TEXT (its transcript) on the server. Falls back
+    to pretrained speaker ids when the loaded model ships any.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_COSYVOICE2_MODEL,
+        voice: str = "default",
+        speed: float = 1.0,
+        sample_rate: int = 24000,
+    ):
+        self.model = model
+        self.voice = voice
+        self.speed = speed
+        self._sample_rate = sample_rate
+        self._engine = None
+        self._prompt_speech: torch.Tensor | None = None
+        self._prompt_text: str | None = None
+        self.logger = logging.getLogger(__name__)
+
+    def _ensure_initialized(self):
+        if self._engine is not None:
+            return
+
+        try:
+            from cosyvoice.cli.cosyvoice import CosyVoice2
+        except ImportError as e:
+            raise RuntimeError(
+                "The cosyvoice2 TTS provider requires the optional 'cosyvoice' "
+                "package from the FunAudioLLM/CosyVoice repository and is "
+                "experimental. Install it or select another tts_provider. "
+                f"Import failed with: {e}"
+            ) from e
+
+        from huggingface_hub import snapshot_download
+
+        self.logger.info(f"Initializing CosyVoice2 TTS: {self.model}")
+        model_dir = snapshot_download(self.model)
+        self._engine = CosyVoice2(model_dir)
+        self._sample_rate = int(getattr(self._engine, "sample_rate", self._sample_rate))
+        self._load_prompt_voice()
+
+    def _load_prompt_voice(self):
+        """Load the operator-configured reference voice for zero-shot synthesis."""
+        import os
+
+        prompt_audio = os.getenv("COSYVOICE2_PROMPT_AUDIO")
+        prompt_text = os.getenv("COSYVOICE2_PROMPT_TEXT")
+        if not prompt_audio or not prompt_text:
+            return
+
+        waveform, source_rate = torchaudio.load(prompt_audio)
+        waveform = torch.mean(waveform, dim=0, keepdim=True)
+        if source_rate != 16000:
+            waveform = torchaudio.functional.resample(waveform, source_rate, 16000)
+        self._prompt_speech = waveform
+        self._prompt_text = prompt_text
+
+    def _stream_outputs(self, text: str, stream: bool) -> Iterator[torch.Tensor]:
+        self._ensure_initialized()
+        engine = self._engine
+        if engine is None:
+            raise RuntimeError("CosyVoice2 engine failed to initialize")
+
+        if self._prompt_speech is not None and self._prompt_text is not None:
+            outputs = engine.inference_zero_shot(
+                text, self._prompt_text, self._prompt_speech, stream=stream, speed=self.speed
+            )
+        else:
+            available = []
+            if hasattr(engine, "list_available_spks"):
+                available = list(engine.list_available_spks() or [])
+            if not available:
+                raise RuntimeError(
+                    "CosyVoice2-0.5B has no pretrained speakers; configure "
+                    "COSYVOICE2_PROMPT_AUDIO and COSYVOICE2_PROMPT_TEXT with a "
+                    "reference voice sample for zero-shot synthesis."
+                )
+            spk_id = self.voice if self.voice in available else available[0]
+            outputs = engine.inference_sft(text, spk_id, stream=stream, speed=self.speed)
+
+        for output in outputs:
+            speech = output["tts_speech"] if isinstance(output, dict) else output
+            yield speech.detach().cpu().float().squeeze()
+
+    def synthesize(self, text: str, speaker: int = 0) -> torch.Tensor:
+        segments = list(self._stream_outputs(text, stream=False))
+        if not segments:
+            return torch.zeros(0)
+        return torch.cat(segments)
+
+    def synthesize_streaming(
+        self, text: str, speaker: int = 0, chunk_size_ms: int = 100
+    ) -> Iterator[bytes]:
+        for segment in self._stream_outputs(text, stream=True):
+            audio_np = np.clip(segment.numpy(), -1.0, 1.0)
+            audio_int16 = (audio_np * 32767).astype(np.int16)
+            yield audio_int16.tobytes()
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+
 def create_tts_provider(provider_type: str = "sesame", **kwargs) -> TTSProvider:
     """
     Factory function to create TTS provider.
 
     Args:
-        provider_type: Type of provider ("sesame", "openai", or "qwen3")
+        provider_type: Type of provider ("sesame", "openai", "qwen3",
+            "kokoro", or "cosyvoice2")
         **kwargs: Provider-specific arguments
 
     Returns:
@@ -601,6 +879,23 @@ def create_tts_provider(provider_type: str = "sesame", **kwargs) -> TTSProvider:
             instruct=kwargs.get("instruct"),
             speed=float(kwargs.get("speed", 1.0)),
             device=kwargs.get("device"),
+            sample_rate=int(kwargs.get("sample_rate", 24000)),
+        )
+    elif provider_type.lower() == "kokoro":
+        _validate_tts_model("kokoro", kwargs.get("model", DEFAULT_KOKORO_MODEL))
+        return KokoroTTSProvider(
+            voice=kwargs.get("voice", "af_heart"),
+            language=kwargs.get("language", "en"),
+            speed=float(kwargs.get("speed", 1.0)),
+            device=kwargs.get("device"),
+        )
+    elif provider_type.lower() == "cosyvoice2":
+        return CosyVoice2TTSProvider(
+            model=_validate_tts_model(
+                "cosyvoice2", kwargs.get("model", DEFAULT_COSYVOICE2_MODEL)
+            ),
+            voice=kwargs.get("voice", "default"),
+            speed=float(kwargs.get("speed", 1.0)),
             sample_rate=int(kwargs.get("sample_rate", 24000)),
         )
     else:

--- a/app/services/vad.py
+++ b/app/services/vad.py
@@ -1,0 +1,160 @@
+"""
+Voice activity detection (VAD) providers for the voice pipeline.
+
+Two implementations: a Silero VAD neural model (optional 'silero-vad'
+package) and the original RMS energy threshold. The "auto" factory mode
+prefers Silero and falls back to RMS when the package is not installed.
+"""
+
+import importlib.util
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+# Silero VAD consumes fixed-size windows: 512 samples at 16kHz, 256 at 8kHz.
+SILERO_WINDOW_SIZES = {16000: 512, 8000: 256}
+
+
+class VADProvider(ABC):
+    """Abstract base class for voice activity detectors."""
+
+    @abstractmethod
+    def is_speech(self, audio_chunk: np.ndarray) -> bool:
+        """Return True if the chunk (float32 mono, [-1, 1]) contains speech."""
+
+    def reset(self) -> None:
+        """Reset any streaming state between utterances/sessions."""
+        return
+
+
+class RMSVAD(VADProvider):
+    """Energy-threshold VAD (the original behavior)."""
+
+    def __init__(self, threshold: float = 0.01):
+        self.threshold = threshold
+
+    def is_speech(self, audio_chunk: np.ndarray) -> bool:
+        rms = float(np.sqrt(np.mean(audio_chunk**2)))
+        return rms > self.threshold
+
+
+class SileroVAD(VADProvider):
+    """
+    Neural VAD using the Silero VAD model (optional 'silero-vad' package).
+
+    The model is stateful across calls; degrades permanently to an RMS
+    fallback if inference fails at runtime so a broken VAD never takes
+    down a live voice session.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        sample_rate: int = 16000,
+        rms_fallback_threshold: float = 0.01,
+    ):
+        if sample_rate not in SILERO_WINDOW_SIZES:
+            raise ValueError(
+                f"Silero VAD supports sample rates {sorted(SILERO_WINDOW_SIZES)}, "
+                f"got {sample_rate}"
+            )
+        self.threshold = threshold
+        self.sample_rate = sample_rate
+        self.window_size = SILERO_WINDOW_SIZES[sample_rate]
+        self._model: Any = None
+        self._fallback = RMSVAD(threshold=rms_fallback_threshold)
+        self._failed = False
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+
+        try:
+            from silero_vad import load_silero_vad
+        except ImportError as e:
+            raise RuntimeError(
+                "The silero VAD provider requires the optional 'silero-vad' "
+                "package (pip install silero-vad==6.2.1). Install it or "
+                "select vad_provider=rms. "
+                f"Import failed with: {e}"
+            ) from e
+
+        self._model = load_silero_vad()
+
+    def is_speech(self, audio_chunk: np.ndarray) -> bool:
+        if self._failed:
+            return self._fallback.is_speech(audio_chunk)
+
+        try:
+            import torch
+
+            self._ensure_model()
+
+            audio = np.asarray(audio_chunk, dtype=np.float32)
+            if len(audio) < self.window_size:
+                audio = np.pad(audio, (0, self.window_size - len(audio)))
+
+            max_prob = 0.0
+            for start in range(0, len(audio) - self.window_size + 1, self.window_size):
+                window = torch.from_numpy(audio[start : start + self.window_size])
+                prob = float(self._model(window, self.sample_rate).item())
+                max_prob = max(max_prob, prob)
+
+            return max_prob >= self.threshold
+        except RuntimeError:
+            # Missing package: surface the actionable error to the caller.
+            raise
+        except Exception as e:
+            logger.error(f"Silero VAD inference failed, falling back to RMS: {e}")
+            self._failed = True
+            return self._fallback.is_speech(audio_chunk)
+
+    def reset(self) -> None:
+        if self._model is not None:
+            try:
+                self._model.reset_states()
+            except Exception as e:
+                logger.debug(f"Silero VAD reset failed: {e}")
+
+
+def create_vad(
+    provider: str = "auto",
+    rms_threshold: float = 0.01,
+    silero_threshold: float = 0.5,
+    sample_rate: int = 16000,
+) -> VADProvider:
+    """
+    Factory for VAD providers.
+
+    Args:
+        provider: "silero", "rms", or "auto" (silero when the package is
+            installed, otherwise rms)
+    """
+    provider = provider.lower()
+
+    if provider == "rms":
+        return RMSVAD(threshold=rms_threshold)
+
+    if provider == "silero":
+        return SileroVAD(
+            threshold=silero_threshold,
+            sample_rate=sample_rate,
+            rms_fallback_threshold=rms_threshold,
+        )
+
+    if provider == "auto":
+        if importlib.util.find_spec("silero_vad") is not None:
+            return SileroVAD(
+                threshold=silero_threshold,
+                sample_rate=sample_rate,
+                rms_fallback_threshold=rms_threshold,
+            )
+        logger.info("silero-vad not installed; using RMS energy VAD")
+        return RMSVAD(threshold=rms_threshold)
+
+    raise ValueError(f"Unknown VAD provider: {provider}")

--- a/app/services/voice_session.py
+++ b/app/services/voice_session.py
@@ -9,10 +9,10 @@ from typing import Any
 
 import numpy as np
 
-from adapters.mms_adapter import MMSAdapter
-from adapters.whisper_adapter import WhisperAdapter
 from agents.base_agent import BaseAgent
+from app.services.stt import STTAdapter, create_stt_adapter
 from app.services.tts import TTSProvider, create_tts_provider
+from app.services.vad import VADProvider, create_vad
 
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ class VoiceSessionService:
         tts_provider: str = "sesame",
         sample_rate: int = 16000,
         vad_threshold: float = 0.01,
+        vad_provider: str = "auto",
         silence_duration_ms: int = 800,
         chunk_duration_ms: int = 100,
         **provider_kwargs,
@@ -45,10 +46,13 @@ class VoiceSessionService:
 
         Args:
             agent: Agent to use for text completion
-            stt_provider: STT provider ("mms" or "whisper")
-            tts_provider: TTS provider ("sesame", "openai", or "qwen3")
+            stt_provider: STT provider ("mms", "whisper", "faster_whisper",
+                or "parakeet")
+            tts_provider: TTS provider ("sesame", "openai", "qwen3",
+                "kokoro", or "cosyvoice2")
             sample_rate: Audio sample rate in Hz
             vad_threshold: Voice activity detection threshold (RMS)
+            vad_provider: VAD provider ("silero", "rms", or "auto")
             silence_duration_ms: Silence duration to trigger phrase boundary (ms)
             chunk_duration_ms: Audio chunk duration for processing (ms)
             **provider_kwargs: Additional provider-specific arguments
@@ -60,14 +64,12 @@ class VoiceSessionService:
         self.chunk_duration_ms = chunk_duration_ms
 
         # Initialize STT
-        self.stt: MMSAdapter | WhisperAdapter
-        if stt_provider.lower() == "mms":
-            self.stt = MMSAdapter()
-        elif stt_provider.lower() == "whisper":
-            api_key = provider_kwargs.get("whisper_api_key")
-            self.stt = WhisperAdapter(api_key=api_key)
-        else:
-            raise ValueError(f"Unknown STT provider: {stt_provider}")
+        self.stt: STTAdapter = create_stt_adapter(stt_provider, **provider_kwargs)
+
+        # Initialize VAD
+        self.vad: VADProvider = create_vad(
+            vad_provider, rms_threshold=vad_threshold, sample_rate=sample_rate
+        )
 
         # Initialize TTS
         self.tts: TTSProvider = create_tts_provider(tts_provider, **provider_kwargs)
@@ -85,9 +87,8 @@ class VoiceSessionService:
         return float(np.sqrt(np.mean(audio_chunk**2)))
 
     def _detect_speech(self, audio_chunk: np.ndarray) -> bool:
-        """Simple VAD using RMS threshold."""
-        rms = self._calculate_rms(audio_chunk)
-        return rms > self.vad_threshold
+        """Voice activity detection via the configured VAD provider."""
+        return self.vad.is_speech(audio_chunk)
 
     def add_audio_chunk(self, audio_chunk: bytes) -> str | None:
         """
@@ -256,4 +257,5 @@ class VoiceSessionService:
         self.audio_buffer.clear()
         self.transcript_buffer = ""
         self.silence_frames = 0
+        self.vad.reset()
         self.logger.info("Voice session reset")

--- a/plans/155-SOTA-LOCAL-VOICE-MODELS.md
+++ b/plans/155-SOTA-LOCAL-VOICE-MODELS.md
@@ -1,0 +1,103 @@
+# 155 — SOTA Local Voice Models
+
+## Goal
+
+Close the gap between Geist's voice pipeline and the current state of the art
+in local speech models:
+
+1. **Local STT** — the only accurate STT option was the OpenAI Whisper API;
+   the local option (Meta MMS 1B) is well behind the Open ASR Leaderboard.
+   Add NVIDIA Parakeet TDT (leaderboard-class WER at very high throughput)
+   and local Whisper via faster-whisper (CTranslate2).
+2. **Lightweight TTS** — Sesame CSM-1B needs a real GPU. Add Kokoro-82M,
+   which runs on CPU or ~2-3 GB VRAM with strong quality.
+3. **Neural VAD** — replace the hand-rolled RMS threshold with Silero VAD
+   (with RMS retained as fallback).
+4. **Streaming TTS** — add CosyVoice2-0.5B, which supports native
+   low-latency incremental synthesis (plan 145 listed true streaming TTS as
+   known future work).
+
+## What was built
+
+### STT
+
+- `adapters/faster_whisper_adapter.py` — `FasterWhisperAdapter`, lazy-loads
+  `faster_whisper.WhisperModel`. Default model `large-v3-turbo`; allowlisted
+  sizes down to `tiny`.
+- `adapters/parakeet_adapter.py` — `ParakeetAdapter`, lazy-loads NeMo
+  `ASRModel.from_pretrained`. Default `nvidia/parakeet-tdt-0.6b-v3`.
+- `app/services/stt.py` — new STT catalog + factory mirroring the TTS
+  pattern: `SUPPORTED_STT_PROVIDERS` metadata, `_validate_stt_model`
+  allowlist (the model id is client-controlled and reaches model loaders),
+  and `create_stt_adapter()`. `VoiceSessionService` now uses the factory
+  instead of a hardcoded if/elif.
+
+### VAD
+
+- `app/services/vad.py` — `VADProvider` ABC with `SileroVAD` (512-sample
+  windows at 16 kHz, stateful, `reset()` between utterances) and `RMSVAD`
+  (original behavior). `create_vad("auto")` prefers Silero when the
+  `silero-vad` package is installed and falls back to RMS otherwise, so
+  default deployments are unchanged until the package is added. Runtime
+  inference failures degrade permanently to RMS rather than breaking a live
+  session.
+
+### TTS
+
+- `KokoroTTSProvider` in `app/services/tts.py` — optional `kokoro` package,
+  per-segment streaming (audio starts before the full text is synthesized),
+  multi-language via Kokoro lang codes, curated voice list in metadata.
+- `CosyVoice2TTSProvider` in `app/services/tts.py` — experimental, optional
+  `cosyvoice` package (FunAudioLLM/CosyVoice repo). Native `stream=True`
+  incremental synthesis. CosyVoice2-0.5B is zero-shot, so the reference
+  voice comes from server-side env config (`COSYVOICE2_PROMPT_AUDIO` +
+  `COSYVOICE2_PROMPT_TEXT`), never from client input; falls back to
+  pretrained speaker ids when the loaded model ships any.
+
+### API
+
+- `GET /api/v1/voice/models` now also returns `stt_providers` metadata.
+- `/voice/stream` and `/voice/upload` accept `stt_model` and the new
+  provider names (`stt_provider=faster_whisper|parakeet`,
+  `tts_provider=kokoro|cosyvoice2`).
+
+## Dependencies (intentionally undeclared)
+
+Following the qwen_tts precedent from plan 151, the new model packages are
+not declared in `pyproject.toml`; each provider fails loudly at first use
+with install instructions:
+
+| Feature | Package |
+| --- | --- |
+| faster_whisper STT | `pip install faster-whisper==1.2.1` |
+| parakeet STT | `pip install "nemo-toolkit[asr]"` |
+| silero VAD | `pip install silero-vad==6.2.1` |
+| kokoro TTS | `pip install kokoro==0.9.4` |
+| cosyvoice2 TTS | CosyVoice repo install (FunAudioLLM/CosyVoice) |
+
+Rationale: NeMo and CosyVoice have heavy dependency trees that conflict
+easily with the pinned inference stack, and re-locking against the pytorch
+CPU index was not possible in the implementation environment. Promoting the
+well-behaved ones (faster-whisper, silero-vad, kokoro) to declared extras
+with a regenerated `uv.lock` is a good follow-up.
+
+## Non-goals
+
+- Wiring the vendored Moshi speech-to-speech stack into the app (tracked
+  separately; larger project).
+- Voice cloning from client-supplied audio (security: file paths and audio
+  must not come from the client).
+- Frontend selector UI for the new providers (the `/models` endpoint now
+  exposes everything needed).
+
+## Testing
+
+- `tests/services/test_stt.py` — catalog metadata, factory lazy-construction,
+  model allowlist rejection, missing-package errors, transcription result
+  coercion with fake engines.
+- `tests/services/test_vad.py` — RMS behavior, auto-fallback, Silero
+  windowing/threshold with a fake model, reset propagation.
+- `tests/services/test_tts.py` — Kokoro/CosyVoice2 metadata, factory,
+  streaming with fake pipelines/engines, allowlist rejection.
+- `tests/services/test_voice_session.py` — updated to mock the STT factory;
+  VAD wiring covered via provider override.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ voice = [
     "sounddevice==0.5.0",
     "sphn==0.1.12",
 ]
+# Optional voice-model packages are intentionally undeclared, following the
+# qwen_tts precedent (plan 151): providers fail loudly at runtime with
+# install instructions. faster-whisper (faster_whisper STT), silero-vad
+# (neural VAD), kokoro (kokoro TTS), nemo-toolkit[asr] (parakeet STT), and
+# cosyvoice (cosyvoice2 TTS). See plans/155-SOTA-LOCAL-VOICE-MODELS.md.
 
 [dependency-groups]
 dev = [

--- a/tests/services/test_stt.py
+++ b/tests/services/test_stt.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for speech-to-text provider catalog and factory.
+"""
+import numpy as np
+import pytest
+
+from adapters.faster_whisper_adapter import (
+    DEFAULT_FASTER_WHISPER_MODEL,
+    FasterWhisperAdapter,
+)
+from adapters.parakeet_adapter import DEFAULT_PARAKEET_MODEL, ParakeetAdapter
+from adapters.whisper_adapter import WhisperAdapter
+from app.services.stt import create_stt_adapter, get_supported_stt_providers
+
+
+def test_supported_stt_providers_include_new_local_providers():
+    providers = get_supported_stt_providers()
+    names = {provider["provider"] for provider in providers}
+
+    assert {"mms", "whisper", "faster_whisper", "parakeet"} <= names
+
+    faster_whisper = next(p for p in providers if p["provider"] == "faster_whisper")
+    assert faster_whisper["type"] == "local"
+    assert faster_whisper["default_model"] == DEFAULT_FASTER_WHISPER_MODEL
+    assert any(m["id"] == "large-v3-turbo" for m in faster_whisper["models"])
+
+    parakeet = next(p for p in providers if p["provider"] == "parakeet")
+    assert parakeet["type"] == "local"
+    assert parakeet["default_model"] == DEFAULT_PARAKEET_MODEL
+
+
+def test_create_faster_whisper_adapter_is_lazy():
+    adapter = create_stt_adapter("faster_whisper", stt_model="small")
+
+    assert isinstance(adapter, FasterWhisperAdapter)
+    assert adapter.model_id == "small"
+    assert adapter._model is None
+
+
+def test_create_parakeet_adapter_is_lazy():
+    adapter = create_stt_adapter("parakeet")
+
+    assert isinstance(adapter, ParakeetAdapter)
+    assert adapter.model_id == DEFAULT_PARAKEET_MODEL
+    assert adapter._model is None
+
+
+def test_create_whisper_adapter_passes_api_key():
+    adapter = create_stt_adapter("whisper", whisper_api_key="key123")
+
+    assert isinstance(adapter, WhisperAdapter)
+    assert adapter.api_key == "key123"
+
+
+def test_create_stt_adapter_rejects_unlisted_faster_whisper_model():
+    with pytest.raises(ValueError, match="not a supported faster_whisper STT model"):
+        create_stt_adapter("faster_whisper", stt_model="../local/path")
+
+
+def test_create_stt_adapter_rejects_unlisted_parakeet_model():
+    with pytest.raises(ValueError, match="not a supported parakeet STT model"):
+        create_stt_adapter("parakeet", stt_model="attacker/arbitrary-hf-repo")
+
+
+def test_create_stt_adapter_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unknown STT provider"):
+        create_stt_adapter("nonexistent")
+
+
+def test_faster_whisper_missing_package_raises_friendly_error(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "faster_whisper":
+            raise ImportError("No module named 'faster_whisper'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+    adapter = FasterWhisperAdapter()
+    with pytest.raises(RuntimeError, match="faster-whisper"):
+        adapter.transcribe(np.zeros(1600, dtype=np.float32))
+
+
+def test_parakeet_missing_package_raises_friendly_error(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name.startswith("nemo"):
+            raise ImportError("No module named 'nemo'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+    adapter = ParakeetAdapter()
+    with pytest.raises(RuntimeError, match="nemo-toolkit"):
+        adapter.transcribe(np.zeros(1600, dtype=np.float32))
+
+
+def test_faster_whisper_joins_segment_texts():
+    class FakeSegment:
+        def __init__(self, text):
+            self.text = text
+
+    class FakeWhisperModel:
+        def transcribe(self, audio, language=None, beam_size=5):
+            return iter([FakeSegment(" Hello"), FakeSegment("world ")]), None
+
+    adapter = FasterWhisperAdapter()
+    adapter._model = FakeWhisperModel()
+
+    assert adapter.transcribe(np.zeros(1600, dtype=np.float32)) == "Hello world"
+
+
+class _FakeHypothesis:
+    def __init__(self, text):
+        self.text = text
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        ["hello world"],
+        [_FakeHypothesis("hello world")],
+        ([_FakeHypothesis("hello world")], ["extra"]),
+    ],
+)
+def test_parakeet_extracts_text_from_nemo_output_shapes(output):
+    class FakeNemoModel:
+        def transcribe(self, audio_list):
+            return output
+
+    adapter = ParakeetAdapter()
+    adapter._model = FakeNemoModel()
+
+    assert adapter.transcribe(np.zeros(1600, dtype=np.float32)) == "hello world"

--- a/tests/services/test_tts.py
+++ b/tests/services/test_tts.py
@@ -5,7 +5,11 @@ import numpy as np
 import torch
 
 from app.services.tts import (
+    DEFAULT_COSYVOICE2_MODEL,
+    DEFAULT_KOKORO_MODEL,
     DEFAULT_QWEN3_TTS_MODEL,
+    CosyVoice2TTSProvider,
+    KokoroTTSProvider,
     Qwen3TTSProvider,
     create_tts_provider,
     get_supported_tts_providers,
@@ -112,3 +116,140 @@ def test_qwen3_missing_package_raises_friendly_error(monkeypatch):
     provider = Qwen3TTSProvider(model=DEFAULT_QWEN3_TTS_MODEL)
     with pytest.raises(RuntimeError, match="experimental"):
         provider._ensure_initialized()
+
+
+def test_supported_tts_providers_include_kokoro_and_cosyvoice2_metadata():
+    providers = get_supported_tts_providers()
+
+    kokoro = next(provider for provider in providers if provider["provider"] == "kokoro")
+    assert kokoro["type"] == "local"
+    assert kokoro["default_model"] == DEFAULT_KOKORO_MODEL
+    kokoro_model = kokoro["models"][0]
+    assert kokoro_model["supports_streaming"] is True
+    assert any(voice["id"] == "af_heart" for voice in kokoro_model["voices"])
+
+    cosyvoice2 = next(
+        provider for provider in providers if provider["provider"] == "cosyvoice2"
+    )
+    assert cosyvoice2["type"] == "local"
+    assert cosyvoice2["default_model"] == DEFAULT_COSYVOICE2_MODEL
+    assert cosyvoice2["models"][0]["streaming_mode"] == "native"
+
+
+def test_create_tts_provider_builds_kokoro_provider_without_loading_model():
+    provider = create_tts_provider(
+        "kokoro", voice="am_adam", language="en-gb", speed=1.2, device="cpu"
+    )
+
+    assert isinstance(provider, KokoroTTSProvider)
+    assert provider.voice == "am_adam"
+    assert provider.language == "en-gb"
+    assert provider.speed == 1.2
+    assert provider._pipeline is None
+    assert provider.sample_rate == 24000
+
+
+def test_kokoro_missing_package_raises_friendly_error(monkeypatch):
+    import builtins
+
+    import pytest
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "kokoro":
+            raise ImportError("No module named 'kokoro'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+    provider = KokoroTTSProvider()
+    with pytest.raises(RuntimeError, match="kokoro"):
+        provider._ensure_initialized()
+
+
+class FakeKokoroResult:
+    def __init__(self, audio):
+        self.audio = audio
+
+
+class FakeKokoroPipeline:
+    def __call__(self, text, voice, speed):
+        yield FakeKokoroResult(torch.ones(250) * 0.5)
+        yield (None, None, torch.ones(100) * 0.25)
+
+
+def test_kokoro_streams_pcm_per_segment():
+    provider = KokoroTTSProvider()
+    provider._pipeline = FakeKokoroPipeline()
+    provider._sample_rate = 1000
+
+    chunks = list(provider.synthesize_streaming("hello", chunk_size_ms=100))
+
+    # First segment (250 samples) -> 100+100+50; second (100) -> one chunk
+    assert [len(chunk) for chunk in chunks] == [200, 200, 100, 200]
+
+
+def test_kokoro_synthesize_concatenates_segments():
+    provider = KokoroTTSProvider()
+    provider._pipeline = FakeKokoroPipeline()
+
+    audio = provider.synthesize("hello")
+    assert audio.shape[0] == 350
+
+
+def test_create_tts_provider_rejects_unlisted_cosyvoice2_model():
+    import pytest
+
+    with pytest.raises(ValueError, match="not a supported cosyvoice2 TTS model"):
+        create_tts_provider("cosyvoice2", model="attacker/arbitrary-hf-repo")
+
+
+def test_cosyvoice2_streams_native_chunks_with_sft_speaker():
+    class FakeCosyVoiceEngine:
+        sample_rate = 24000
+
+        def list_available_spks(self):
+            return ["default"]
+
+        def inference_sft(self, text, spk_id, stream, speed):
+            assert stream is True
+            yield {"tts_speech": torch.ones(1, 240) * 0.5}
+            yield {"tts_speech": torch.ones(1, 120) * 0.25}
+
+    provider = CosyVoice2TTSProvider()
+    provider._engine = FakeCosyVoiceEngine()
+
+    chunks = list(provider.synthesize_streaming("hello"))
+
+    assert [len(chunk) for chunk in chunks] == [480, 240]
+
+
+def test_cosyvoice2_uses_zero_shot_when_prompt_voice_configured():
+    class FakeCosyVoiceEngine:
+        sample_rate = 24000
+
+        def inference_zero_shot(self, text, prompt_text, prompt_speech, stream, speed):
+            assert prompt_text == "reference transcript"
+            yield {"tts_speech": torch.ones(1, 100) * 0.5}
+
+    provider = CosyVoice2TTSProvider()
+    provider._engine = FakeCosyVoiceEngine()
+    provider._prompt_speech = torch.zeros(1, 16000)
+    provider._prompt_text = "reference transcript"
+
+    audio = provider.synthesize("hello")
+    assert audio.shape[0] == 100
+
+
+def test_cosyvoice2_without_speakers_or_prompt_raises_actionable_error():
+    import pytest
+
+    class FakeCosyVoiceEngine:
+        def list_available_spks(self):
+            return []
+
+    provider = CosyVoice2TTSProvider()
+    provider._engine = FakeCosyVoiceEngine()
+
+    with pytest.raises(RuntimeError, match="COSYVOICE2_PROMPT_AUDIO"):
+        provider.synthesize("hello")

--- a/tests/services/test_vad.py
+++ b/tests/services/test_vad.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for voice activity detection providers.
+"""
+import numpy as np
+import pytest
+
+from app.services.vad import RMSVAD, SileroVAD, create_vad
+
+
+def test_rms_vad_thresholding():
+    vad = RMSVAD(threshold=0.01)
+
+    assert not vad.is_speech(np.zeros(1600, dtype=np.float32))
+    assert vad.is_speech(np.ones(1600, dtype=np.float32) * 0.05)
+
+
+def test_create_vad_rms():
+    vad = create_vad("rms", rms_threshold=0.02)
+
+    assert isinstance(vad, RMSVAD)
+    assert vad.threshold == 0.02
+
+
+def test_create_vad_auto_falls_back_to_rms_when_silero_missing(monkeypatch):
+    import importlib.util
+
+    monkeypatch.setattr(
+        importlib.util, "find_spec", lambda name: None if name == "silero_vad" else object()
+    )
+
+    vad = create_vad("auto")
+    assert isinstance(vad, RMSVAD)
+
+
+def test_create_vad_rejects_unknown_provider():
+    with pytest.raises(ValueError, match="Unknown VAD provider"):
+        create_vad("nonexistent")
+
+
+def test_silero_vad_rejects_unsupported_sample_rate():
+    with pytest.raises(ValueError, match="sample rates"):
+        SileroVAD(sample_rate=44100)
+
+
+def test_silero_missing_package_raises_friendly_error(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name == "silero_vad":
+            raise ImportError("No module named 'silero_vad'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+    vad = SileroVAD()
+    with pytest.raises(RuntimeError, match="silero-vad"):
+        vad.is_speech(np.zeros(1600, dtype=np.float32))
+
+
+class FakeSileroModel:
+    """Callable stand-in returning a fixed probability per 512-sample window."""
+
+    def __init__(self, prob):
+        self.prob = prob
+        self.calls = 0
+        self.reset_calls = 0
+
+    def __call__(self, window, sample_rate):
+        import torch
+
+        assert window.shape[-1] == 512
+        assert sample_rate == 16000
+        self.calls += 1
+        return torch.tensor(self.prob)
+
+    def reset_states(self):
+        self.reset_calls += 1
+
+
+def test_silero_vad_detects_speech_above_threshold():
+    vad = SileroVAD(threshold=0.5)
+    vad._model = FakeSileroModel(prob=0.9)
+
+    # 1600 samples -> three full 512-sample windows
+    assert vad.is_speech(np.ones(1600, dtype=np.float32) * 0.1)
+    assert vad._model.calls == 3
+
+
+def test_silero_vad_rejects_silence_below_threshold():
+    vad = SileroVAD(threshold=0.5)
+    vad._model = FakeSileroModel(prob=0.1)
+
+    assert not vad.is_speech(np.zeros(1600, dtype=np.float32))
+
+
+def test_silero_vad_pads_short_chunks():
+    vad = SileroVAD(threshold=0.5)
+    vad._model = FakeSileroModel(prob=0.9)
+
+    assert vad.is_speech(np.ones(100, dtype=np.float32) * 0.1)
+    assert vad._model.calls == 1
+
+
+def test_silero_vad_degrades_to_rms_on_inference_failure():
+    class BrokenModel:
+        def __call__(self, window, sample_rate):
+            raise ValueError("boom")
+
+    vad = SileroVAD(threshold=0.5, rms_fallback_threshold=0.01)
+    vad._model = BrokenModel()
+
+    # First call fails and flips to RMS fallback; loud audio is still speech.
+    assert vad.is_speech(np.ones(1600, dtype=np.float32) * 0.05)
+    assert vad._failed
+    assert not vad.is_speech(np.zeros(1600, dtype=np.float32))
+
+
+def test_silero_vad_reset_propagates_to_model():
+    vad = SileroVAD()
+    vad._model = FakeSileroModel(prob=0.5)
+
+    vad.reset()
+    assert vad._model.reset_calls == 1

--- a/tests/services/test_voice_session.py
+++ b/tests/services/test_voice_session.py
@@ -23,9 +23,10 @@ def mock_agent():
 @pytest.fixture
 def mock_stt():
     """Create a mock STT adapter."""
-    with patch('app.services.voice_session.MMSAdapter') as MockSTT:
-        stt = MockSTT.return_value
+    with patch('app.services.voice_session.create_stt_adapter') as mock_create:
+        stt = Mock()
         stt.transcribe = Mock(return_value="test transcript")
+        mock_create.return_value = stt
         yield stt
 
 
@@ -42,11 +43,12 @@ def mock_tts():
 
 @pytest.fixture
 def voice_service(mock_agent, mock_stt, mock_tts):
-    """Create a voice session service for testing."""
+    """Create a voice session service for testing (deterministic RMS VAD)."""
     service = VoiceSessionService(
         agent=mock_agent,
         stt_provider="mms",
-        tts_provider="sesame"
+        tts_provider="sesame",
+        vad_provider="rms"
     )
     return service
 
@@ -174,6 +176,25 @@ class TestVoiceSessionService:
         # Should fall back to complete_text
         mock_agent.complete_text.assert_called_once()
         assert any(r["type"] == "text_complete" for r in responses)
+
+    def test_stt_factory_receives_provider_and_kwargs(self, mock_agent, mock_tts):
+        """The configured STT provider and kwargs reach the STT factory."""
+        with patch('app.services.voice_session.create_stt_adapter') as mock_create:
+            mock_create.return_value = Mock()
+            VoiceSessionService(
+                agent=mock_agent,
+                stt_provider="faster_whisper",
+                tts_provider="sesame",
+                vad_provider="rms",
+                stt_model="small",
+            )
+            mock_create.assert_called_once_with("faster_whisper", stt_model="small")
+
+    def test_reset_clears_vad_state(self, voice_service):
+        """Session reset propagates to the VAD provider."""
+        voice_service.vad = Mock()
+        voice_service.reset()
+        voice_service.vad.reset.assert_called_once()
 
     def test_reset(self, voice_service):
         """Test session reset."""


### PR DESCRIPTION
## Description

Closes the gap between Geist's voice pipeline and the current SOTA in local speech models (per plan `plans/155-SOTA-LOCAL-VOICE-MODELS.md`, added in this PR):

- **Local STT** — new `FasterWhisperAdapter` (local Whisper via CTranslate2, default `large-v3-turbo`, sizes down to `tiny`) and `ParakeetAdapter` (NVIDIA Parakeet TDT 0.6B v3 via NeMo, leaderboard-class WER). Previously the only accurate STT option was the cloud Whisper API; the local option (MMS-1B) is well behind current benchmarks.
- **STT catalog/factory** — new `app/services/stt.py` mirroring the TTS provider pattern: `SUPPORTED_STT_PROVIDERS` metadata, a model-id allowlist (the model string is client-controlled and reaches model loaders), and `create_stt_adapter()`. Replaces the hardcoded if/elif in `VoiceSessionService`.
- **Lightweight TTS** — `KokoroTTSProvider` (Kokoro-82M, runs on CPU or ~2–3 GB VRAM, streams audio per text segment, multi-language). Sesame CSM-1B stays the default.
- **Streaming TTS** — `CosyVoice2TTSProvider` (experimental) with native `stream=True` incremental synthesis, addressing the "true streaming TTS" future-work item from plan 145. The zero-shot reference voice comes only from server env (`COSYVOICE2_PROMPT_AUDIO`/`COSYVOICE2_PROMPT_TEXT`), never from client input.
- **Neural VAD** — new `app/services/vad.py` with `SileroVAD` (512-sample windows, stateful, resets between sessions) and the original RMS threshold as fallback. Default `auto` mode keeps existing RMS behavior until `silero-vad` is installed; runtime inference failures degrade to RMS instead of breaking a live session.
- **API** — `/voice/stream` and `/voice/upload` accept `stt_model` and the new provider names; `GET /api/v1/voice/models` now also returns STT provider metadata.

Optional model packages are intentionally **not** declared in `pyproject.toml`, following the `qwen_tts` precedent from plan 151 — each provider fails loudly at first use with exact install instructions (`faster-whisper==1.2.1`, `silero-vad==6.2.1`, `kokoro==0.9.4`, `nemo-toolkit[asr]`, CosyVoice repo). Regenerating `uv.lock` was not possible in the implementation environment (the network policy blocks `download.pytorch.org`, which the pinned CPU torch index requires); promoting the well-behaved packages to declared extras is a suggested follow-up.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix

## Testing

Docker backend tests could not be run in the implementation sandbox; both attempts hit hard network-policy blocks, verified directly:

- `docker pull python:3.11` (the Dockerfile base image) fails — the registry manifest resolves but Docker Hub's blob CDN (`production.cloudfront.docker.com`) returns 403 Forbidden, so the image cannot be built.
- Independently, `uv sync --frozen` / `uv lock` fail because the gateway rejects CONNECT to `download.pytorch.org` (403), which the pinned `pytorch-cpu` index requires on Linux.

Native MLX validation was not required (no changes to MLX runners, model loading, tokenization, generation, or `MLX_BACKEND` code paths) and would be blocked by the same pytorch index restriction regardless.

As mitigation, tests ran in a virtualenv installed from PyPI at the exact versions pinned in `pyproject.toml` (torch 2.6.0, transformers 4.57.6, fastapi 0.115.8, etc.):

- `pytest tests/services tests/adapters` — 165 passed (includes new `test_stt.py`, `test_vad.py`, extended `test_tts.py`, updated `test_voice_session.py`; collection imports `app.main`, so app startup and route registration were exercised)
- `ruff check` (0.8.4) on all changed files — clean
- `mypy` (1.13.0) on the six changed/new backend modules — clean

Please re-run the Docker suite (`docker compose up`, then `cd /opt/geist && PYTHONPATH=/opt/geist pytest`) in CI or locally before merge.

- [x] Tests pass locally
- [x] Added new tests for new functionality
- [x] Updated existing tests

## Security Checklist

- [ ] Pre-commit security hooks pass locally (not run: hooks not installed in the implementation sandbox)
- [x] No secrets or credentials committed
- [x] Dependencies scanned for vulnerabilities (no new declared dependencies)
- [x] Code reviewed for security issues (SQL injection, XSS, etc.)
- [x] Input validation added where necessary (client-controlled STT/TTS model ids validated against published allowlists before reaching `from_pretrained`/model loaders; CosyVoice2 reference-voice path is server-env-only)
- [x] Authentication/authorization properly implemented (no changes to auth surfaces)
- [x] Sensitive data properly encrypted/protected (no changes)

## Code Quality

- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable) — `plans/155-SOTA-LOCAL-VOICE-MODELS.md`
- [x] No unnecessary dependencies added

## CI/CD Pipeline

- [ ] All CI checks pass (pending)
- [ ] Security scan results reviewed (pending CI)
- [x] No critical vulnerabilities introduced
- [x] Docker images build successfully (if applicable) — no Dockerfile/lockfile changes; `uv sync --frozen` behavior unchanged (build not runnable in sandbox, see Testing)

## Additional Notes

- New provider names: `stt_provider=faster_whisper|parakeet`, `tts_provider=kokoro|cosyvoice2`; new `stt_model` query param on both voice endpoints.
- Defaults are unchanged (`mms` STT, `sesame` TTS, RMS-equivalent VAD until `silero-vad` is installed), so existing deployments behave identically.
- Follow-ups worth considering: declare `faster-whisper`/`silero-vad`/`kokoro` as extras with a regenerated `uv.lock`, and wire in the vendored Moshi stack for true speech-to-speech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fYyovQjZ4ND5nJaokUe3a