### PR TITLE
Show local model load lifecycle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 .pytest_cache
 .mypy_cache
 .ruff_cache
+.cache
 output
 .venv
 .env

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -16,6 +16,7 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
 from agents.architectures.base_runner import BaseRunner, GenerationConfig
 from agents.model_catalog import infer_model_spec
+from agents.model_load_status import model_load_status_registry
 from agents.models.llama_completion import strings_to_message_dict
 
 
@@ -40,6 +41,21 @@ class TransformersRunner(BaseRunner):
         self.trust_remote_code = False
 
     def load(self, model_id: str, device_config: dict[str, Any] | None = None) -> None:
+        model_load_status_registry.mark_loading(
+            model_id,
+            "Preparing local model files.",
+        )
+        try:
+            self._load(model_id, device_config)
+        except Exception as error:
+            model_load_status_registry.mark_failed(
+                model_id,
+                f"Model failed to load: {error}",
+            )
+            raise
+        model_load_status_registry.mark_ready(model_id)
+
+    def _load(self, model_id: str, device_config: dict[str, Any] | None = None) -> None:
         device_config = dict(device_config or {})
         allow_server_backed = bool(device_config.pop("allow_server_backed", False))
         self.model_id = model_id
@@ -79,6 +95,12 @@ class TransformersRunner(BaseRunner):
             None,
         )
         self.source = weights_dir or local_default or model_id
+        source_description = (
+            "Loading model from local files."
+            if self.source != model_id
+            else "Downloading or loading model files from the Hugging Face cache."
+        )
+        model_load_status_registry.mark_loading(model_id, source_description)
         explicit_device = device_config.pop("device", None)
         self.device = self._select_device(explicit_device)
         compile_model = bool(device_config.pop("compile", False))
@@ -203,7 +225,10 @@ class TransformersRunner(BaseRunner):
             return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
         if self.device.type == "mps":
             return torch.float16
-        return torch.float32
+        # Preserve the checkpoint dtype on CPU. Expanding an 8B bf16 checkpoint
+        # to fp32 roughly doubles its resident memory and can OOM before the
+        # first generated token.
+        return "auto"
 
     def generate(self, prompt: str, generation_config: GenerationConfig) -> list[dict[str, str]]:
         return self.complete("", prompt, generation_config)

--- a/agents/architectures/transformers_runner.py
+++ b/agents/architectures/transformers_runner.py
@@ -202,12 +202,12 @@ class TransformersRunner(BaseRunner):
             return torch.device("mps")
         return torch.device("cpu")
 
-    def _select_dtype(self, explicit: Any | None):
+    def _select_dtype(self, explicit: Any | None) -> torch.dtype | str:
         if explicit is not None:
             if isinstance(explicit, torch.dtype):
                 return explicit
             value = str(explicit).replace("torch.", "").lower()
