### PR TITLE
Fix local model selection

### DIFF
--- a/agents/architectures/registry.py
+++ b/agents/architectures/registry.py
@@ -11,6 +11,11 @@ from enum import Enum
 from typing import Any, cast
 
 from agents.model_catalog import MODEL_SPECS, PROVIDERS
+from agents.model_ids import (
+    META_LLAMA_3_8B_INSTRUCT_ID,
+    META_LLAMA_31_8B_BASE_ID,
+    META_LLAMA_31_8B_INSTRUCT_ID,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +70,7 @@ class OnlineModelNames(Enum):
     # Open Source / Huggingface Models
     QWEN3 = "qwen3"
     QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
-    META_LLAMA_31_8B = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    META_LLAMA_31_8B = META_LLAMA_31_8B_INSTRUCT_ID
     MIXTRAL_8X7B_HF = "mistralai/Mixtral-8x7B-Instruct-v0.1"
     # Offline / Local models
     META_LLAMA_31_8B_LOCAL = "Meta-Llama-3.1-8B-Instruct"
@@ -654,7 +659,7 @@ STATIC_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
     ],
     OnlineModelProviders.OFFLINE: [
         ModelInfo(
-            id="Meta-Llama-3.1-8B-Instruct",
+            id=META_LLAMA_31_8B_INSTRUCT_ID,
             name="Meta Llama 3.1 8B Instruct (Local)",
             provider=OnlineModelProviders.OFFLINE,
             context_window=131072,
@@ -665,7 +670,7 @@ STATIC_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
             family="llama-3",
         ),
         ModelInfo(
-            id="Meta-Llama-3.1-8B",
+            id=META_LLAMA_31_8B_BASE_ID,
             name="Meta Llama 3.1 8B (Local)",
             provider=OnlineModelProviders.OFFLINE,
             context_window=131072,
@@ -676,7 +681,7 @@ STATIC_MODELS: dict[OnlineModelProviders | str, list[ModelInfo]] = {
             family="llama-3",
         ),
         ModelInfo(
-            id="Meta-Llama-3-8B-Instruct",
+            id=META_LLAMA_3_8B_INSTRUCT_ID,
             name="Meta Llama 3 8B Instruct (Local)",
             provider=OnlineModelProviders.OFFLINE,
             context_window=8192,

--- a/agents/factory.py
+++ b/agents/factory.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from agents.agent_context import AgentContext
 from agents.base_agent import BaseAgent
+from agents.model_ids import canonicalize_local_model_id
 
 
 logger = logging.getLogger(__name__)
@@ -113,7 +114,11 @@ class AgentFactory:
 
             # Default model
             if not model:
-                model = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+                from agents.model_catalog import default_local_model_id
+
+                model = default_local_model_id()
+
+            model = canonicalize_local_model_id(model)
 
             configured_runner = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip()
             runner_was_explicit = runner_type is not None or bool(configured_runner)

--- a/agents/model_catalog.py
+++ b/agents/model_catalog.py
@@ -11,8 +11,10 @@ import platform
 import re
 from dataclasses import dataclass
 
+from agents.model_ids import META_LLAMA_31_8B_INSTRUCT_ID
 
-MLX_DEFAULT_LOCAL_MODEL = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+MLX_DEFAULT_LOCAL_MODEL = META_LLAMA_31_8B_INSTRUCT_ID
 GGUF_DEFAULT_LOCAL_MODEL = "Qwen/Qwen3-4B"
 
 
@@ -87,16 +89,11 @@ PROVIDERS: dict[str, ProviderSpec] = {
 MODEL_SPECS: tuple[ModelSpec, ...] = (
     # Existing families and practical local reference checkpoints.
     ModelSpec(
-        "Meta-Llama-3.1-8B-Instruct", "Meta Llama 3.1 8B Instruct (Local)",
+        "meta-llama/Meta-Llama-3.1-8B-Instruct", "Meta Llama 3.1 8B Instruct (Local)",
         "llama", backend="mlx_llama", context_window=131072,
         max_output_tokens=8192, recommended=True, gated=True,
-        parameter_count="8B", performance_note="Optimized legacy MLX path on Apple Silicon.",
-    ),
-    ModelSpec(
-        "meta-llama/Meta-Llama-3.1-8B-Instruct", "Meta Llama 3.1 8B Instruct (HF Local)",
-        "llama", backend="mlx_llama", context_window=131072, max_output_tokens=8192, gated=True,
         parameter_count="8B",
-        performance_note="Preserves Geist's optimized Llama path; use an explicit transformers override for HF-native loading.",
+        performance_note="Optimized MLX path on Apple Silicon; use an explicit transformers override for HF-native loading.",
     ),
     ModelSpec(
         "Qwen/Qwen2.5-3B-Instruct", "Qwen 2.5 3B Instruct (Local)", "qwen",

--- a/agents/model_ids.py
+++ b/agents/model_ids.py
@@ -1,0 +1,18 @@
+"""Canonical identifiers for local language models."""
+
+META_LLAMA_31_8B_INSTRUCT_ID = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+META_LLAMA_31_8B_BASE_ID = "meta-llama/Meta-Llama-3.1-8B"
+META_LLAMA_3_8B_INSTRUCT_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
+
+DEFAULT_LOCAL_MODEL_ID = META_LLAMA_31_8B_INSTRUCT_ID
+
+_LEGACY_LOCAL_MODEL_IDS = {
+    "Meta-Llama-3.1-8B-Instruct": META_LLAMA_31_8B_INSTRUCT_ID,
+    "Meta-Llama-3.1-8B": META_LLAMA_31_8B_BASE_ID,
+    "Meta-Llama-3-8B-Instruct": META_LLAMA_3_8B_INSTRUCT_ID,
+}
+
+
+def canonicalize_local_model_id(model_id: str) -> str:
+    """Return the canonical repository-qualified ID for a local model."""
+    return _LEGACY_LOCAL_MODEL_IDS.get(model_id, model_id)

--- a/app/models/user_settings.py
+++ b/app/models/user_settings.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from agents.model_catalog import default_local_model_id
+from agents.model_ids import canonicalize_local_model_id
 
 
 class UserSettingsBase(BaseModel):
@@ -128,7 +129,9 @@ class AgentFactoryConfig(BaseModel):
         agent_type = overrides.agent_type or settings.default_agent_type
 
         if agent_type == "local":
-            model = overrides.model or settings.default_local_model
+            model = canonicalize_local_model_id(
+                overrides.model or settings.default_local_model
+            )
             # Leave unset so AgentFactory can select a backend from catalog
             # capabilities. Explicit user overrides still take precedence.
             runner_type = overrides.runner_type

--- a/app/services/user_settings_service.py
+++ b/app/services/user_settings_service.py
@@ -6,6 +6,7 @@ import logging
 from agents.agent_context import AgentContext
 from agents.base_agent import BaseAgent
 from agents.factory import AgentFactory
+from agents.model_ids import canonicalize_local_model_id
 from app.models.database.geist_user import get_default_user
 from app.models.database.user_settings import (
     get_or_create_user_settings,
@@ -42,7 +43,7 @@ class UserSettingsService:
                 user_settings_id=settings_model.user_settings_id,
                 user_id=settings_model.user_id,
                 default_agent_type=settings_model.default_agent_type,
-                default_local_model=settings_model.default_local_model,
+                default_local_model=canonicalize_local_model_id(settings_model.default_local_model),
                 default_local_artifact_id=settings_model.default_local_artifact_id,
                 default_online_model=settings_model.default_online_model,
                 default_online_provider=settings_model.default_online_provider,
@@ -76,7 +77,7 @@ class UserSettingsService:
             user_settings_id=settings_model.user_settings_id,
             user_id=settings_model.user_id,
             default_agent_type=settings_model.default_agent_type,
-            default_local_model=settings_model.default_local_model,
+            default_local_model=canonicalize_local_model_id(settings_model.default_local_model),
             default_local_artifact_id=settings_model.default_local_artifact_id,
             default_online_model=settings_model.default_online_model,
             default_online_provider=settings_model.default_online_provider,
@@ -112,10 +113,16 @@ class UserSettingsService:
         if current_settings is None:
             return None
 
+        if "default_local_model" in update_dict:
+            update_dict["default_local_model"] = canonicalize_local_model_id(
+                update_dict["default_local_model"]
+            )
+
+        current_local_model = canonicalize_local_model_id(current_settings.default_local_model)
         if (
             "default_local_model" in update_dict
             and "default_local_artifact_id" not in update_dict
-            and update_dict["default_local_model"] != current_settings.default_local_model
+            and update_dict["default_local_model"] != current_local_model
         ):
             update_dict["default_local_artifact_id"] = None
 
@@ -125,7 +132,7 @@ class UserSettingsService:
 
             selected_model = (
                 update_dict.get("default_local_model")
-                or current_settings.default_local_model
+                or current_local_model
             )
             manager = get_local_model_manager()
             try:
@@ -163,7 +170,7 @@ class UserSettingsService:
                 user_settings_id=settings_model.user_settings_id,
                 user_id=settings_model.user_id,
                 default_agent_type=settings_model.default_agent_type,
-                default_local_model=settings_model.default_local_model,
+                default_local_model=canonicalize_local_model_id(settings_model.default_local_model),
                 default_local_artifact_id=settings_model.default_local_artifact_id,
                 default_online_model=settings_model.default_online_model,
                 default_online_provider=settings_model.default_online_provider,

--- a/client/geist/src/Components/AgentConfigSection.tsx
+++ b/client/geist/src/Components/AgentConfigSection.tsx
@@ -49,9 +49,9 @@ const AgentConfigSection: React.FC<AgentConfigSectionProps> = ({
     }
 
     return [
-      { value: 'Meta-Llama-3.1-8B-Instruct', label: 'Meta-Llama-3.1-8B-Instruct' },
-      { value: 'Meta-Llama-3.1-8B', label: 'Meta-Llama-3.1-8B' },
-      { value: 'Meta-Llama-3-8B-Instruct', label: 'Meta-Llama-3-8B-Instruct' }
+      { value: 'meta-llama/Meta-Llama-3.1-8B-Instruct', label: 'Meta-Llama-3.1-8B-Instruct' },
+      { value: 'meta-llama/Meta-Llama-3.1-8B', label: 'Meta-Llama-3.1-8B' },
+      { value: 'meta-llama/Meta-Llama-3-8B-Instruct', label: 'Meta-Llama-3-8B-Instruct' }
     ];
   }, [getModelsForProvider]);
 

--- a/client/geist/src/Components/__tests__/AgentConfigSection.test.tsx
+++ b/client/geist/src/Components/__tests__/AgentConfigSection.test.tsx
@@ -6,7 +6,7 @@ describe('AgentConfigSection', () => {
   const originalFetch = global.fetch;
   const defaultProps = {
     agentType: 'online',
-    localModel: 'Meta-Llama-3.1-8B-Instruct',
+    localModel: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
     onlineProvider: 'openai',
     onlineModel: 'gpt-4',
     onAgentTypeChange: jest.fn(),
@@ -152,8 +152,8 @@ describe('AgentConfigSection', () => {
       const options = modelSelect.querySelectorAll('option');
       const optionValues = Array.from(options).map((opt) => opt.getAttribute('value'));
 
-      // STATIC_MODELS.offline only contains Meta-Llama-3.1-8B-Instruct
-      expect(optionValues).toContain('Meta-Llama-3.1-8B-Instruct');
+      // STATIC_MODELS.offline contains the canonical repository-qualified ID.
+      expect(optionValues).toContain('meta-llama/Meta-Llama-3.1-8B-Instruct');
     });
 
     it('shows online provider and model options when agent type is online', () => {
@@ -195,9 +195,9 @@ describe('AgentConfigSection', () => {
       );
 
       const modelSelect = screen.getByLabelText('Local Model');
-      fireEvent.change(modelSelect, { target: { value: 'Meta-Llama-3.1-8B-Instruct' } });
+      fireEvent.change(modelSelect, { target: { value: 'meta-llama/Meta-Llama-3.1-8B-Instruct' } });
 
-      expect(onLocalModelChange).toHaveBeenCalledWith('Meta-Llama-3.1-8B-Instruct');
+      expect(onLocalModelChange).toHaveBeenCalledWith('meta-llama/Meta-Llama-3.1-8B-Instruct');
     });
   });
 

--- a/client/geist/src/Hooks/__tests__/useUserSettings.test.tsx
+++ b/client/geist/src/Hooks/__tests__/useUserSettings.test.tsx
@@ -5,7 +5,7 @@ const mockSettings: UserSettings = {
   user_settings_id: 1,
   user_id: 1,
   default_agent_type: 'local',
-  default_local_model: 'Meta-Llama-3.1-8B-Instruct',
+  default_local_model: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
   default_online_model: 'gpt-4',
   default_online_provider: 'openai',
   default_file_archives: [101, 102],

--- a/client/geist/src/Hooks/useAvailableModels.tsx
+++ b/client/geist/src/Hooks/useAvailableModels.tsx
@@ -184,7 +184,7 @@ const STATIC_MODELS: AvailableModels = {
     ],
     offline: [
       {
-        id: 'Meta-Llama-3.1-8B-Instruct',
+        id: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
         name: 'Meta Llama 3.1 8B Instruct (Local)',
         provider: 'offline',
         context_window: 131072,

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -6,7 +6,7 @@ const baseSettings = {
   user_settings_id: 1,
   user_id: 1,
   default_agent_type: 'local',
-  default_local_model: 'Meta-Llama-3.1-8B-Instruct',
+  default_local_model: 'meta-llama/Meta-Llama-3.1-8B-Instruct',
   default_online_model: 'gpt-4',
   default_online_provider: 'openai',
   default_file_archives: [],
@@ -32,7 +32,8 @@ const mockModelsResponse = {
       { id: 'claude-3-opus-20240229', name: 'Claude 3 Opus', provider: 'anthropic', recommended: true },
     ],
     offline: [
-      { id: 'Meta-Llama-3.1-8B-Instruct', name: 'Meta Llama 3.1 8B Instruct', provider: 'offline', recommended: true },
+      { id: 'meta-llama/Meta-Llama-3.1-8B-Instruct', name: 'Meta Llama 3.1 8B Instruct', provider: 'offline', recommended: true },
+      { id: 'Qwen/Qwen3-4B', name: 'Qwen 3 4B', provider: 'offline', recommended: true },
     ],
   },
   last_updated: '2025-01-01T00:00:00Z',
@@ -104,6 +105,25 @@ describe('Settings page', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Settings saved successfully/i)).toBeInTheDocument();
+    });
+  });
+
+  it('selects the stored canonical local model', async () => {
+    // @ts-ignore
+    global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
+
+    render(<Settings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Models and Providers' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Models and Providers' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Local Model')).toHaveValue(
+        'meta-llama/Meta-Llama-3.1-8B-Instruct'
+      );
     });
   });
 
@@ -282,7 +302,10 @@ describe('Settings page', () => {
 
       // Change the local model
       const modelSelect = screen.getByLabelText('Local Model');
-      fireEvent.change(modelSelect, { target: { value: 'Meta-Llama-3.1-8B-Instruct' } });
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Qwen 3 4B' })).toBeInTheDocument();
+      });
+      fireEvent.change(modelSelect, { target: { value: 'Qwen/Qwen3-4B' } });
 
       // Save and verify agent_type is 'local'
       fireEvent.click(screen.getByText(/Save Changes/i));
@@ -290,7 +313,7 @@ describe('Settings page', () => {
       await waitFor(() => {
         expect(savedUpdates).not.toBeNull();
         expect(savedUpdates.default_agent_type).toBe('local');
-        expect(savedUpdates.default_local_model).toBe('Meta-Llama-3.1-8B-Instruct');
+        expect(savedUpdates.default_local_model).toBe('Qwen/Qwen3-4B');
       });
     });
   });

--- a/plans/153-LOCAL-MODEL-SELECTION-FIX.md
+++ b/plans/153-LOCAL-MODEL-SELECTION-FIX.md
@@ -1,0 +1,26 @@
+# Local Model Selection Fix
+
+## Objective
+
+Make the Settings model selector reflect the stored local model exactly and ensure the selected model uses its compatible local runner.
+
+## Implementation
+
+1. Define canonical local model identifiers and legacy aliases in a lightweight shared Python module.
+2. Return and persist canonical model identifiers through the user-settings service.
+3. Use canonical identifiers in the offline model catalog and frontend fallback catalog.
+4. Normalize legacy identifiers before the existing catalog-based runner inference runs.
+5. Preserve the generic open-weight model support and explicit runner overrides already present on `main`.
+
+## Tests
+
+1. Add unit coverage for legacy model-ID normalization and canonical settings updates.
+2. Update frontend tests to assert the stored default matches an actual selector option and that Qwen selection is saved.
+3. Update agent configuration tests to assert automatic runner inference remains enabled.
+4. Run focused Python and frontend tests, then smoke-test the native backend and Settings selector in the browser.
+
+## Out of Scope
+
+- Downloading or deleting model weights from the UI.
+- Supporting model architectures that do not have a registered local runner.
+- Downloading model weights during tests.

--- a/tests/agents/test_model_ids.py
+++ b/tests/agents/test_model_ids.py
@@ -1,0 +1,26 @@
+from agents.model_ids import (
+    META_LLAMA_3_8B_INSTRUCT_ID,
+    META_LLAMA_31_8B_BASE_ID,
+    META_LLAMA_31_8B_INSTRUCT_ID,
+    canonicalize_local_model_id,
+)
+
+
+def test_canonicalizes_legacy_llama_model_ids():
+    assert canonicalize_local_model_id("Meta-Llama-3.1-8B-Instruct") == META_LLAMA_31_8B_INSTRUCT_ID
+    assert canonicalize_local_model_id("Meta-Llama-3.1-8B") == META_LLAMA_31_8B_BASE_ID
+    assert canonicalize_local_model_id("Meta-Llama-3-8B-Instruct") == META_LLAMA_3_8B_INSTRUCT_ID
+
+
+def test_preserves_already_canonical_and_qwen_model_ids():
+    assert canonicalize_local_model_id(META_LLAMA_31_8B_INSTRUCT_ID) == META_LLAMA_31_8B_INSTRUCT_ID
+    assert canonicalize_local_model_id("Qwen/Qwen3-4B") == "Qwen/Qwen3-4B"
+
+
+def test_offline_catalog_exposes_each_llama_model_under_its_canonical_id():
+    from agents.architectures.registry import STATIC_MODELS, OnlineModelProviders
+
+    model_ids = [model.id for model in STATIC_MODELS[OnlineModelProviders.OFFLINE]]
+
+    assert "Meta-Llama-3.1-8B-Instruct" not in model_ids
+    assert model_ids.count(META_LLAMA_31_8B_INSTRUCT_ID) == 1

--- a/tests/agents/test_new_architecture.py
+++ b/tests/agents/test_new_architecture.py
@@ -197,6 +197,11 @@ class TestUserSettingsIntegration:
         assert config.runner_type is None
         assert config.endpoint is None
 
+        settings.default_local_model = "Qwen/Qwen3-4B"
+        config = AgentFactoryConfig.from_user_settings(settings)
+        assert config.model == "Qwen/Qwen3-4B"
+        assert config.runner_type is None
+
         # Test online agent config
         settings.default_agent_type = "online"
         config = AgentFactoryConfig.from_user_settings(settings)

--- a/tests/services/test_user_settings_service.py
+++ b/tests/services/test_user_settings_service.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from app.models.database.user_settings import UserSettingsModel
+from app.models.user_settings import UserSettingsUpdate
+from app.services.user_settings_service import UserSettingsService
+
+
+def make_settings_model(local_model: str) -> UserSettingsModel:
+    now = datetime.now()
+    return UserSettingsModel(
+        user_settings_id=1,
+        user_id=1,
+        default_agent_type="local",
+        default_local_model=local_model,
+        default_local_artifact_id=None,
+        default_online_model="gpt-4",
+        default_online_provider="openai",
+        default_file_archives=[],
+        enable_rag_by_default=True,
+        default_max_tokens=4096,
+        default_temperature=1.0,
+        default_top_p=1.0,
+        default_frequency_penalty=0.0,
+        default_presence_penalty=0.0,
+        backup_providers=[],
+        ui_preferences={},
+        create_date=now,
+        update_date=now,
+    )
+
+
+def test_returns_canonical_local_model_for_legacy_settings():
+    settings_model = make_settings_model("Meta-Llama-3.1-8B-Instruct")
+
+    with patch(
+        "app.services.user_settings_service.get_user_settings",
+        return_value=settings_model,
+    ):
+        response = UserSettingsService.get_user_settings_by_id(1)
+
+    assert response is not None
+    assert response.default_local_model == "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+
+def test_persists_canonical_local_model_for_legacy_update():
+    settings_model = make_settings_model("meta-llama/Meta-Llama-3.1-8B-Instruct")
+
+    with (
+        patch(
+            "app.services.user_settings_service.get_user_settings",
+            return_value=settings_model,
+        ),
+        patch(
+            "app.services.user_settings_service.update_user_settings",
+            return_value=settings_model,
+        ) as update_settings,
+    ):
+        response = UserSettingsService.update_user_settings_by_id(
+            1,
+            UserSettingsUpdate(default_local_model="Meta-Llama-3.1-8B-Instruct"),
+        )
+
+    update_dict = update_settings.call_args.args[1]
+    assert update_dict["default_local_model"] == "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    assert update_dict["default_agent_type"] == "local"
+    assert response is not None
+    assert response.default_local_model == "meta-llama/Meta-Llama-3.1-8B-Instruct"


### PR DESCRIPTION
## What changed

- use canonical Hugging Face repository IDs throughout local model settings and catalogs
- normalize legacy short Llama IDs when reading, updating, or creating local agents
- remove the duplicate legacy Llama entry while preserving the generic open-weight model catalog and runner inference already on `main`
- align frontend fallback options with backend IDs
- add backend and frontend regression coverage for the selected model and Qwen persistence

## Root cause

The stored default was `meta-llama/Meta-Llama-3.1-8B-Instruct`, while the offline selector exposed `Meta-Llama-3.1-8B-Instruct`. Because the controlled `<select>` could not match its value to an option, it visually fell back to another option and appeared not to accept selections.

## Impact

The Settings selector now reflects the stored model exactly. Legacy settings are migrated transparently, and selecting Qwen or another catalog model continues through the existing catalog-based runner and Hugging Face download paths.

## Validation

- `ruff check` and formatting checks passed
- mypy passed for the changed model/settings modules
- 84 focused backend tests passed
- 29 affected frontend tests passed
- native MLX backend started on the rebased branch; settings and model-catalog APIs returned canonical IDs
- Playwright selected `Qwen/Qwen3-4B`, saved it, verified persistence after reload, restored the canonical Llama model, and found no browser console errors

## Known baseline issue

A transitive mypy run through `app/main.py` reaches five existing errors in `app/services/memory_service.py` on current `main`; those unrelated memory errors are not changed by this PR.