-            dtypes = {
+            dtypes: dict[str, torch.dtype | str] = {
                 "auto": "auto",
                 "float32": torch.float32,
                 "fp32": torch.float32,
@@ -225,9 +225,10 @@ class TransformersRunner(BaseRunner):
             return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
         if self.device.type == "mps":
             return torch.float16
-        # Preserve the checkpoint dtype on CPU. Expanding an 8B bf16 checkpoint
-        # to fp32 roughly doubles its resident memory and can OOM before the
-        # first generated token.
+        # Preserve supported checkpoint dtypes on CPU. PyTorch CPU kernels do
+        # not consistently support fp16, so use bf16 for fp16 checkpoints.
+        if getattr(self.config, "torch_dtype", None) == torch.float16:
+            return torch.bfloat16
         return "auto"
 
     def generate(self, prompt: str, generation_config: GenerationConfig) -> list[dict[str, str]]:

--- a/agents/local_agent.py
+++ b/agents/local_agent.py
@@ -11,6 +11,7 @@ from agents.architectures import get_runner
 from agents.architectures.base_runner import BaseRunner, GenerationConfig
 from agents.architectures.registry import ensure_runners_registered
 from agents.base_agent import BaseAgent
+from agents.model_load_status import model_load_status_registry
 from agents.models.llama_completion import LlamaCompletion
 from agents.models.tool_calling import (
     ChatMessage,
@@ -77,11 +78,23 @@ class LocalAgent(BaseAgent):
 
         self.logger.info(f"Initializing {self.runner_type} runner with model: {self.model_id}")
         runner = runner_class()
-        runner.load(self.model_id, self.device_config)
+        model_load_status_registry.mark_loading(
+            self.model_id,
+            f"Loading model with the {self.runner_type} runtime.",
+        )
+        try:
+            runner.load(self.model_id, self.device_config)
+        except Exception as error:
+            model_load_status_registry.mark_failed(
+                self.model_id,
+                f"Model failed to load: {error}",
+            )
+            raise
         self.runner = runner
         self.supports_native_tool_calling = bool(
             getattr(runner, "supports_native_tool_calling", False)
         )
+        model_load_status_registry.mark_ready(self.model_id)
 
     def _create_generation_config(
         self,

--- a/agents/model_load_status.py
+++ b/agents/model_load_status.py
@@ -1,0 +1,91 @@
+"""Thread-safe lifecycle state for local model initialization."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Literal
+
+
+ModelLoadState = Literal["unloaded", "loading", "ready", "failed"]
+
+
+@dataclass(frozen=True)
+class ModelLoadStatus:
+    model_id: str
+    state: ModelLoadState
+    detail: str
+    started_at: datetime | None
+    updated_at: datetime
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ModelLoadStatusRegistry:
+    """Keep model load state aligned with process-local runner instances."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._statuses: dict[str, ModelLoadStatus] = {}
+
+    def get(self, model_id: str) -> ModelLoadStatus:
+        with self._lock:
+            status = self._statuses.get(model_id)
+            if status is not None:
+                return status
+        now = datetime.now(UTC)
+        return ModelLoadStatus(
+            model_id=model_id,
+            state="unloaded",
+            detail="Model is not loaded in this backend process.",
+            started_at=None,
+            updated_at=now,
+        )
+
+    def mark_loading(self, model_id: str, detail: str) -> ModelLoadStatus:
+        with self._lock:
+            current = self._statuses.get(model_id)
+            now = datetime.now(UTC)
+            status = ModelLoadStatus(
+                model_id=model_id,
+                state="loading",
+                detail=detail,
+                started_at=current.started_at if current and current.started_at else now,
+                updated_at=now,
+            )
+            self._statuses[model_id] = status
+            return status
+
+    def mark_ready(self, model_id: str) -> ModelLoadStatus:
+        return self._set_terminal(model_id, "ready", "Model is loaded and ready.")
+
+    def mark_failed(self, model_id: str, detail: str) -> ModelLoadStatus:
+        return self._set_terminal(model_id, "failed", detail)
+
+    def _set_terminal(
+        self,
+        model_id: str,
+        state: Literal["ready", "failed"],
+        detail: str,
+    ) -> ModelLoadStatus:
+        with self._lock:
+            current = self._statuses.get(model_id)
+            now = datetime.now(UTC)
+            status = ModelLoadStatus(
+                model_id=model_id,
+                state=state,
+                detail=detail,
+                started_at=current.started_at if current else now,
+                updated_at=now,
+            )
+            self._statuses[model_id] = status
+            return status
+
+    def clear(self) -> None:
+        with self._lock:
+            self._statuses.clear()
+
+
+model_load_status_registry = ModelLoadStatusRegistry()

--- a/app/api/v1/endpoints/models.py
+++ b/app/api/v1/endpoints/models.py
@@ -1,6 +1,7 @@
 """
 API endpoints for model discovery and listing.
 """
+
 import logging
 from datetime import datetime
 
@@ -17,6 +18,7 @@ from agents.architectures.registry import (
     provider_from_string,
     provider_to_string,
 )
+from agents.model_load_status import model_load_status_registry
 from app.services.local_models import get_local_model_manager
 
 
@@ -27,6 +29,7 @@ router = APIRouter()
 
 class ModelResponse(BaseModel):
     """Response model for a single model."""
+
     id: str
     name: str
     provider: str
@@ -35,7 +38,7 @@ class ModelResponse(BaseModel):
     supports_vision: bool
     supports_function_calling: bool
     supports_streaming: bool
-    #recommended models can be filtered to the top in the UI.
+    # recommended models can be filtered to the top in the UI.
     recommended: bool
     family: str | None
     backend: str | None = None
@@ -53,6 +56,7 @@ class ModelResponse(BaseModel):
 
 class ModelsListResponse(BaseModel):
     """Response model for list of models grouped by provider."""
+
     providers: dict[str, list[ModelResponse]]
     last_updated: datetime | None
 
@@ -61,6 +65,16 @@ def _model_response(model) -> ModelResponse:
     payload = model.to_dict()
     payload["local_artifacts"] = get_local_model_manager().list_artifacts(model.id)
     return ModelResponse(**payload)
+
+
+class ModelLoadStatusResponse(BaseModel):
+    """Current process-local lifecycle state for a local model."""
+
+    model_id: str
+    state: str
+    detail: str
+    started_at: datetime | None
+    updated_at: datetime
 
 
 @router.get("/", response_model=ModelsListResponse)
@@ -80,10 +94,7 @@ async def get_available_models():
                 _model_response(model) for model in models
             ]
 
-        return ModelsListResponse(
-            providers=providers_dict,
-            last_updated=get_last_model_sync_time()
-        )
+        return ModelsListResponse(providers=providers_dict, last_updated=get_last_model_sync_time())
     except Exception as e:
         logger.error(f"Error getting available models: {e}")
         raise HTTPException(status_code=500, detail="Internal server error") from e
@@ -105,7 +116,7 @@ async def get_models_by_provider(provider: str):
         if provider_enum is None:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid provider: {provider}. Valid providers: {get_provider_ids()}"
+                detail=f"Invalid provider: {provider}. Valid providers: {get_provider_ids()}",
             )
 
         models = get_models_for_provider(provider_enum)
@@ -139,6 +150,24 @@ async def get_model(model_id: str):
     except Exception as e:
         logger.error(f"Error getting model {model_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get("/status/{model_id:path}", response_model=ModelLoadStatusResponse)
+async def get_model_load_status(model_id: str):
+    """Return whether a local model is unloaded, loading, ready, or failed."""
+    model = get_model_by_id(model_id)
+    if model is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+    if not model.local:
+        now = datetime.now().astimezone()
+        return ModelLoadStatusResponse(
+            model_id=model_id,
+            state="ready",
+            detail="Remote models do not require a local load.",
+            started_at=None,
+            updated_at=now,
+        )
+    return ModelLoadStatusResponse(**model_load_status_registry.get(model_id).to_dict())
 
 
 @router.get("/providers", response_model=list[str])

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -1497,6 +1497,25 @@ textarea:focus-visible {
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
 }
 
+.model-load-indicator {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+  max-width: min(820px, 92%);
+  padding: 9px 12px;
+  color: var(--geist-color-text);
+  background: var(--geist-color-surface-strong);
+  border: 1px solid var(--geist-color-border);
+  border-left: 3px solid var(--geist-color-accent);
+  border-radius: var(--geist-radius-lg);
+  font-size: 0.85rem;
+}
+
+.model-load-failed {
+  border-left-color: var(--geist-color-danger);
+}
+
 .chat-loading-dot {
   width: 7px;
   height: 7px;

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -446,6 +446,7 @@ const Chat = () => {
           user: activeTurn!.prompt,
           ai: activeTurn!.message,
           status: activeTurn!.status,
+          model_load: activeTurn!.model_load,
           tool_calls: activeTurn!.tool_calls,
           artifacts: activeTurn!.artifacts,
         },

--- a/client/geist/src/Components/ChatTextArea.tsx
+++ b/client/geist/src/Components/ChatTextArea.tsx
@@ -35,7 +35,9 @@ const ChatTextArea = forwardRef<HTMLDivElement, ChatTextAreaProps>((props, ref) 
             {element.ai}
           </div>
 
-          {element.model_load && element.model_load.state !== 'ready' && (
+          {element.model_load
+            && (element.model_load.state === 'loading' || element.model_load.state === 'failed')
+            && (
             <div
               aria-live="polite"
               aria-label="Model loading status"

--- a/client/geist/src/Components/ChatTextArea.tsx
+++ b/client/geist/src/Components/ChatTextArea.tsx
@@ -35,7 +35,19 @@ const ChatTextArea = forwardRef<HTMLDivElement, ChatTextAreaProps>((props, ref) 
             {element.ai}
           </div>
 
-          {element.status && element.status !== 'completed' && (
+          {element.model_load && element.model_load.state !== 'ready' && (
+            <div
+              aria-live="polite"
+              aria-label="Model loading status"
+              role="status"
+              className={`model-load-indicator model-load-${element.model_load.state}`}
+            >
+              <strong>{element.model_load.model_id}</strong>
+              <span>{element.model_load.detail}</span>
+            </div>
+          )}
+
+          {element.status && element.status !== 'completed' && element.status !== 'model_loading' && (
             <div aria-live="polite" className="input-help">
               Turn status: {statusLabel(element.status)}
             </div>

--- a/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
@@ -16,6 +16,29 @@ describe('ChatTextArea loading state', () => {
 
     expect(screen.queryByRole('status', { name: 'Geist is responding' })).not.toBeInTheDocument();
   });
+
+  it('shows the selected model lifecycle while weights are loading', () => {
+    render(<ChatTextArea chatHistory={[{
+      user: 'Hello',
+      ai: '',
+      status: 'model_loading',
+      model_load: {
+        model_id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        state: 'loading',
+        detail: 'Downloading or loading model files from the Hugging Face cache.',
+        started_at: '2026-07-26T00:00:00Z',
+        updated_at: '2026-07-26T00:00:01Z',
+      },
+    }]} isLoading />);
+
+    expect(screen.getByRole('status', { name: 'Model loading status' })).toHaveTextContent(
+      'meta-llama/Meta-Llama-3.1-8B-Instruct',
+    );
+    expect(screen.getByRole('status', { name: 'Model loading status' })).toHaveTextContent(
+      'Downloading or loading model files from the Hugging Face cache.',
+    );
+    expect(screen.queryByText('Turn status: model loading')).not.toBeInTheDocument();
+  });
 });
 
 describe('ChatTextArea tool activity', () => {

--- a/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
@@ -39,6 +39,26 @@ describe('ChatTextArea loading state', () => {
     );
     expect(screen.queryByText('Turn status: model loading')).not.toBeInTheDocument();
   });
+
+  it('does not claim an unloaded model is actively loading', () => {
+    render(<ChatTextArea chatHistory={[{
+      user: 'Hello',
+      ai: '',
+      status: 'connecting',
+      model_load: {
+        model_id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        state: 'unloaded',
+        detail: 'Model is not loaded in this backend process.',
+        started_at: null,
+        updated_at: '2026-07-26T00:00:01Z',
+      },
+    }]} isLoading />);
+
+    expect(screen.queryByRole('status', { name: 'Model loading status' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Model is not loaded in this backend process.'))
+      .not.toBeInTheDocument();
+    expect(screen.getByText('Turn status: connecting')).toBeInTheDocument();
+  });
 });
 
 describe('ChatTextArea tool activity', () => {

--- a/client/geist/src/Hooks/__tests__/useCompleteText.test.tsx
+++ b/client/geist/src/Hooks/__tests__/useCompleteText.test.tsx
@@ -31,6 +31,28 @@ const streamingResponse = (chunks: string[]): Response => {
 };
 
 describe('chatStreamReducer', () => {
+  it('reflects backend model loading state before the stream starts', () => {
+    let state = chatStreamReducer(initialChatStreamState, {
+      type: 'START',
+      prompt: 'Hello',
+      chatId: null,
+    });
+
+    state = chatStreamReducer(state, {
+      type: 'MODEL_LOAD_STATUS',
+      status: {
+        model_id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        state: 'loading',
+        detail: 'Loading cached weights.',
+        started_at: '2026-07-26T00:00:00Z',
+        updated_at: '2026-07-26T00:00:01Z',
+      },
+    });
+
+    expect(state.activeTurn?.status).toBe('model_loading');
+    expect(state.activeTurn?.model_load?.detail).toBe('Loading cached weights.');
+  });
+
   it('upserts repeated tool lifecycle events by id', () => {
     let state = chatStreamReducer(initialChatStreamState, {
       type: 'START',

--- a/client/geist/src/Hooks/__tests__/useCompleteText.test.tsx
+++ b/client/geist/src/Hooks/__tests__/useCompleteText.test.tsx
@@ -4,6 +4,7 @@ import useCompleteText, {
   chatStreamReducer,
   initialChatStreamState,
 } from '../useCompleteText';
+import { UserSettings } from '../useUserSettings';
 
 
 Object.defineProperty(global, 'TextDecoder', {
@@ -30,12 +31,39 @@ const streamingResponse = (chunks: string[]): Response => {
   } as unknown as Response;
 };
 
+const localSettings = {
+  default_agent_type: 'local',
+  default_local_model: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+} as UserSettings;
+
+const pendingStreamingResponse = (signal?: AbortSignal | null): Response => ({
+  ok: true,
+  body: {
+    getReader: () => ({
+      read: jest.fn(() => new Promise((_, reject) => {
+        signal?.addEventListener('abort', () => {
+          const error = new Error('Aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      })),
+    }),
+  },
+} as unknown as Response);
+
+const flushAsyncWork = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
 describe('chatStreamReducer', () => {
   it('reflects backend model loading state before the stream starts', () => {
     let state = chatStreamReducer(initialChatStreamState, {
       type: 'START',
       prompt: 'Hello',
       chatId: null,
+      startedAt: '2026-07-26T00:00:00Z',
     });
 
     state = chatStreamReducer(state, {
@@ -51,6 +79,54 @@ describe('chatStreamReducer', () => {
 
     expect(state.activeTurn?.status).toBe('model_loading');
     expect(state.activeTurn?.model_load?.detail).toBe('Loading cached weights.');
+  });
+
+  it('ignores model status left over from an earlier turn', () => {
+    const state = chatStreamReducer(chatStreamReducer(initialChatStreamState, {
+      type: 'START',
+      prompt: 'Try again',
+      chatId: null,
+      startedAt: '2026-07-26T00:01:00Z',
+    }), {
+      type: 'MODEL_LOAD_STATUS',
+      status: {
+        model_id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        state: 'failed',
+        detail: 'Previous load failed.',
+        started_at: '2026-07-26T00:00:00Z',
+        updated_at: '2026-07-26T00:00:30Z',
+      },
+    });
+
+    expect(state.activeTurn?.status).toBe('connecting');
+    expect(state.activeTurn?.model_load).toBeUndefined();
+    expect(state.error).toBeNull();
+  });
+
+  it.each([
+    { type: 'ERROR' as const, message: 'Stream failed.' },
+    { type: 'CANCELLED' as const },
+  ])('clears model loading state on $type', (terminalAction) => {
+    let state = chatStreamReducer(initialChatStreamState, {
+      type: 'START',
+      prompt: 'Hello',
+      chatId: null,
+      startedAt: '2026-07-26T00:00:00Z',
+    });
+    state = chatStreamReducer(state, {
+      type: 'MODEL_LOAD_STATUS',
+      status: {
+        model_id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        state: 'loading',
+        detail: 'Loading cached weights.',
+        started_at: '2026-07-26T00:00:01Z',
+        updated_at: '2026-07-26T00:00:02Z',
+      },
+    });
+
+    state = chatStreamReducer(state, terminalAction);
+
+    expect(state.activeTurn?.model_load).toBeUndefined();
   });
 
   it('upserts repeated tool lifecycle events by id', () => {
@@ -133,6 +209,91 @@ describe('chatStreamReducer', () => {
 describe('useCompleteText', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stops model status polling when the endpoint returns 404', async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest.fn((url: RequestInfo | URL, options?: RequestInit) => {
+      if (String(url).startsWith('/api/v1/models/status/')) {
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }
+      return Promise.resolve(pendingStreamingResponse(options?.signal));
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { result, unmount } = renderHook(() => useCompleteText(localSettings));
+    let completionPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      completionPromise = result.current.completeText('Hello');
+    });
+    await flushAsyncWork();
+
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes('/models/status/')))
+      .toHaveLength(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes('/models/status/')))
+      .toHaveLength(1);
+
+    unmount();
+    await completionPromise;
+  });
+
+  it('backs off repeated model status polling failures', async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest.fn((url: RequestInfo | URL, options?: RequestInit) => {
+      if (String(url).startsWith('/api/v1/models/status/')) {
+        return Promise.resolve({ ok: false, status: 503 } as Response);
+      }
+      return Promise.resolve(pendingStreamingResponse(options?.signal));
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { result, unmount } = renderHook(() => useCompleteText(localSettings));
+    let completionPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      completionPromise = result.current.completeText('Hello');
+    });
+    await flushAsyncWork();
+    const statusCallCount = () => fetchMock.mock.calls
+      .filter(([url]) => String(url).includes('/models/status/')).length;
+
+    expect(statusCallCount()).toBe(1);
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    expect(statusCallCount()).toBe(2);
+    await act(async () => {
+      jest.advanceTimersByTime(1999);
+      await Promise.resolve();
+    });
+    expect(statusCallCount()).toBe(2);
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+    expect(statusCallCount()).toBe(3);
+    await act(async () => {
+      jest.advanceTimersByTime(4999);
+      await Promise.resolve();
+    });
+    expect(statusCallCount()).toBe(3);
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+    expect(statusCallCount()).toBe(4);
+
+    unmount();
+    await completionPromise;
   });
 
   it('handles fragmented SSE and returns the authoritative final envelope', async () => {

--- a/client/geist/src/Hooks/useCompleteText.tsx
+++ b/client/geist/src/Hooks/useCompleteText.tsx
@@ -17,7 +17,7 @@ const AGENT_TYPE_MAPPING = {
 }
 
 const DEFAULT_AGENT_TYPE = "LOCALAGENT";
-const MODEL_STATUS_POLL_INTERVAL_MS = 1000;
+const MODEL_STATUS_POLL_DELAYS_MS = [1000, 2000, 5000] as const;
 
 const getAgentTypeFromSettings = (settings: UserSettings | null): string => {
   if (!settings) {
@@ -53,7 +53,7 @@ export interface ChatStreamState {
 }
 
 export type ChatStreamAction =
-  | { type: 'START'; prompt: string; chatId: number | null }
+  | { type: 'START'; prompt: string; chatId: number | null; startedAt?: string }
   | { type: 'RUN_STARTED'; runId: string; chatId?: number | null }
   | { type: 'TEXT_DELTA'; text: string }
   | { type: 'MODEL_LOAD_STATUS'; status: ModelLoadStatus }
@@ -136,6 +136,17 @@ const dedupeArtifacts = (artifacts: WorkArtifact[]): WorkArtifact[] =>
     [],
   );
 
+const isStatusCurrentForTurn = (
+  status: ModelLoadStatus,
+  turnStartedAt: string,
+): boolean => {
+  const statusUpdatedAt = Date.parse(status.updated_at);
+  const startedAt = Date.parse(turnStartedAt);
+  return !Number.isFinite(statusUpdatedAt)
+    || !Number.isFinite(startedAt)
+    || statusUpdatedAt >= startedAt;
+};
+
 export const chatStreamReducer = (
   state: ChatStreamState,
   action: ChatStreamAction,
@@ -150,6 +161,7 @@ export const chatStreamReducer = (
           chat_id: action.chatId,
           origin_chat_id: action.chatId,
           status: 'connecting',
+          started_at: action.startedAt ?? new Date().toISOString(),
           tool_calls: [],
           artifacts: [],
         },
@@ -177,6 +189,7 @@ export const chatStreamReducer = (
       };
     case 'MODEL_LOAD_STATUS':
       if (!state.activeTurn || state.activeTurn.run_id) return state;
+      if (!isStatusCurrentForTurn(action.status, state.activeTurn.started_at)) return state;
       return {
         ...state,
         error: action.status.state === 'failed' ? action.status.detail : state.error,
@@ -185,7 +198,7 @@ export const chatStreamReducer = (
           model_load: action.status,
           status: action.status.state === 'failed'
             ? 'failed'
-            : action.status.state === 'ready'
+            : action.status.state === 'ready' || action.status.state === 'unloaded'
               ? 'connecting'
               : 'model_loading',
         },
@@ -259,7 +272,7 @@ export const chatStreamReducer = (
         loading: false,
         error: action.message,
         activeTurn: state.activeTurn
-          ? { ...state.activeTurn, status: 'failed' }
+          ? { ...state.activeTurn, status: 'failed', model_load: undefined }
           : null,
       };
     case 'CANCELLING':
@@ -288,6 +301,7 @@ export const chatStreamReducer = (
               ...state.activeTurn,
               chat_id: action.chatId ?? state.activeTurn.chat_id,
               status: 'cancelled',
+              model_load: undefined,
               tool_calls: state.activeTurn.tool_calls.map<ToolCallResult>((toolCall) =>
                 ['proposed', 'awaiting_approval', 'running'].includes(toolCall.status)
                   ? { ...toolCall, status: 'cancelled' }
@@ -349,26 +363,28 @@ const useCompleteText = (userSettings: UserSettings | null = null) => {
   const hasActiveTurn = streamState.activeTurn !== null;
   const activeRunId = streamState.activeTurn?.run_id;
   const currentModelState = streamState.activeTurn?.model_load?.state;
+  const activeTurnStartedAt = streamState.activeTurn?.started_at;
+  const modelStatusIsTerminal = currentModelState === 'ready' || currentModelState === 'failed';
+  const shouldPollModelStatus = Boolean(
+    streamState.loading
+    && hasActiveTurn
+    && !activeRunId
+    && userSettings?.default_agent_type === 'local'
+    && userSettings?.default_local_model
+    && !modelStatusIsTerminal
+  );
 
   useEffect(() => {
-    const isLocalModel = userSettings?.default_agent_type === 'local';
     const modelId = userSettings?.default_local_model;
-    const shouldPoll = Boolean(
-      streamState.loading
-      && hasActiveTurn
-      && !activeRunId
-      && isLocalModel
-      && modelId
-      && currentModelState !== 'ready'
-      && currentModelState !== 'failed'
-    );
-    if (!shouldPoll || !modelId) return undefined;
+    if (!shouldPollModelStatus || !modelId || !activeTurnStartedAt) return undefined;
 
     let stopped = false;
     let pollTimer: number | undefined;
+    let consecutiveFailures = 0;
 
     const poll = async () => {
       let keepPolling = true;
+      let nextDelay: number = MODEL_STATUS_POLL_DELAYS_MS[0];
       try {
         const response = await fetch(
           `/api/v1/models/status/${encodeURIComponent(modelId)}`,
@@ -377,14 +393,28 @@ const useCompleteText = (userSettings: UserSettings | null = null) => {
         if (response.ok) {
           const status = await response.json() as ModelLoadStatus;
           if (!stopped) dispatch({ type: 'MODEL_LOAD_STATUS', status });
-          keepPolling = status.state !== 'ready' && status.state !== 'failed';
+          const currentForTurn = isStatusCurrentForTurn(status, activeTurnStartedAt);
+          keepPolling = !currentForTurn
+            || (status.state !== 'ready' && status.state !== 'failed');
+          consecutiveFailures = 0;
+        } else if (response.status === 404) {
+          keepPolling = false;
+        } else {
+          nextDelay = MODEL_STATUS_POLL_DELAYS_MS[
+            Math.min(consecutiveFailures, MODEL_STATUS_POLL_DELAYS_MS.length - 1)
+          ];
+          consecutiveFailures += 1;
         }
       } catch {
         // The chat stream remains authoritative. A transient polling failure
         // should not replace its eventual response or error.
+        nextDelay = MODEL_STATUS_POLL_DELAYS_MS[
+          Math.min(consecutiveFailures, MODEL_STATUS_POLL_DELAYS_MS.length - 1)
+        ];
+        consecutiveFailures += 1;
       }
       if (!stopped && keepPolling) {
-        pollTimer = window.setTimeout(poll, MODEL_STATUS_POLL_INTERVAL_MS);
+        pollTimer = window.setTimeout(poll, nextDelay);
       }
     };
 
@@ -394,11 +424,8 @@ const useCompleteText = (userSettings: UserSettings | null = null) => {
       if (pollTimer !== undefined) window.clearTimeout(pollTimer);
     };
   }, [
-    streamState.loading,
-    hasActiveTurn,
-    activeRunId,
-    currentModelState,
-    userSettings?.default_agent_type,
+    shouldPollModelStatus,
+    activeTurnStartedAt,
     userSettings?.default_local_model,
   ]);
 

--- a/client/geist/src/Hooks/useCompleteText.tsx
+++ b/client/geist/src/Hooks/useCompleteText.tsx
@@ -4,6 +4,7 @@ import {
   ActiveChatTurn,
   ChatTurnResult,
   CompleteTextResponse,
+  ModelLoadStatus,
   ToolCallResult,
   WorkArtifact,
 } from '../chatTypes';
@@ -16,6 +17,7 @@ const AGENT_TYPE_MAPPING = {
 }
 
 const DEFAULT_AGENT_TYPE = "LOCALAGENT";
+const MODEL_STATUS_POLL_INTERVAL_MS = 1000;
 
 const getAgentTypeFromSettings = (settings: UserSettings | null): string => {
   if (!settings) {
@@ -54,6 +56,7 @@ export type ChatStreamAction =
   | { type: 'START'; prompt: string; chatId: number | null }
   | { type: 'RUN_STARTED'; runId: string; chatId?: number | null }
   | { type: 'TEXT_DELTA'; text: string }
+  | { type: 'MODEL_LOAD_STATUS'; status: ModelLoadStatus }
   | { type: 'TOOL_UPSERT'; toolCall: ToolCallUpdate }
   | { type: 'ARTIFACT_UPSERT'; artifact: WorkArtifact }
   | { type: 'FINAL'; prompt: string; data: CompleteTextResponse }
@@ -163,6 +166,28 @@ export const chatStreamReducer = (
           run_id: action.runId,
           chat_id: action.chatId ?? state.activeTurn.chat_id,
           status: 'streaming',
+          model_load: state.activeTurn.model_load
+            ? {
+                ...state.activeTurn.model_load,
+                state: 'ready',
+                detail: 'Model is loaded and ready.',
+              }
+            : undefined,
+        },
+      };
+    case 'MODEL_LOAD_STATUS':
+      if (!state.activeTurn || state.activeTurn.run_id) return state;
+      return {
+        ...state,
+        error: action.status.state === 'failed' ? action.status.detail : state.error,
+        activeTurn: {
+          ...state.activeTurn,
+          model_load: action.status,
+          status: action.status.state === 'failed'
+            ? 'failed'
+            : action.status.state === 'ready'
+              ? 'connecting'
+              : 'model_loading',
         },
       };
     case 'TEXT_DELTA':
@@ -320,6 +345,62 @@ const useCompleteText = (userSettings: UserSettings | null = null) => {
     abortControllerRef.current?.abort();
     abortControllerRef.current = null;
   }, []);
+
+  const hasActiveTurn = streamState.activeTurn !== null;
+  const activeRunId = streamState.activeTurn?.run_id;
+  const currentModelState = streamState.activeTurn?.model_load?.state;
+
+  useEffect(() => {
+    const isLocalModel = userSettings?.default_agent_type === 'local';
+    const modelId = userSettings?.default_local_model;
+    const shouldPoll = Boolean(
+      streamState.loading
+      && hasActiveTurn
+      && !activeRunId
+      && isLocalModel
+      && modelId
+      && currentModelState !== 'ready'
+      && currentModelState !== 'failed'
+    );
+    if (!shouldPoll || !modelId) return undefined;
+
+    let stopped = false;
+    let pollTimer: number | undefined;
+
+    const poll = async () => {
+      let keepPolling = true;
+      try {
+        const response = await fetch(
+          `/api/v1/models/status/${encodeURIComponent(modelId)}`,
+          { headers: { 'Content-Type': 'application/json' } },
+        );
+        if (response.ok) {
+          const status = await response.json() as ModelLoadStatus;
+          if (!stopped) dispatch({ type: 'MODEL_LOAD_STATUS', status });
+          keepPolling = status.state !== 'ready' && status.state !== 'failed';
+        }
+      } catch {
+        // The chat stream remains authoritative. A transient polling failure
+        // should not replace its eventual response or error.
+      }
+      if (!stopped && keepPolling) {
+        pollTimer = window.setTimeout(poll, MODEL_STATUS_POLL_INTERVAL_MS);
+      }
+    };
+
+    void poll();
+    return () => {
+      stopped = true;
+      if (pollTimer !== undefined) window.clearTimeout(pollTimer);
+    };
+  }, [
+    streamState.loading,
+    hasActiveTurn,
+    activeRunId,
+    currentModelState,
+    userSettings?.default_agent_type,
+    userSettings?.default_local_model,
+  ]);
 
   const handleSseEvent = (eventBlock: string, turnPrompt: string): string | null => {
     const parsedEvent = parseSseEventBlock(eventBlock);

--- a/client/geist/src/chatTypes.ts
+++ b/client/geist/src/chatTypes.ts
@@ -67,6 +67,7 @@ export type ActiveTurnStatus =
 
 export interface ActiveChatTurn extends ChatTurnResult {
   status: ActiveTurnStatus;
+  started_at: string;
   model_load?: ModelLoadStatus;
 }
 

--- a/client/geist/src/chatTypes.ts
+++ b/client/geist/src/chatTypes.ts
@@ -45,8 +45,19 @@ export interface ChatTurnResult {
   artifacts: WorkArtifact[];
 }
 
+export type ModelLoadState = 'unloaded' | 'loading' | 'ready' | 'failed';
+
+export interface ModelLoadStatus {
+  model_id: string;
+  state: ModelLoadState;
+  detail: string;
+  started_at: string | null;
+  updated_at: string;
+}
+
 export type ActiveTurnStatus =
   | 'connecting'
+  | 'model_loading'
   | 'cancelling'
   | 'streaming'
   | 'awaiting_approval'
@@ -56,6 +67,7 @@ export type ActiveTurnStatus =
 
 export interface ActiveChatTurn extends ChatTurnResult {
   status: ActiveTurnStatus;
+  model_load?: ModelLoadStatus;
 }
 
 export interface ChatPair {
@@ -63,6 +75,7 @@ export interface ChatPair {
   user: string;
   ai: string;
   status?: ActiveTurnStatus;
+  model_load?: ModelLoadStatus;
   tool_calls?: ToolCallResult[];
   artifacts?: WorkArtifact[];
 }

--- a/plans/155-MODEL-LOAD-LIFECYCLE.md
+++ b/plans/155-MODEL-LOAD-LIFECYCLE.md
@@ -22,9 +22,12 @@ without explaining what is happening.
 - Poll the status endpoint while a local chat turn is waiting for its first
   stream event and the model is not ready.
 - Replace the ambiguous `connecting` label with a model-specific loading message
-  while the backend reports `unloaded` or `loading`.
+  only while the backend reports `loading` or `failed`; an `unloaded` response
+  does not claim that loading has begun.
 - Stop polling once the model is ready, failed, the stream starts, or the turn is
   cancelled.
+- Ignore lifecycle records older than the active turn and back off transient
+  polling failures while stopping immediately when the model endpoint is absent.
 
 ## Tests
 
@@ -32,5 +35,7 @@ without explaining what is happening.
 - Route-test unloaded and active model status responses.
 - Verify runner success/failure updates the lifecycle.
 - Test frontend polling, loading-state rendering, and polling termination.
+- Isolate the process-local registry between backend tests and cover unknown
+  model responses.
 - Rebuild and smoke-test the Docker backend/frontend and inspect the chat UI in a
   browser.

--- a/plans/155-MODEL-LOAD-LIFECYCLE.md
+++ b/plans/155-MODEL-LOAD-LIFECYCLE.md
@@ -1,0 +1,36 @@
+# Model Load Lifecycle Indicator
+
+## Problem
+
+The chat UI labels a first local-model request as `connecting` while the backend
+downloads and loads model weights. Large models can spend minutes in that state
+without explaining what is happening.
+
+## Contract
+
+- Track local model lifecycle state in the backend as `unloaded`, `loading`,
+  `ready`, or `failed`.
+- Expose `GET /api/v1/models/status/{model_id}` so clients can poll a selected
+  model without starting another load.
+- Have local runners mark the model `loading` before expensive initialization,
+  `ready` after the runner is usable, and `failed` when initialization raises.
+- Keep status state process-local because loaded runner instances are also
+  process-local.
+
+## Frontend
+
+- Poll the status endpoint while a local chat turn is waiting for its first
+  stream event and the model is not ready.
+- Replace the ambiguous `connecting` label with a model-specific loading message
+  while the backend reports `unloaded` or `loading`.
+- Stop polling once the model is ready, failed, the stream starts, or the turn is
+  cancelled.
+
+## Tests
+
+- Unit-test lifecycle transitions and defensive copies in the backend registry.
+- Route-test unloaded and active model status responses.
+- Verify runner success/failure updates the lifecycle.
+- Test frontend polling, loading-state rendering, and polling termination.
+- Rebuild and smoke-test the Docker backend/frontend and inspect the chat UI in a
+  browser.

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -1,0 +1,15 @@
+"""Shared isolation for agent tests."""
+
+from collections.abc import Generator
+
+import pytest
+
+from agents.model_load_status import model_load_status_registry
+
+
+@pytest.fixture(autouse=True)
+def clear_model_load_status_registry() -> Generator[None, None, None]:
+    """Prevent process-local model state from leaking between tests."""
+    model_load_status_registry.clear()
+    yield
+    model_load_status_registry.clear()

--- a/tests/agents/test_model_load_status.py
+++ b/tests/agents/test_model_load_status.py
@@ -1,0 +1,51 @@
+import asyncio
+
+from agents.model_load_status import ModelLoadStatusRegistry, model_load_status_registry
+from app.api.v1.endpoints.models import get_model_load_status
+
+
+def test_model_load_registry_tracks_lifecycle() -> None:
+    registry = ModelLoadStatusRegistry()
+
+    unloaded = registry.get("org/model")
+    loading = registry.mark_loading("org/model", "Loading model files.")
+    ready = registry.mark_ready("org/model")
+
+    assert unloaded.state == "unloaded"
+    assert unloaded.started_at is None
+    assert loading.state == "loading"
+    assert loading.started_at is not None
+    assert ready.state == "ready"
+    assert ready.started_at == loading.started_at
+
+
+def test_model_load_registry_records_failure() -> None:
+    registry = ModelLoadStatusRegistry()
+    registry.mark_loading("org/model", "Loading model files.")
+
+    failed = registry.mark_failed("org/model", "Model failed to load.")
+
+    assert failed.state == "failed"
+    assert failed.detail == "Model failed to load."
+
+
+def test_model_status_endpoint_reports_process_local_state() -> None:
+    model_id = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    model_load_status_registry.clear()
+    try:
+        unloaded = asyncio.run(get_model_load_status(model_id))
+        model_load_status_registry.mark_loading(model_id, "Loading cached weights.")
+        loading = asyncio.run(get_model_load_status(model_id))
+
+        assert unloaded.state == "unloaded"
+        assert loading.state == "loading"
+        assert loading.detail == "Loading cached weights."
+    finally:
+        model_load_status_registry.clear()
+
+
+def test_remote_model_status_is_always_ready() -> None:
+    status = asyncio.run(get_model_load_status("gpt-4"))
+
+    assert status.state == "ready"
+    assert status.started_at is None

--- a/tests/agents/test_model_load_status.py
+++ b/tests/agents/test_model_load_status.py
@@ -1,5 +1,8 @@
 import asyncio
 
+import pytest
+from fastapi import HTTPException
+
 from agents.model_load_status import ModelLoadStatusRegistry, model_load_status_registry
 from app.api.v1.endpoints.models import get_model_load_status
 
@@ -31,17 +34,20 @@ def test_model_load_registry_records_failure() -> None:
 
 def test_model_status_endpoint_reports_process_local_state() -> None:
     model_id = "meta-llama/Meta-Llama-3.1-8B-Instruct"
-    model_load_status_registry.clear()
-    try:
-        unloaded = asyncio.run(get_model_load_status(model_id))
-        model_load_status_registry.mark_loading(model_id, "Loading cached weights.")
-        loading = asyncio.run(get_model_load_status(model_id))
+    unloaded = asyncio.run(get_model_load_status(model_id))
+    model_load_status_registry.mark_loading(model_id, "Loading cached weights.")
+    loading = asyncio.run(get_model_load_status(model_id))
 
-        assert unloaded.state == "unloaded"
-        assert loading.state == "loading"
-        assert loading.detail == "Loading cached weights."
-    finally:
-        model_load_status_registry.clear()
+    assert unloaded.state == "unloaded"
+    assert loading.state == "loading"
+    assert loading.detail == "Loading cached weights."
+
+
+def test_model_status_endpoint_rejects_unknown_model() -> None:
+    with pytest.raises(HTTPException) as error:
+        asyncio.run(get_model_load_status("unknown/model"))
+
+    assert error.value.status_code == 404
 
 
 def test_remote_model_status_is_always_ready() -> None:

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -99,6 +99,7 @@ def test_complete_messages_preserves_structured_conversation_roles():
 def test_default_llama_uses_existing_legacy_weights_directory(
     config_cls, tokenizer_cls, model_cls, _find_spec, tmp_path, monkeypatch
 ):
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
     weights_dir = tmp_path / "app" / "model_weights" / "llama_3_1"
     weights_dir.mkdir(parents=True)
     (weights_dir / "config.json").write_text("{}")
@@ -224,6 +225,14 @@ def test_cpu_preserves_checkpoint_dtype_to_avoid_expanding_model_memory():
     runner.device = torch.device("cpu")
 
     assert runner._select_dtype(None) == "auto"
+
+
+def test_cpu_promotes_float16_checkpoint_to_bfloat16():
+    runner = TransformersRunner()
+    runner.device = torch.device("cpu")
+    runner.config = MagicMock(torch_dtype=torch.float16)
+
+    assert runner._select_dtype(None) == torch.bfloat16
 
 
 @patch("agents.architectures.transformers_runner.metadata.version", return_value="4.48.0")

--- a/tests/agents/test_transformers_runner.py
+++ b/tests/agents/test_transformers_runner.py
@@ -11,6 +11,7 @@ torch = pytest.importorskip("torch")
 
 from agents.architectures.base_runner import GenerationConfig
 from agents.architectures.transformers_runner import TransformersRunner
+from agents.model_load_status import model_load_status_registry
 
 
 def _tokenizer():
@@ -52,6 +53,7 @@ def test_load_and_generate_uses_direct_suffix_decode(
 
     runner = TransformersRunner()
     runner.load("Qwen/Qwen2.5-3B-Instruct", {"device": "cpu"})
+    assert model_load_status_registry.get("Qwen/Qwen2.5-3B-Instruct").state == "ready"
     result = runner.complete(
         "Be helpful", "hello", GenerationConfig(max_tokens=100, temperature=0.0)
     )
@@ -217,6 +219,13 @@ def test_mps_defaults_to_stable_eager_attention(config_cls, tokenizer_cls, model
     assert model_cls.from_pretrained.call_args.kwargs["attn_implementation"] == "eager"
 
 
+def test_cpu_preserves_checkpoint_dtype_to_avoid_expanding_model_memory():
+    runner = TransformersRunner()
+    runner.device = torch.device("cpu")
+
+    assert runner._select_dtype(None) == "auto"
+
+
 @patch("agents.architectures.transformers_runner.metadata.version", return_value="4.48.0")
 def test_minimum_transformers_version_fails_early(_version):
     runner = TransformersRunner()
@@ -228,6 +237,7 @@ def test_server_backed_model_fails_before_loading():
     runner = TransformersRunner()
     with pytest.raises(ValueError, match="server-backed"):
         runner.load("kimi-k2.5")
+    assert model_load_status_registry.get("kimi-k2.5").state == "failed"
 
 
 @patch("agents.architectures.transformers_runner.importlib.util.find_spec", return_value=None)


### PR DESCRIPTION
## What changed

- expose process-local model states (`unloaded`, `loading`, `ready`, `failed`) through `GET /api/v1/models/status/{model_id}`
- poll that endpoint while a local chat is waiting for its first stream event
- render the selected model and current load detail instead of an ambiguous connecting state
- preserve checkpoint dtype on CPU to prevent bf16 8B weights from expanding to fp32 and exhausting Docker memory
- exclude the local Hugging Face cache from Docker build contexts

## Why

The first local chat could appear stuck at `connecting` while model files were downloaded or loaded. In Docker, the default 8B checkpoint was also expanded to fp32 on CPU and OOM-killed at generation time, leaving the UI with `Failed to fetch`.

## Validation

- Docker focused backend tests: 22 passed
- frontend focused tests: 14 passed
- frontend production build passed (one pre-existing `useVoiceChat` hook warning)
- Ruff check and format check passed
- native `make run MLX_BACKEND=1` startup passed
- browser chat on `http://localhost:3001/chat` completed a real MLX response with no console errors
- final status endpoint reported `ready`; frontend returned HTTP 200