### PR TITLE
Codex/memory scope UI + Windows compatibility fixes

### DIFF
--- a/client/geist/e2e/memory-privacy.spec.ts
+++ b/client/geist/e2e/memory-privacy.spec.ts
@@ -30,6 +30,14 @@ async function search(
   return (await response.json()).results as Array<{ content: string }>;
 }
 
+async function selectMemoryScope(
+  page: import('@playwright/test').Page,
+  name: string,
+) {
+  await page.getByRole('button', { name: /^Memory settings:/ }).click();
+  await page.getByRole('menuitemradio', { name, exact: true }).click();
+}
+
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/chat');
@@ -57,8 +65,12 @@ test('public chat promotes an explicit durable fact to global memory', async ({ 
 
 
 test('private chat is searchable only inside its own thread', async ({ page }) => {
-  await page.getByRole('switch', { name: 'Private' }).click();
-  await expect(page.getByText('Stored only in this private chat')).toBeVisible();
+  await selectMemoryScope(page, 'Memory Enabled (this chat only)');
+  await expect(
+    page.getByRole('button', {
+      name: 'Memory settings: Memory Enabled (this chat only)',
+    }),
+  ).toBeVisible();
   const chatId = await sendMemoryChat(page, 'Remember obsidian-e2e.');
 
   const globalResults = await search(page, {
@@ -77,8 +89,10 @@ test('private chat is searchable only inside its own thread', async ({ page }) =
 
 
 test('memory disabled prevents chat-derived storage', async ({ page }) => {
-  await page.getByRole('switch', { name: 'Memory enabled' }).click();
-  await expect(page.getByText('Memory is off for this chat')).toBeVisible();
+  await selectMemoryScope(page, 'Memory Disabled');
+  await expect(
+    page.getByRole('button', { name: 'Memory settings: Memory Disabled' }),
+  ).toBeVisible();
   await sendMemoryChat(page, 'Remember vermilion-e2e.', 'disabled');
 
   const globalResults = await search(page, {
@@ -97,17 +111,22 @@ test('folder memory stays inside the selected private folder', async ({ page }) 
   await expect(
     page.getByRole('button', { name: /^E2E Vault \d+ chats? · Private$/ }),
   ).toBeVisible();
-  await page.getByRole('button', { name: 'Close chat history' }).click();
-
   const folderResponse = await page.request.get('/api/v1/memory/folders');
   const folders = await folderResponse.json();
   const folder = folders.find((item: { name: string }) => item.name === 'E2E Vault');
   expect(folder).toBeTruthy();
-  await page.getByRole('combobox', { name: 'Memory folder' }).selectOption(
-    String(folder.folder_id),
-  );
-  await expect(page.getByText('Stored only in this private folder')).toBeVisible();
+  await page.getByRole('button', { name: 'New Chat', exact: true }).click();
+  await expect(
+    page.getByRole('button', {
+      name: 'Memory settings: Memory: E2E Vault',
+    }),
+  ).toBeVisible();
   const chatId = await sendMemoryChat(page, 'Remember topaz-e2e launches Friday.');
+  const inheritedSettings = await (
+    await page.request.get(`/api/v1/memory/chats/${chatId}`)
+  ).json();
+  expect(inheritedSettings.folder_id).toBe(folder.folder_id);
+  expect(inheritedSettings.effective_scope).toBe('folder');
 
   const folderResults = await search(page, {
     query: 'topaz-e2e',

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -482,6 +482,25 @@ textarea:focus-visible {
   border-radius: 999px;
 }
 
+.models-tabs {
+  flex: 0 0 auto;
+}
+
+.models-tab-panel {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.models-providers-loading {
+  flex: 1 1 auto;
+}
+
+.local-model-panel {
+  flex: 0 0 auto;
+}
+
 .provider-panel {
   overflow: hidden;
 }

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -632,10 +632,34 @@ textarea:focus-visible {
   left: 0;
   width: 100%;
   height: 100%;
-  background: var(--geist-color-surface);
-  border-color: var(--geist-color-border);
-  border-radius: var(--geist-radius-lg);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), var(--geist-shadow-panel);
+  padding-right: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--geist-color-border-strong) transparent;
+  scrollbar-width: thin;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.stage-panel-expanded.stage-panel-scrollbar-visible .stage-panel-surface {
+  padding-right: 6px;
+}
+
+.stage-panel-expanded .stage-panel-surface::-webkit-scrollbar {
+  width: 10px;
+}
+
+.stage-panel-expanded .stage-panel-surface::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.stage-panel-expanded .stage-panel-surface::-webkit-scrollbar-thumb {
+  background: var(--geist-color-border-strong);
+  border: 3px solid var(--geist-color-bg);
+  border-radius: 999px;
 }
 
 .stage-panel-compact-controls,
@@ -718,11 +742,15 @@ textarea:focus-visible {
 
 .stage-panel-content {
   width: 100%;
-  height: 100%;
+  height: auto;
   min-width: 0;
-  min-height: 0;
+  min-height: 100%;
   padding: 18px;
-  overflow: auto;
+  overflow: visible;
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02), var(--geist-shadow-panel);
 }
 
 .stage-panel-content-column {

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -580,7 +580,7 @@ textarea:focus-visible {
 }
 
 .ChatSidebar.stage-panel {
-  --stage-panel-compact-width: 190px;
+  --stage-panel-compact-width: 266px;
 }
 
 .stage-panel-surface {
@@ -1294,6 +1294,18 @@ textarea:focus-visible {
   border-radius: var(--geist-radius-md);
 }
 
+.chat-memory-scope.is-enabled .chat-memory-trigger {
+  color: var(--geist-color-accent-strong);
+  background: color-mix(in srgb, var(--geist-color-accent) 11%, var(--geist-color-surface));
+  border-color: color-mix(in srgb, var(--geist-color-accent) 42%, var(--geist-color-border));
+}
+
+.chat-memory-scope.is-disabled .chat-memory-trigger {
+  color: var(--geist-color-text-muted);
+  background: var(--geist-color-surface-muted);
+  border-color: var(--geist-color-border);
+}
+
 .chat-memory-trigger:hover:not(:disabled),
 .chat-memory-trigger[aria-expanded="true"] {
   color: var(--geist-color-text);
@@ -1324,23 +1336,30 @@ textarea:focus-visible {
 
 .chat-memory-trigger-label {
   overflow: hidden;
-  color: var(--geist-color-text);
+  color: currentColor;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .chat-memory-scope.is-compact {
-  flex: 0 0 34px;
-  width: 34px;
+  flex: 0 0 auto;
+  width: auto;
 }
 
 .chat-memory-scope.is-compact .chat-memory-trigger {
-  display: grid;
-  width: 34px;
+  display: inline-flex;
+  gap: 7px;
+  width: auto;
   height: 34px;
   min-height: 34px;
-  padding: 0;
-  place-items: center;
+  padding: 0 10px;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-memory-scope.is-compact .chat-memory-trigger-label {
+  font-size: 0.72rem;
+  font-weight: 720;
 }
 
 .chat-memory-scope.is-compact .chat-memory-trigger > svg:last-child {

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -612,6 +612,21 @@ textarea:focus-visible {
   overflow: visible;
 }
 
+.ChatSidebar.stage-panel-minimized::before {
+  position: absolute;
+  top: 0;
+  right: var(--chat-scrollbar-lane);
+  left: 0;
+  z-index: 0;
+  height: 58px;
+  pointer-events: none;
+  content: "";
+}
+
+.ChatSidebar.stage-panel-minimized .stage-panel-surface {
+  z-index: 1;
+}
+
 .stage-panel-expanded .stage-panel-surface {
   top: 0;
   left: 0;
@@ -1221,12 +1236,23 @@ textarea:focus-visible {
 
 .ChatContent {
   --chat-composer-clearance: 162px;
+  --chat-toolbar-clearance: 72px;
+  --chat-scrollbar-lane: 0px;
+  --chat-scrollbar-gap: 0px;
+  --chat-glass-fill: color-mix(in srgb, var(--geist-color-surface-strong) 56%, transparent);
+  --chat-glass-highlight: color-mix(in srgb, var(--geist-color-text) 9%, transparent);
+  --chat-glass-control-fill: color-mix(in srgb, var(--geist-color-surface-strong) 28%, transparent);
   position: relative;
   min-width: 0;
   min-height: 0;
   height: 100%;
   padding: 16px;
   overflow: hidden;
+}
+
+.ChatContainer.chat-scrollbar-visible .ChatContent {
+  --chat-scrollbar-lane: 16px;
+  --chat-scrollbar-gap: 6px;
 }
 
 .chat-stage,
@@ -1251,23 +1277,132 @@ textarea:focus-visible {
   transform: scale(0.995);
 }
 
-.chat-transcript-layer .chat-history {
+.chat-history-scroll {
+  position: relative;
+  z-index: 1;
+  width: 100%;
   height: 100%;
+  min-height: 0;
+  padding-right: var(--chat-scrollbar-gap);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--geist-color-border-strong) transparent;
+  scrollbar-width: thin;
+  scroll-padding-top: var(--chat-toolbar-clearance);
+  scroll-padding-bottom: var(--chat-composer-clearance);
+}
+
+.chat-history-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+.chat-history-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-history-scroll::-webkit-scrollbar-thumb {
+  background: var(--geist-color-border-strong);
+  border: 3px solid var(--geist-color-bg);
+  border-radius: 999px;
+}
+
+.chat-history-scroll .chat-history {
+  min-height: 100%;
 }
 
 .chat-composer-dock {
   position: absolute;
-  right: 12px;
+  right: var(--chat-scrollbar-lane);
   bottom: 12px;
   left: 12px;
   z-index: 12;
   display: grid;
   gap: 8px;
+  isolation: isolate;
+  pointer-events: none;
   opacity: 1;
   transform: translateY(0);
   transition:
     opacity var(--geist-motion-fast) var(--geist-ease-standard),
     transform var(--geist-motion-standard) var(--geist-ease-emphasized);
+}
+
+.chat-composer-dock::before {
+  position: absolute;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+  inset: -12px 0 -12px -12px;
+}
+
+.ChatSidebar.stage-panel-minimized::before,
+.chat-composer-dock::before {
+  background: var(--geist-color-surface);
+  background:
+    linear-gradient(135deg, var(--chat-glass-highlight), transparent 52%),
+    var(--chat-glass-fill);
+  border: 1px solid color-mix(in srgb, var(--geist-color-border-strong) 58%, transparent);
+  border-radius: var(--geist-radius-lg);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.11),
+    0 10px 28px rgba(0, 0, 0, 0.16);
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .ChatSidebar.stage-panel-minimized::before,
+  .chat-composer-dock::before {
+    -webkit-backdrop-filter: blur(14px) saturate(145%);
+    backdrop-filter: blur(14px) saturate(145%);
+  }
+}
+
+.chat-composer-dock textarea,
+.chat-composer-dock button,
+.chat-composer-dock input,
+.chat-composer-dock a,
+.chat-composer-dock .suggestion-menu {
+  pointer-events: auto;
+}
+
+.chat-composer-dock .chat-textarea,
+.chat-composer-dock .chat-context-info,
+.chat-composer-dock .input-banner {
+  background: var(--chat-glass-control-fill);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.chat-composer-dock .chat-textarea,
+.chat-composer-dock .chat-context-info {
+  border-color: color-mix(in srgb, var(--geist-color-border) 72%, transparent);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .ChatSidebar.stage-panel-minimized::before,
+  .chat-composer-dock::before {
+    background: var(--geist-color-surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .chat-composer-dock .chat-textarea,
+  .chat-composer-dock .chat-context-info,
+  .chat-composer-dock .input-banner {
+    background: var(--geist-color-surface-strong);
+  }
+}
+
+@media (forced-colors: active) {
+  .ChatSidebar.stage-panel-minimized::before,
+  .chat-composer-dock::before,
+  .chat-composer-dock .chat-textarea,
+  .chat-composer-dock .chat-context-info,
+  .chat-composer-dock .input-banner {
+    background: Canvas;
+    border-color: CanvasText;
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 
 .chat-memory-scope {
@@ -1512,6 +1647,10 @@ textarea:focus-visible {
   transform: translateY(6px);
 }
 
+.ChatContainer.chat-drawer-expanded .chat-composer-dock * {
+  pointer-events: none;
+}
+
 .ChatInputForm {
   display: block;
 }
@@ -1523,7 +1662,6 @@ textarea:focus-visible {
   width: 100%;
   min-height: 0;
   padding: 14px;
-  overflow-y: auto;
   background: var(--geist-color-surface);
   border: 1px solid var(--geist-color-border);
   border-radius: var(--geist-radius-lg);
@@ -1531,6 +1669,7 @@ textarea:focus-visible {
 }
 
 .chat-history:not(.chat-history-empty) {
+  padding-top: var(--chat-toolbar-clearance);
   padding-bottom: var(--chat-composer-clearance);
 }
 
@@ -1872,6 +2011,17 @@ ul.relative {
   gap: 8px;
 }
 
+.input-actions {
+  display: flex;
+  flex: 0 0 72px;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+  align-self: flex-end;
+  width: 72px;
+  margin-right: 10px;
+}
+
 .chat-textarea,
 .form-control {
   width: 100%;
@@ -1909,6 +2059,7 @@ ul.relative {
 .icon-button {
   display: grid;
   flex: 0 0 40px;
+  align-self: center;
   place-items: center;
   width: 40px;
   border-radius: 50%;
@@ -1932,7 +2083,8 @@ ul.relative {
 
 .send-button {
   flex: 0 0 auto;
-  padding: 0 16px;
+  width: 100%;
+  padding: 0 12px;
   font-weight: 720;
 }
 
@@ -2121,13 +2273,29 @@ select.form-control {
   }
 
   .ChatContent {
+    --chat-toolbar-clearance: 66px;
     padding: 12px;
   }
 
   .chat-composer-dock {
-    right: 10px;
+    right: var(--chat-scrollbar-lane);
     bottom: 10px;
     left: 10px;
+  }
+
+  .chat-composer-dock::before {
+    inset: -10px 0 -10px -10px;
+  }
+
+  .input-actions {
+    flex-basis: 68px;
+    width: 68px;
+    margin-right: 8px;
+  }
+
+  .ChatSidebar.stage-panel-minimized::before {
+    right: var(--chat-scrollbar-lane);
+    height: 54px;
   }
 
   .stage-panel-surface {

--- a/client/geist/src/App.css
+++ b/client/geist/src/App.css
@@ -579,6 +579,10 @@ textarea:focus-visible {
   pointer-events: none;
 }
 
+.ChatSidebar.stage-panel {
+  --stage-panel-compact-width: 190px;
+}
+
 .stage-panel-surface {
   position: absolute;
   top: 12px;
@@ -752,6 +756,15 @@ textarea:focus-visible {
 .chat-new-button {
   gap: 8px;
   width: 100%;
+}
+
+.chat-new-toolbar {
+  position: relative;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(220px, 0.85fr);
+  gap: 8px;
+  align-items: stretch;
 }
 
 .chat-search {
@@ -1207,7 +1220,7 @@ textarea:focus-visible {
 }
 
 .ChatContent {
-  --chat-composer-clearance: 224px;
+  --chat-composer-clearance: 162px;
   position: relative;
   min-width: 0;
   min-height: 0;
@@ -1257,198 +1270,221 @@ textarea:focus-visible {
     transform var(--geist-motion-standard) var(--geist-ease-emphasized);
 }
 
-.chat-memory-controls {
-  display: grid;
-  grid-template-columns: minmax(190px, 1fr) auto;
-  gap: 8px 16px;
-  align-items: center;
-  min-height: 58px;
-  padding: 9px 12px;
-  background:
-    linear-gradient(
-      100deg,
-      color-mix(in srgb, var(--geist-color-accent) 9%, transparent),
-      transparent 42%
-    ),
-    color-mix(in srgb, var(--geist-color-surface) 96%, transparent);
-  border: 1px solid var(--geist-color-border);
-  border-radius: var(--geist-radius-lg);
-  box-shadow: var(--geist-shadow-panel);
-  backdrop-filter: blur(14px);
-}
-
-.chat-memory-status {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.chat-memory-scope {
+  position: relative;
   min-width: 0;
 }
 
-.chat-memory-status strong,
-.chat-memory-status small {
-  display: block;
+.chat-memory-trigger {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 14px;
+  gap: 7px;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 10px;
+  color: var(--geist-color-text-muted);
+  font-size: 0.74rem;
+  font-weight: 680;
+  text-align: left;
+  cursor: pointer;
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
 }
 
-.chat-memory-status strong {
+.chat-memory-trigger:hover:not(:disabled),
+.chat-memory-trigger[aria-expanded="true"] {
   color: var(--geist-color-text);
-  font-size: 0.8rem;
-  font-weight: 740;
+  background: var(--geist-color-surface-strong);
+  border-color: var(--geist-color-border-strong);
 }
 
-.chat-memory-state {
-  display: inline-block;
-  margin-left: 7px;
-  color: var(--geist-color-text-muted);
-  font-size: 0.58rem;
-  font-style: normal;
-  font-weight: 720;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+.chat-memory-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
-.chat-memory-state.state-ready {
-  color: var(--geist-color-success);
+.chat-memory-trigger svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
-.chat-memory-state.state-disabled {
-  color: var(--geist-color-text-muted);
+.chat-memory-trigger > svg:last-child {
+  width: 13px;
+  height: 13px;
+  transition: transform var(--geist-motion-fast) var(--geist-ease-standard);
 }
 
-.chat-memory-status small {
-  margin-top: 2px;
+.chat-memory-trigger[aria-expanded="true"] > svg:last-child {
+  transform: rotate(180deg);
+}
+
+.chat-memory-trigger-label {
   overflow: hidden;
-  color: var(--geist-color-text-muted);
-  font-size: 0.7rem;
+  color: var(--geist-color-text);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.chat-memory-orb {
-  position: relative;
-  width: 26px;
-  height: 26px;
-  flex: 0 0 26px;
+.chat-memory-scope.is-compact {
+  flex: 0 0 34px;
+  width: 34px;
+}
+
+.chat-memory-scope.is-compact .chat-memory-trigger {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  min-height: 34px;
+  padding: 0;
+  place-items: center;
+}
+
+.chat-memory-scope.is-compact .chat-memory-trigger > svg:last-child {
+  display: none;
+}
+
+.chat-memory-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 60;
+  display: grid;
+  width: min(330px, calc(100vw - 48px));
+  max-height: min(560px, calc(100vh - 90px));
+  padding: 6px;
+  overflow-y: auto;
+  color: var(--geist-color-text);
   background: var(--geist-color-surface-strong);
   border: 1px solid var(--geist-color-border-strong);
-  border-radius: 50%;
+  border-radius: var(--geist-radius-lg);
+  box-shadow: var(--geist-shadow-panel);
 }
 
-.chat-memory-orb::after {
-  position: absolute;
-  inset: 8px;
-  content: "";
-  background: var(--geist-color-text-muted);
-  border-radius: inherit;
-  opacity: 0.45;
+.chat-memory-scope.is-compact .chat-memory-menu {
+  right: auto;
+  left: 0;
 }
 
-.chat-memory-orb.is-active {
-  background: color-mix(in srgb, var(--geist-color-accent) 16%, var(--geist-color-surface));
-  border-color: color-mix(in srgb, var(--geist-color-accent) 48%, var(--geist-color-border));
-  box-shadow: 0 0 18px color-mix(in srgb, var(--geist-color-accent) 18%, transparent);
+.chat-memory-menu-section {
+  display: grid;
+  gap: 3px;
 }
 
-.chat-memory-orb.is-active::after {
-  background: var(--geist-color-accent-strong);
-  opacity: 1;
+.chat-memory-menu-section + .chat-memory-menu-section {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--geist-color-border);
 }
 
-.chat-memory-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.chat-memory-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 34px;
-  padding: 6px 9px;
+.chat-memory-menu-heading {
+  padding: 5px 9px 3px;
   color: var(--geist-color-text-muted);
-  font-size: 0.72rem;
-  font-weight: 650;
+  font-size: 0.62rem;
+  font-weight: 760;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.chat-memory-option,
+.chat-memory-manage {
+  width: 100%;
+  color: var(--geist-color-text-muted);
+  text-align: left;
   cursor: pointer;
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--geist-radius-md);
 }
 
-.chat-memory-switch:hover:not(:disabled) {
+.chat-memory-option {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-height: 46px;
+  padding: 6px 8px;
+}
+
+.chat-memory-option:hover,
+.chat-memory-option:focus-visible,
+.chat-memory-manage:hover,
+.chat-memory-manage:focus-visible {
   color: var(--geist-color-text);
-  background: var(--geist-color-surface-strong);
+  background: var(--geist-color-surface);
   border-color: var(--geist-color-border);
 }
 
-.chat-memory-switch:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.chat-memory-switch-track {
-  display: flex;
-  align-items: center;
-  width: 30px;
-  height: 17px;
-  padding: 2px;
-  background: var(--geist-color-border-strong);
-  border-radius: 999px;
-  transition: background var(--geist-motion-fast) var(--geist-ease-standard);
-}
-
-.chat-memory-switch-thumb {
-  width: 13px;
-  height: 13px;
-  background: var(--geist-color-text-muted);
-  border-radius: 50%;
-  transform: translateX(0);
-  transition:
-    background var(--geist-motion-fast) var(--geist-ease-standard),
-    transform var(--geist-motion-standard) var(--geist-ease-emphasized);
-}
-
-.chat-memory-switch.is-on {
+.chat-memory-option.is-selected {
   color: var(--geist-color-text);
+  background: color-mix(in srgb, var(--geist-color-accent) 10%, var(--geist-color-surface));
+  border-color: color-mix(in srgb, var(--geist-color-accent) 38%, var(--geist-color-border));
 }
 
-.chat-memory-switch.is-on .chat-memory-switch-track {
-  background: color-mix(in srgb, var(--geist-color-accent) 62%, var(--geist-color-border));
+.chat-memory-option-marker {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  color: var(--geist-color-accent-strong);
+  font-size: 0.68rem;
+  font-weight: 850;
+  border: 1px solid var(--geist-color-border-strong);
+  border-radius: 50%;
 }
 
-.chat-memory-switch.is-on .chat-memory-switch-thumb {
-  background: white;
-  transform: translateX(13px);
+.chat-memory-option.is-selected .chat-memory-option-marker {
+  color: var(--geist-color-surface);
+  background: var(--geist-color-accent-strong);
+  border-color: var(--geist-color-accent-strong);
 }
 
-.chat-memory-folder-select {
+.chat-memory-option-copy {
   display: grid;
   gap: 2px;
+  min-width: 0;
 }
 
-.chat-memory-folder-select > span {
+.chat-memory-option-copy strong {
+  overflow: hidden;
+  color: currentColor;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-memory-option-copy small {
+  overflow: hidden;
   color: var(--geist-color-text-muted);
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 0.66rem;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.chat-memory-folder-select select {
-  max-width: 160px;
-  height: 28px;
-  padding: 0 24px 0 8px;
-  color: var(--geist-color-text);
-  font-size: 0.72rem;
-  background: var(--geist-color-surface-strong);
-  border: 1px solid var(--geist-color-border);
-  border-radius: var(--geist-radius-sm);
+.chat-memory-manage {
+  min-height: 34px;
+  margin-top: 6px;
+  padding: 7px 9px;
+  border-top-color: var(--geist-color-border);
 }
 
 .chat-memory-error {
-  grid-column: 1 / -1;
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  z-index: 55;
+  width: min(300px, calc(100vw - 48px));
+  padding: 6px 8px;
   color: var(--geist-color-danger);
-  font-size: 0.7rem;
+  font-size: 0.68rem;
+  background: var(--geist-color-surface-strong);
+  border: 1px solid color-mix(in srgb, var(--geist-color-danger) 45%, var(--geist-color-border));
+  border-radius: var(--geist-radius-md);
+  box-shadow: var(--geist-shadow-panel);
 }
 
 .ChatContainer.chat-drawer-expanded .chat-composer-dock {
@@ -1668,6 +1704,10 @@ ul.relative {
   min-width: 0;
 }
 
+.chat-session-menu-host {
+  position: relative;
+}
+
 .chat-session-row .chat-session-link {
   min-width: 0;
 }
@@ -1689,6 +1729,72 @@ ul.relative {
   color: var(--geist-color-text);
   background: var(--geist-color-surface-strong);
   border-color: var(--geist-color-border-strong);
+}
+
+.chat-session-row-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 45;
+  display: grid;
+  gap: 3px;
+  width: min(240px, 70vw);
+  padding: 6px;
+  color: var(--geist-color-text);
+  background: var(--geist-color-surface-strong);
+  border: 1px solid var(--geist-color-border-strong);
+  border-radius: var(--geist-radius-lg);
+  box-shadow: var(--geist-shadow-panel);
+}
+
+.chat-session-row-menu button {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 8px;
+  color: var(--geist-color-text-muted);
+  text-align: left;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--geist-radius-md);
+}
+
+.chat-session-row-menu button:hover:not(:disabled),
+.chat-session-row-menu button:focus-visible {
+  color: var(--geist-color-text);
+  background: var(--geist-color-surface);
+  border-color: var(--geist-color-border);
+}
+
+.chat-session-row-menu button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.chat-session-row-menu button svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.chat-session-row-menu-label {
+  padding: 7px 8px 3px;
+  color: var(--geist-color-text-muted);
+  font-size: 0.62rem;
+  font-weight: 740;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.chat-session-menu-check {
+  color: var(--geist-color-accent-strong);
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-align: center;
 }
 
 .chat-title-edit-form {
@@ -2314,16 +2420,11 @@ select.form-control {
 
 @media (max-width: 780px) {
   .ChatContent {
-    --chat-composer-clearance: 286px;
+    --chat-composer-clearance: 216px;
   }
 
-  .chat-memory-controls {
+  .chat-new-toolbar {
     grid-template-columns: 1fr;
-  }
-
-  .chat-memory-actions {
-    justify-content: flex-start;
-    flex-wrap: wrap;
   }
 
   .file-selection-content.with-preview {

--- a/client/geist/src/App.tsx
+++ b/client/geist/src/App.tsx
@@ -8,25 +8,28 @@ import Files from './Files';
 import Models from './Models';
 import Settings from './Settings';
 import { BrandingProvider } from './branding';
+import { UserSettingsProvider } from './Hooks/useUserSettings';
 import './Motion.css';
 
 function App() {
   return (
     <BrandingProvider>
-      <BrowserRouter>
-        <AppShell>
-          <Routes>
-            <Route path="/" element={<Navigate to="/chat" replace />} />
-            <Route path="/chat" element={<Chat />} />
-            <Route path="/chat/:chatId" element={<Chat />} />
-            <Route path="/workflows" element={<WorkflowBuilder />} />
-            <Route path="/workflows/:workflowId" element={<WorkflowBuilder />} />
-            <Route path="/files" element={<Files />} />
-            <Route path="/models" element={<Models />} />
-            <Route path="/settings" element={<Settings />} />
-          </Routes>
-        </AppShell>
-      </BrowserRouter>
+      <UserSettingsProvider>
+        <BrowserRouter>
+          <AppShell>
+            <Routes>
+              <Route path="/" element={<Navigate to="/chat" replace />} />
+              <Route path="/chat" element={<Chat />} />
+              <Route path="/chat/:chatId" element={<Chat />} />
+              <Route path="/workflows" element={<WorkflowBuilder />} />
+              <Route path="/workflows/:workflowId" element={<WorkflowBuilder />} />
+              <Route path="/files" element={<Files />} />
+              <Route path="/models" element={<Models />} />
+              <Route path="/settings" element={<Settings />} />
+            </Routes>
+          </AppShell>
+        </BrowserRouter>
+      </UserSettingsProvider>
     </BrandingProvider>
   );
 }

--- a/client/geist/src/AppShell.test.tsx
+++ b/client/geist/src/AppShell.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AppShell from './AppShell';
+import useUserSettings from './Hooks/useUserSettings';
+
+
+jest.mock('./Hooks/useUserSettings');
+
+const mockUseUserSettings = useUserSettings as jest.MockedFunction<typeof useUserSettings>;
+const baseSettings = {
+  user_settings_id: 1,
+  user_id: 1,
+  default_agent_type: 'local',
+  default_local_model: 'Qwen/Qwen3-4B',
+  default_local_artifact_id: 'qwen3-4b-q4-k-m',
+  default_online_model: 'gpt-4o',
+  default_online_provider: 'openai',
+  default_file_archives: [],
+  enable_rag_by_default: false,
+  default_max_tokens: 1024,
+  default_temperature: 1,
+  default_top_p: 1,
+  default_frequency_penalty: 0,
+  default_presence_penalty: 0,
+  backup_providers: [],
+  ui_preferences: {},
+  create_date: '2026-07-27T00:00:00Z',
+  update_date: '2026-07-27T00:00:00Z',
+};
+
+function renderShell(): void {
+  render(
+    <MemoryRouter>
+      <AppShell>
+        <div>Content</div>
+      </AppShell>
+    </MemoryRouter>,
+  );
+}
+
+it('does not repeat local as a provider badge', () => {
+  mockUseUserSettings.mockReturnValue({
+    settings: baseSettings,
+    loading: false,
+    error: null,
+    updateSettings: jest.fn(),
+    resetSettings: jest.fn(),
+    refetch: jest.fn(),
+  });
+
+  renderShell();
+
+  const summary = screen.getByLabelText('Current runtime');
+  expect(within(summary).getAllByText('local')).toHaveLength(1);
+  expect(within(summary).getByText('Qwen/Qwen3-4B')).toBeInTheDocument();
+});
+
+it('shows the provider badge for online inference', () => {
+  mockUseUserSettings.mockReturnValue({
+    settings: {
+      ...baseSettings,
+      default_agent_type: 'online',
+    },
+    loading: false,
+    error: null,
+    updateSettings: jest.fn(),
+    resetSettings: jest.fn(),
+    refetch: jest.fn(),
+  });
+
+  renderShell();
+
+  const summary = screen.getByLabelText('Current runtime');
+  expect(within(summary).getByText('online')).toBeInTheDocument();
+  expect(within(summary).getByText('openai')).toBeInTheDocument();
+  expect(within(summary).getByText('gpt-4o')).toBeInTheDocument();
+});

--- a/client/geist/src/AppShell.tsx
+++ b/client/geist/src/AppShell.tsx
@@ -104,12 +104,13 @@ function RuntimeSummary(): JSX.Element {
 
   const mode = settings.default_agent_type || 'local';
   const model = mode === 'online' ? settings.default_online_model : settings.default_local_model;
-  const provider = mode === 'online' ? settings.default_online_provider : 'local';
 
   return (
     <div className="runtime-summary" aria-label="Current runtime">
       <span className="runtime-chip">{mode}</span>
-      <span className="runtime-chip">{provider}</span>
+      {mode === 'online' && (
+        <span className="runtime-chip">{settings.default_online_provider}</span>
+      )}
       <span className="runtime-model" title={model}>{model || 'No model selected'}</span>
     </div>
   );

--- a/client/geist/src/Chat.test.tsx
+++ b/client/geist/src/Chat.test.tsx
@@ -1,7 +1,20 @@
 import React from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Chat from './Chat';
+
+const mockPrepareNewChat = jest.fn();
+const mockSetScope = jest.fn(async () => true);
+const mockSetChatFolder = jest.fn(async () => true);
+const mockRefreshChatSessions = jest.fn();
+const mockRefreshFolders = jest.fn();
+let mockCompletedTurn: {
+  run_id: string;
+  prompt: string;
+  message: string;
+  origin_chat_id: number | null;
+  chat_id: number;
+} | null = null;
 
 jest.mock('./Hooks/useGetChatSessions', () => ({
   __esModule: true,
@@ -10,14 +23,17 @@ jest.mock('./Hooks/useGetChatSessions', () => ({
       {
         chat_id: 42,
         create_date: '2026-07-09T10:00:00.000Z',
-        chat_history: [{ user: 'Plan Geist drawer behavior', ai: 'Done' }]
+        chat_history: [{ user: 'Plan Geist drawer behavior', ai: 'Done' }],
+        folder_id: null,
+        memory_enabled: true,
+        memory_mode: 'public',
       }
     ],
     loading: false,
     error: null,
     hasMore: false,
     loadMore: jest.fn(),
-    refreshChatSessions: jest.fn()
+    refreshChatSessions: mockRefreshChatSessions,
   })
 }));
 
@@ -31,7 +47,7 @@ jest.mock('./Hooks/useCompleteText', () => ({
     loading: false,
     error: null,
     completedText: null,
-    completedTurn: null,
+    completedTurn: mockCompletedTurn,
     activeTurn: null,
     state_chat_id: null
   })
@@ -60,6 +76,17 @@ jest.mock('./Hooks/useUserSettings', () => ({
 
 jest.mock('./Hooks/useChatMemory', () => ({
   __esModule: true,
+  getMemoryScope: (settings: {
+    memory_enabled: boolean;
+    memory_mode: 'public' | 'private';
+    folder_id: number | null;
+  }) => {
+    if (!settings.memory_enabled) return { kind: 'disabled' };
+    if (settings.folder_id !== null) {
+      return { kind: 'folder', folderId: settings.folder_id };
+    }
+    return { kind: settings.memory_mode };
+  },
   default: () => ({
     settings: {
       memory_enabled: true,
@@ -78,12 +105,13 @@ jest.mock('./Hooks/useChatMemory', () => ({
     ],
     loading: false,
     error: null,
+    refreshFolders: mockRefreshFolders,
     createFolder: jest.fn(),
     renameFolder: jest.fn(),
     deleteFolder: jest.fn(),
-    setMemoryEnabled: jest.fn(),
-    setPrivate: jest.fn(),
-    setFolder: jest.fn(),
+    setScope: mockSetScope,
+    prepareNewChat: mockPrepareNewChat,
+    setChatFolder: mockSetChatFolder,
   }),
 }));
 
@@ -102,9 +130,16 @@ jest.mock('./Components/EnhancedChatInput', () => ({
   )
 }));
 
+jest.mock('./Components/MemoryExplorer', () => ({
+  __esModule: true,
+  default: () => <div>Memory explorer</div>,
+}));
+
 describe('Chat history panel', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    jest.clearAllMocks();
+    mockCompletedTurn = null;
   });
 
   it('morphs from compact chat controls into the chat-sized history panel', () => {
@@ -115,13 +150,10 @@ describe('Chat history panel', () => {
     );
 
     const drawer = screen.getByRole('complementary', { name: 'Chat sessions' });
-    const stage = drawer.closest('.chat-stage') as HTMLElement;
-    const composerDock = screen.getByRole('textbox', { name: 'Message' }).closest('.chat-composer-dock') as HTMLElement;
+    const composer = screen.getByRole('textbox', { name: 'Message' });
     expect(drawer).toHaveAttribute('data-state', 'minimized');
     expect(drawer).toHaveClass('stage-panel-minimized');
-    expect(stage).not.toBeNull();
-    expect(stage).toContainElement(composerDock);
-    expect(composerDock).toHaveAttribute('aria-hidden', 'false');
+    expect(composer).toBeInTheDocument();
     const newChatButton = within(drawer).getByRole('button', { name: 'New chat' });
     expect(newChatButton).toBeInTheDocument();
     expect(newChatButton).toHaveTextContent('New Chat');
@@ -133,8 +165,7 @@ describe('Chat history panel', () => {
 
     expect(drawer).toHaveAttribute('data-state', 'expanded');
     expect(drawer).toHaveClass('stage-panel-expanded');
-    expect(composerDock).toHaveAttribute('aria-hidden', 'true');
-    expect(drawer.querySelector('.stage-panel-surface')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Message' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Chats' })).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Search chats')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Research/ })).toBeInTheDocument();
@@ -147,11 +178,11 @@ describe('Chat history panel', () => {
 
     expect(drawer).toHaveAttribute('data-state', 'minimized');
     expect(drawer).toHaveClass('stage-panel-minimized');
-    expect(composerDock).toHaveAttribute('aria-hidden', 'false');
+    expect(screen.getByRole('textbox', { name: 'Message' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Chats' })).not.toBeInTheDocument();
     expect(window.localStorage.getItem('geist.chatDrawerState')).toBe('minimized');
-    expect(screen.getByRole('switch', { name: 'Memory enabled' })).toBeInTheDocument();
-    expect(screen.getByRole('switch', { name: 'Private' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Memory settings:/ })).toBeInTheDocument();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
   });
 
   it('edits a chat name and persists it locally', () => {
@@ -162,7 +193,10 @@ describe('Chat history panel', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Expand chat history' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Rename Plan Geist drawer behavior' }));
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Chat options for Plan Geist drawer behavior',
+    }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
 
     const titleInput = screen.getByRole('textbox', { name: 'Chat name' });
     fireEvent.change(titleInput, { target: { value: 'Drawer polish' } });
@@ -170,5 +204,94 @@ describe('Chat history panel', () => {
 
     expect(screen.getByText('Drawer polish')).toBeInTheDocument();
     expect(JSON.parse(window.localStorage.getItem('geist.chatTitles') || '{}')).toEqual({ '42': 'Drawer polish' });
+  });
+
+  it('inherits the selected folder when starting a new chat', () => {
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand chat history' }));
+    fireEvent.click(screen.getByRole('button', { name: /Research/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'New Chat' }));
+
+    expect(mockPrepareNewChat).toHaveBeenCalledWith({
+      kind: 'folder',
+      folderId: 9,
+    });
+  });
+
+  it('refreshes chat sessions and folder counts when a turn completes', async () => {
+    mockCompletedTurn = {
+      run_id: 'run-42',
+      prompt: 'Remember the launch date',
+      message: 'Saved',
+      origin_chat_id: null,
+      chat_id: 42,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockRefreshChatSessions).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRefreshFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves a chat into a folder from its row menu after confirmation', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    mockSetChatFolder.mockResolvedValueOnce(true);
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand chat history' }));
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Chat options for Plan Geist drawer behavior',
+    }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Research' }));
+
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining(
+      "existing summary and future saved memory will be available",
+    ));
+    await waitFor(() => {
+      expect(mockSetChatFolder).toHaveBeenCalledWith(42, 9);
+    });
+    await waitFor(() => {
+      expect(mockRefreshChatSessions).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('supports keyboard navigation and focus restoration in a chat row menu', () => {
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand chat history' }));
+    const trigger = screen.getByRole('button', {
+      name: 'Chat options for Plan Geist drawer behavior',
+    });
+    fireEvent.click(trigger);
+
+    const renameItem = screen.getByRole('menuitem', { name: 'Rename' });
+    expect(renameItem).toHaveFocus();
+    fireEvent.keyDown(renameItem, { key: 'ArrowDown' });
+    expect(screen.getByRole('menuitemradio', { name: 'No folder' })).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu', {
+      name: 'Plan Geist drawer behavior options',
+    })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
   });
 });

--- a/client/geist/src/Chat.test.tsx
+++ b/client/geist/src/Chat.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Chat from './Chat';
+import { installResizeObserverMock } from './testUtils/mockResizeObserver';
 
 const mockPrepareNewChat = jest.fn();
 const mockSetScope = jest.fn(async () => true);
@@ -143,29 +144,15 @@ describe('Chat history panel', () => {
   });
 
   it('only reserves the external scrollbar rail while the transcript overflows', () => {
-    let resizeObserverCallback: ResizeObserverCallback | null = null;
-    const originalResizeObserver = window.ResizeObserver;
-    class MockResizeObserver {
-      constructor(callback: ResizeObserverCallback) {
-        resizeObserverCallback = callback;
-      }
-
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-    Object.defineProperty(window, 'ResizeObserver', {
-      configurable: true,
-      writable: true,
-      value: MockResizeObserver,
-    });
+    const resizeObserver = installResizeObserverMock();
+    const renderResult = render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
 
     try {
-      const { container } = render(
-        <MemoryRouter initialEntries={['/chat']}>
-          <Chat />
-        </MemoryRouter>
-      );
+      const { container } = renderResult;
       const chat = container.querySelector<HTMLDivElement>('.ChatContainer');
       const transcript = container.querySelector<HTMLDivElement>('.chat-history-scroll');
       expect(chat).not.toBeNull();
@@ -182,18 +169,53 @@ describe('Chat history panel', () => {
         get: () => scrollHeight,
       });
 
-      act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+      act(() => resizeObserver.trigger(transcript as HTMLDivElement));
       expect(chat).toHaveClass('chat-scrollbar-visible');
 
       scrollHeight = 500;
-      act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+      act(() => resizeObserver.trigger(transcript as HTMLDivElement));
       expect(chat).not.toHaveClass('chat-scrollbar-visible');
     } finally {
-      Object.defineProperty(window, 'ResizeObserver', {
+      renderResult.unmount();
+      resizeObserver.restore();
+    }
+  });
+
+  it('only adds an external scrollbar gap while the chat drawer overflows', () => {
+    const resizeObserver = installResizeObserverMock();
+    const renderResult = render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    try {
+      const drawer = screen.getByRole('complementary', { name: 'Chat sessions' });
+      const drawerScroll = drawer.querySelector<HTMLDivElement>('.stage-panel-surface');
+      expect(drawerScroll).not.toBeNull();
+      expect(drawer).not.toHaveClass('stage-panel-scrollbar-visible');
+
+      fireEvent.click(within(drawer).getByRole('button', { name: 'Expand chat history' }));
+
+      let scrollHeight = 700;
+      Object.defineProperty(drawerScroll, 'clientHeight', {
         configurable: true,
-        writable: true,
-        value: originalResizeObserver,
+        get: () => 500,
       });
+      Object.defineProperty(drawerScroll, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      act(() => resizeObserver.trigger(drawerScroll as HTMLDivElement));
+      expect(drawer).toHaveClass('stage-panel-scrollbar-visible');
+
+      scrollHeight = 500;
+      act(() => resizeObserver.trigger(drawerScroll as HTMLDivElement));
+      expect(drawer).not.toHaveClass('stage-panel-scrollbar-visible');
+    } finally {
+      renderResult.unmount();
+      resizeObserver.restore();
     }
   });
 

--- a/client/geist/src/Chat.test.tsx
+++ b/client/geist/src/Chat.test.tsx
@@ -223,6 +223,19 @@ describe('Chat history panel', () => {
     });
   });
 
+  it('omits folder management from the memory menu when the drawer is already open', () => {
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <Chat />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand chat history' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Memory settings:/ }));
+
+    expect(screen.queryByRole('menuitem', { name: /Manage folders/ })).not.toBeInTheDocument();
+  });
+
   it('refreshes chat sessions and folder counts when a turn completes', async () => {
     mockCompletedTurn = {
       run_id: 'run-42',

--- a/client/geist/src/Chat.test.tsx
+++ b/client/geist/src/Chat.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import Chat from './Chat';
 
@@ -140,6 +140,61 @@ describe('Chat history panel', () => {
     window.localStorage.clear();
     jest.clearAllMocks();
     mockCompletedTurn = null;
+  });
+
+  it('only reserves the external scrollbar rail while the transcript overflows', () => {
+    let resizeObserverCallback: ResizeObserverCallback | null = null;
+    const originalResizeObserver = window.ResizeObserver;
+    class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallback = callback;
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.defineProperty(window, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: MockResizeObserver,
+    });
+
+    try {
+      const { container } = render(
+        <MemoryRouter initialEntries={['/chat']}>
+          <Chat />
+        </MemoryRouter>
+      );
+      const chat = container.querySelector<HTMLDivElement>('.ChatContainer');
+      const transcript = container.querySelector<HTMLDivElement>('.chat-history-scroll');
+      expect(chat).not.toBeNull();
+      expect(transcript).not.toBeNull();
+      expect(chat).not.toHaveClass('chat-scrollbar-visible');
+
+      let scrollHeight = 700;
+      Object.defineProperty(transcript, 'clientHeight', {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(transcript, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+      expect(chat).toHaveClass('chat-scrollbar-visible');
+
+      scrollHeight = 500;
+      act(() => resizeObserverCallback?.([], {} as ResizeObserver));
+      expect(chat).not.toHaveClass('chat-scrollbar-visible');
+    } finally {
+      Object.defineProperty(window, 'ResizeObserver', {
+        configurable: true,
+        writable: true,
+        value: originalResizeObserver,
+      });
+    }
   });
 
   it('morphs from compact chat controls into the chat-sized history panel', () => {

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -4,6 +4,7 @@ import useGetChatSessions from './Hooks/useGetChatSessions';
 import useFileContext from './Hooks/useFileContext';
 import useUserSettings from './Hooks/useUserSettings';
 import useChatMemory, { MemoryScope } from './Hooks/useChatMemory';
+import useOverflowObserver from './Hooks/useOverflowObserver';
 import ChatTextArea from './Components/ChatTextArea';
 import EnhancedChatInput from './Components/EnhancedChatInput';
 import ChatMemoryControls from './Components/ChatMemoryControls';
@@ -152,17 +153,16 @@ const Chat = () => {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
-  const [hasChatScrollbar, setHasChatScrollbar] = useState(false);
-  const chatContainerRef = useRef<HTMLDivElement>(null);
+  const {
+    ref: chatContainerRef,
+    hasOverflow: hasChatScrollbar,
+  } = useOverflowObserver<HTMLDivElement>();
+  const {
+    ref: chatDrawerScrollRef,
+    hasOverflow: hasChatDrawerScrollbar,
+  } = useOverflowObserver<HTMLDivElement>(chatDrawerState === 'expanded');
   const prevScrollHeightRef = useRef<number>(0);
   const shouldRestoreScrollRef = useRef(false);
-  const updateChatScrollbarState = useCallback(() => {
-    const container = chatContainerRef.current;
-    if (!container) return;
-
-    const nextHasScrollbar = container.scrollHeight > container.clientHeight + 1;
-    setHasChatScrollbar(current => current === nextHasScrollbar ? current : nextHasScrollbar);
-  }, []);
 
   const fetchHistory = useCallback(async (pageNum: number, currentChatId: string) => {
     if (!currentChatId) return;
@@ -220,7 +220,7 @@ const Chat = () => {
     } else if (page === 1 && chatContainerRef.current && !shouldRestoreScrollRef.current) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
-  }, [chatHistory, page, isLoading]);
+  }, [chatContainerRef, chatHistory, page, isLoading]);
 
   useEffect(() => {
     const container = chatContainerRef.current;
@@ -233,7 +233,7 @@ const Chat = () => {
         }
       }
     }
-  }, [chatHistory, hasMore, isLoadingHistory, page, chatId, fetchHistory]);
+  }, [chatContainerRef, chatHistory, hasMore, isLoadingHistory, page, chatId, fetchHistory]);
 
   const observer = useRef<IntersectionObserver>();
   const lastItemRef = useCallback(
@@ -263,7 +263,7 @@ const Chat = () => {
         }
       }
     }
-  }, [hasMore, isLoadingHistory, page, chatId, loadedHistoryLength, fetchHistory]);
+  }, [chatContainerRef, hasMore, isLoadingHistory, page, chatId, loadedHistoryLength, fetchHistory]);
 
   useEffect(() => {
     const container = chatContainerRef.current;
@@ -271,7 +271,7 @@ const Chat = () => {
       container.addEventListener('scroll', handleScroll);
       return () => container.removeEventListener('scroll', handleScroll);
     }
-  }, [handleScroll]);
+  }, [chatContainerRef, handleScroll]);
 
   const chatWithServer = async (input: string) => {
     const parsedChatId = routeChatId ?? state_chat_id;
@@ -576,34 +576,6 @@ const Chat = () => {
     ],
   );
 
-  useLayoutEffect(() => {
-    updateChatScrollbarState();
-  }, [chatDrawerState, displayedHistory, isLoading, updateChatScrollbarState]);
-
-  useLayoutEffect(() => {
-    const container = chatContainerRef.current;
-    if (!container) return undefined;
-
-    updateChatScrollbarState();
-    window.addEventListener('resize', updateChatScrollbarState);
-
-    if (typeof ResizeObserver === 'undefined') {
-      return () => window.removeEventListener('resize', updateChatScrollbarState);
-    }
-
-    const resizeObserver = new ResizeObserver(updateChatScrollbarState);
-    resizeObserver.observe(container);
-    const content = container.firstElementChild;
-    if (content) {
-      resizeObserver.observe(content);
-    }
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', updateChatScrollbarState);
-    };
-  }, [updateChatScrollbarState]);
-
   return (
     <div className={`ChatContainer chat-drawer-${chatDrawerState}${hasChatScrollbar ? ' chat-scrollbar-visible' : ''}`}>
       <section className="ChatContent">
@@ -618,11 +590,11 @@ const Chat = () => {
           </div>
 
           <aside
-            className={`ChatSidebar stage-panel chat-library-panel-host stage-panel-${chatDrawerState}`}
+            className={`ChatSidebar stage-panel chat-library-panel-host stage-panel-${chatDrawerState}${hasChatDrawerScrollbar ? ' stage-panel-scrollbar-visible' : ''}`}
             aria-label="Chat sessions"
             data-state={chatDrawerState}
           >
-            <div className="stage-panel-surface">
+            <div className="stage-panel-surface" ref={chatDrawerScrollRef}>
               {chatDrawerState === 'minimized' ? (
                 <div className="chat-minimized-controls stage-panel-compact-controls" aria-label="Chat shortcuts">
                   <button className="button chat-minimized-new-button stage-panel-primary-button" type="button" onClick={handleNewChat} aria-label="New chat" title="New chat">

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -152,9 +152,17 @@ const Chat = () => {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [hasChatScrollbar, setHasChatScrollbar] = useState(false);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef<number>(0);
   const shouldRestoreScrollRef = useRef(false);
+  const updateChatScrollbarState = useCallback(() => {
+    const container = chatContainerRef.current;
+    if (!container) return;
+
+    const nextHasScrollbar = container.scrollHeight > container.clientHeight + 1;
+    setHasChatScrollbar(current => current === nextHasScrollbar ? current : nextHasScrollbar);
+  }, []);
 
   const fetchHistory = useCallback(async (pageNum: number, currentChatId: string) => {
     if (!currentChatId) return;
@@ -545,31 +553,68 @@ const Chat = () => {
     activeTurn?.run_id &&
     (chatHistory?.chatHistory ?? []).some((turn) => turn.run_id === activeTurn.run_id)
   );
-  const displayedHistory: ChatPair[] = activeTurnBelongsToCurrentChat && !activeTurnAlreadyPersisted
-    ? [
-        ...(chatHistory?.chatHistory ?? []),
-        {
-          run_id: activeTurn!.run_id,
-          user: activeTurn!.prompt,
-          ai: activeTurn!.message,
-          status: activeTurn!.status,
-          model_load: activeTurn!.model_load,
-          tool_calls: activeTurn!.tool_calls,
-          artifacts: activeTurn!.artifacts,
-        },
-      ]
-    : (chatHistory?.chatHistory ?? []);
+  const displayedHistory = useMemo<ChatPair[]>(
+    () => activeTurnBelongsToCurrentChat && !activeTurnAlreadyPersisted
+      ? [
+          ...(chatHistory?.chatHistory ?? []),
+          {
+            run_id: activeTurn!.run_id,
+            user: activeTurn!.prompt,
+            ai: activeTurn!.message,
+            status: activeTurn!.status,
+            model_load: activeTurn!.model_load,
+            tool_calls: activeTurn!.tool_calls,
+            artifacts: activeTurn!.artifacts,
+          },
+        ]
+      : (chatHistory?.chatHistory ?? []),
+    [
+      activeTurn,
+      activeTurnAlreadyPersisted,
+      activeTurnBelongsToCurrentChat,
+      chatHistory?.chatHistory,
+    ],
+  );
+
+  useLayoutEffect(() => {
+    updateChatScrollbarState();
+  }, [chatDrawerState, displayedHistory, isLoading, updateChatScrollbarState]);
+
+  useLayoutEffect(() => {
+    const container = chatContainerRef.current;
+    if (!container) return undefined;
+
+    updateChatScrollbarState();
+    window.addEventListener('resize', updateChatScrollbarState);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => window.removeEventListener('resize', updateChatScrollbarState);
+    }
+
+    const resizeObserver = new ResizeObserver(updateChatScrollbarState);
+    resizeObserver.observe(container);
+    const content = container.firstElementChild;
+    if (content) {
+      resizeObserver.observe(content);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateChatScrollbarState);
+    };
+  }, [updateChatScrollbarState]);
 
   return (
-    <div className={`ChatContainer chat-drawer-${chatDrawerState}`}>
+    <div className={`ChatContainer chat-drawer-${chatDrawerState}${hasChatScrollbar ? ' chat-scrollbar-visible' : ''}`}>
       <section className="ChatContent">
         <div className="chat-stage">
           <div className="chat-transcript-layer" aria-hidden={chatDrawerState === 'expanded'}>
-            <ChatTextArea
-              chatHistory={displayedHistory}
-              isLoading={isLoading}
-              ref={chatContainerRef}
-            />
+            <div className="chat-history-scroll" ref={chatContainerRef}>
+              <ChatTextArea
+                chatHistory={displayedHistory}
+                isLoading={isLoading}
+              />
+            </div>
           </div>
 
           <aside

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -630,7 +630,6 @@ const Chat = () => {
                         disabled={isLoading}
                         error={memoryError}
                         onScopeChange={scope => void changeMemoryScope(scope)}
-                        onManageFolders={manageFolders}
                       />
                     </div>
 

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -3,7 +3,7 @@ import useCompleteText from './Hooks/useCompleteText';
 import useGetChatSessions from './Hooks/useGetChatSessions';
 import useFileContext from './Hooks/useFileContext';
 import useUserSettings from './Hooks/useUserSettings';
-import useChatMemory from './Hooks/useChatMemory';
+import useChatMemory, { MemoryScope } from './Hooks/useChatMemory';
 import ChatTextArea from './Components/ChatTextArea';
 import EnhancedChatInput from './Components/EnhancedChatInput';
 import ChatMemoryControls from './Components/ChatMemoryControls';
@@ -80,6 +80,10 @@ const Chat = () => {
   const [editingFolderId, setEditingFolderId] = useState<number | null>(null);
   const [folderRenameDraft, setFolderRenameDraft] = useState('');
   const [confirmDeleteFolderId, setConfirmDeleteFolderId] = useState<number | null>(null);
+  const [openChatMenuId, setOpenChatMenuId] = useState<number | null>(null);
+  const [movingChatId, setMovingChatId] = useState<number | null>(null);
+  const chatMenuHostRef = useRef<HTMLDivElement>(null);
+  const chatMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
   const { chatSessions, loading: isChatSessionLoading, error: chatSessionError, loadMore: loadMoreSessions, hasMore: hasMoreSessions, refreshChatSessions } = useGetChatSessions();
   const [userInput, setUserInput] = useState('');
   const [fileContextInfo, setFileContextInfo] = useState<string>('');
@@ -102,13 +106,42 @@ const Chat = () => {
     folders,
     loading: isMemoryLoading,
     error: memoryError,
+    refreshFolders,
     createFolder,
     renameFolder,
     deleteFolder,
-    setMemoryEnabled,
-    setPrivate,
-    setFolder,
+    setScope,
+    prepareNewChat,
+    setChatFolder,
   } = useChatMemory(selectedChatId);
+
+  useEffect(() => {
+    if (openChatMenuId === null) return undefined;
+
+    const firstItem = chatMenuHostRef.current?.querySelector<HTMLButtonElement>(
+      '[role="menu"] button:not(:disabled)',
+    );
+    firstItem?.focus();
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!chatMenuHostRef.current?.contains(event.target as Node)) {
+        setOpenChatMenuId(null);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpenChatMenuId(null);
+        chatMenuTriggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [openChatMenuId]);
 
   useEffect(() => {
     if (!chatId && state_chat_id !== null) {
@@ -303,11 +336,14 @@ const Chat = () => {
       }
       return { chatHistory: [...existingHistory, newHistory] };
     });
-    void refreshChatSessions();
-  }, [completedTurn, refreshChatSessions, routeChatId, state_chat_id]);
+    void Promise.all([
+      refreshChatSessions(),
+      refreshFolders(),
+    ]);
+  }, [completedTurn, refreshChatSessions, refreshFolders, routeChatId, state_chat_id]);
 
   const handleSubmit = async (message: string) => {
-    if (message.trim()) {
+    if (message.trim() && !isMemoryLoading) {
       await chatWithServer(message);
       setUserInput('');
     }
@@ -316,7 +352,7 @@ const Chat = () => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (userInput.trim() && !isLoading) {
+      if (userInput.trim() && !isLoading && !isMemoryLoading) {
         void handleSubmit(userInput);
       }
     }
@@ -329,10 +365,15 @@ const Chat = () => {
       setEditingChatId(null);
       setChatTitleDraft('');
       setChatTitleError('');
+      setOpenChatMenuId(null);
     }
   };
 
   const handleNewChat = () => {
+    const newChatScope: MemoryScope = folderFilter === 'all'
+      ? { kind: 'public' }
+      : { kind: 'folder', folderId: folderFilter };
+    prepareNewChat(newChatScope);
     resetChatSession();
     setDrawerState('minimized');
     setChatHistory(undefined);
@@ -341,6 +382,7 @@ const Chat = () => {
     navigate('/chat');
   };
   const startEditingChatTitle = (session: ChatSessionListItem) => {
+    setOpenChatMenuId(null);
     setEditingChatId(session.id);
     setChatTitleDraft(session.name);
     setChatTitleError('');
@@ -410,6 +452,7 @@ const Chat = () => {
   const removeFolder = async (folderId: number) => {
     try {
       await deleteFolder(folderId);
+      await refreshChatSessions();
       setFolderFilter('all');
       setConfirmDeleteFolderId(null);
       setFolderCreateError('');
@@ -418,6 +461,70 @@ const Chat = () => {
         folderError instanceof Error ? folderError.message : 'Could not delete folder.',
       );
     }
+  };
+
+  const changeMemoryScope = async (scope: MemoryScope) => {
+    const updated = await setScope(scope);
+    if (updated && selectedChatId !== null) {
+      await refreshChatSessions();
+    }
+  };
+
+  const moveChatToFolder = async (
+    session: ChatSessionListItem,
+    folderId: number | null,
+  ) => {
+    setOpenChatMenuId(null);
+    if (session.folderId === folderId) return;
+
+    const destination = folderId === null
+      ? null
+      : folders.find(folder => folder.folder_id === folderId) ?? null;
+    const confirmed = window.confirm(
+      destination
+        ? `Move "${session.name}" to "${destination.name}"? While memory is enabled, this chat's existing summary and future saved memory will be available to other chats in this folder.`
+        : `Remove "${session.name}" from its folder? If memory is enabled, its saved memory will stop contributing to the folder and remain available only in this chat.`,
+    );
+    if (!confirmed) return;
+
+    setMovingChatId(session.id);
+    try {
+      const updated = await setChatFolder(session.id, folderId);
+      if (updated) {
+        await refreshChatSessions();
+      }
+    } finally {
+      setMovingChatId(null);
+    }
+  };
+
+  const manageFolders = () => {
+    if (memorySettings.folder_id !== null) {
+      setFolderFilter(memorySettings.folder_id);
+    }
+    setDrawerState('expanded');
+  };
+
+  const moveChatMenuFocus = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Tab') {
+      setOpenChatMenuId(null);
+      return;
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const items = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'),
+    );
+    if (items.length === 0) return;
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIndex = currentIndex;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = items.length - 1;
+    if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1 + items.length) % items.length;
+    if (event.key === 'ArrowUp') {
+      nextIndex = (currentIndex - 1 + items.length) % items.length;
+    }
+    items[nextIndex].focus();
   };
 
   const searchQuery = chatSearch.trim().toLowerCase();
@@ -477,6 +584,16 @@ const Chat = () => {
                     <span>New Chat</span>
                     <StagePanelIcon name="plus" />
                   </button>
+                  <ChatMemoryControls
+                    compact
+                    settings={memorySettings}
+                    folders={folders}
+                    loading={isMemoryLoading}
+                    disabled={isLoading}
+                    error={memoryError}
+                    onScopeChange={scope => void changeMemoryScope(scope)}
+                    onManageFolders={manageFolders}
+                  />
                   <button
                     className="chat-minimized-open-button stage-panel-open-button"
                     type="button"
@@ -501,10 +618,21 @@ const Chat = () => {
                       </button>
                     </header>
 
-                    <button className="button chat-new-button" type="button" onClick={handleNewChat}>
-                      <StagePanelIcon name="plus" />
-                      <span>New Chat</span>
-                    </button>
+                    <div className="chat-new-toolbar">
+                      <button className="button chat-new-button" type="button" onClick={handleNewChat}>
+                        <StagePanelIcon name="plus" />
+                        <span>New Chat</span>
+                      </button>
+                      <ChatMemoryControls
+                        settings={memorySettings}
+                        folders={folders}
+                        loading={isMemoryLoading}
+                        disabled={isLoading}
+                        error={memoryError}
+                        onScopeChange={scope => void changeMemoryScope(scope)}
+                        onManageFolders={manageFolders}
+                      />
+                    </div>
 
                     <label className="chat-search" htmlFor="chat-session-search">
                       <StagePanelIcon name="search" />
@@ -625,7 +753,7 @@ const Chat = () => {
                         )}
                         {confirmDeleteFolderId === selectedFolder.folder_id && (
                           <div className="chat-folder-delete-confirm" role="alert">
-                            <p>Chats stay private and become unfiled.</p>
+                            <p>Chats stay private and become unfiled. Shared folder facts and the folder summary will be deleted.</p>
                             <button type="button" onClick={() => setConfirmDeleteFolderId(null)}>Cancel</button>
                             <button
                               className="is-danger"
@@ -651,9 +779,6 @@ const Chat = () => {
 
                     <div className="chat-drawer-section-title">
                       <span>Recent chats</span>
-                      <button className="chat-icon-plain" type="button" aria-label="Chat list options" title="Chat list options">
-                        <StagePanelIcon name="more" />
-                      </button>
                     </div>
 
                     {filteredChatSessionLinks.length > 0 ? (
@@ -708,15 +833,72 @@ const Chat = () => {
                                           : session.memoryMode === 'private' ? 'Private' : 'Global memory'}
                                     </span>
                                   </NavLink>
-                                  <button
-                                    className="chat-session-edit-button"
-                                    type="button"
-                                    onClick={() => startEditingChatTitle(session)}
-                                    aria-label={`Rename ${session.name}`}
-                                    title="Rename chat"
+                                  <div
+                                    className="chat-session-menu-host"
+                                    ref={openChatMenuId === session.id ? chatMenuHostRef : undefined}
                                   >
-                                    <StagePanelIcon name="edit" />
-                                  </button>
+                                    <button
+                                      className="chat-session-edit-button"
+                                      type="button"
+                                      onClick={(event) => {
+                                        chatMenuTriggerRef.current = event.currentTarget;
+                                        setOpenChatMenuId(
+                                          openChatMenuId === session.id ? null : session.id,
+                                        );
+                                      }}
+                                      aria-label={`Chat options for ${session.name}`}
+                                      aria-haspopup="menu"
+                                      aria-expanded={openChatMenuId === session.id}
+                                      title="Chat options"
+                                    >
+                                      <StagePanelIcon name="more" />
+                                    </button>
+                                    {openChatMenuId === session.id && (
+                                      <div
+                                        className="chat-session-row-menu"
+                                        role="menu"
+                                        aria-label={`${session.name} options`}
+                                        onKeyDown={moveChatMenuFocus}
+                                      >
+                                        <button
+                                          type="button"
+                                          role="menuitem"
+                                          onClick={() => startEditingChatTitle(session)}
+                                        >
+                                          <StagePanelIcon name="edit" />
+                                          <span>Rename</span>
+                                        </button>
+                                        <span className="chat-session-row-menu-label">Move to</span>
+                                        <button
+                                          type="button"
+                                          role="menuitemradio"
+                                          aria-checked={session.folderId === null}
+                                          disabled={movingChatId === session.id}
+                                          onClick={() => void moveChatToFolder(session, null)}
+                                        >
+                                          <span className="chat-session-menu-check" aria-hidden="true">
+                                            {session.folderId === null ? '✓' : ''}
+                                          </span>
+                                          <span>No folder</span>
+                                        </button>
+                                        {folders.map(folder => (
+                                          <button
+                                            type="button"
+                                            role="menuitemradio"
+                                            aria-checked={session.folderId === folder.folder_id}
+                                            disabled={movingChatId === session.id}
+                                            onClick={() => void moveChatToFolder(session, folder.folder_id)}
+                                            key={folder.folder_id}
+                                          >
+                                            <span className="chat-session-menu-check" aria-hidden="true">
+                                              {session.folderId === folder.folder_id ? '✓' : ''}
+                                            </span>
+                                            <span>{folder.name}</span>
+                                          </button>
+                                        ))}
+                                      </div>
+                                    )}
+                                  </div>
                                 </>
                               )}
                             </div>
@@ -738,15 +920,6 @@ const Chat = () => {
           </aside>
 
           <div className="chat-composer-dock" aria-hidden={chatDrawerState === 'expanded'}>
-            <ChatMemoryControls
-              settings={memorySettings}
-              folders={folders}
-              loading={isMemoryLoading}
-              error={memoryError}
-              onMemoryEnabledChange={enabled => void setMemoryEnabled(enabled)}
-              onPrivateChange={isPrivate => void setPrivate(isPrivate)}
-              onFolderChange={folderId => void setFolder(folderId)}
-            />
             {fileContextInfo && (
               <div className="chat-context-info">
                 {fileContextInfo}
@@ -758,7 +931,7 @@ const Chat = () => {
                 value={userInput}
                 onChange={setUserInput}
                 onSubmit={handleSubmit}
-                disabled={isLoading || isProcessingFiles}
+                disabled={isLoading || isProcessingFiles || isMemoryLoading}
                 placeholder="Type your message..."
                 handleKeyDown={handleKeyDown}
                 rows={3}

--- a/client/geist/src/Components/ChatMemoryControls.tsx
+++ b/client/geist/src/Components/ChatMemoryControls.tsx
@@ -1,107 +1,263 @@
-import { MemoryFolder, ChatMemorySettings } from '../Hooks/useChatMemory';
+import { useEffect, useId, useRef, useState } from 'react';
+import {
+  ChatMemorySettings,
+  getMemoryScope,
+  MemoryFolder,
+  MemoryScope,
+} from '../Hooks/useChatMemory';
+import StagePanelIcon from './StagePanelIcon';
 
 interface ChatMemoryControlsProps {
   settings: ChatMemorySettings;
   folders: MemoryFolder[];
   loading: boolean;
+  disabled?: boolean;
+  compact?: boolean;
   error: string | null;
-  onMemoryEnabledChange: (enabled: boolean) => void;
-  onPrivateChange: (isPrivate: boolean) => void;
-  onFolderChange: (folderId: number | null) => void;
+  onScopeChange: (scope: MemoryScope) => void;
+  onManageFolders: () => void;
 }
 
-function MemorySwitch({
-  label,
-  checked,
-  disabled = false,
-  onChange,
-}: {
+interface ScopeOption {
+  scope: MemoryScope;
   label: string;
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (checked: boolean) => void;
-}) {
-  return (
-    <button
-      type="button"
-      className={`chat-memory-switch${checked ? ' is-on' : ''}`}
-      role="switch"
-      aria-label={label}
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-    >
-      <span className="chat-memory-switch-track">
-        <span className="chat-memory-switch-thumb" />
-      </span>
-      <span>{label}</span>
-    </button>
-  );
+  description: string;
+}
+
+const STANDARD_OPTIONS: ScopeOption[] = [
+  {
+    scope: { kind: 'disabled' },
+    label: 'Memory Disabled',
+    description: 'Do not save or recall memory.',
+  },
+  {
+    scope: { kind: 'public' },
+    label: 'Memory Enabled',
+    description: 'Use memory across chats.',
+  },
+  {
+    scope: { kind: 'private' },
+    label: 'Memory Enabled (this chat only)',
+    description: 'Keep memory within this chat.',
+  },
+];
+
+function scopesMatch(left: MemoryScope, right: MemoryScope): boolean {
+  if (left.kind !== right.kind) return false;
+  return left.kind !== 'folder'
+    || (right.kind === 'folder' && left.folderId === right.folderId);
+}
+
+function triggerLabel(scope: MemoryScope, folders: MemoryFolder[]): string {
+  if (scope.kind === 'folder') {
+    const folder = folders.find(item => item.folder_id === scope.folderId);
+    return `Memory: ${folder?.name ?? 'Folder'}`;
+  }
+  if (scope.kind === 'disabled') return 'Memory Disabled';
+  if (scope.kind === 'private') return 'Memory Enabled (this chat only)';
+  return 'Memory Enabled';
 }
 
 export default function ChatMemoryControls({
   settings,
   folders,
   loading,
+  disabled = false,
+  compact = false,
   error,
-  onMemoryEnabledChange,
-  onPrivateChange,
-  onFolderChange,
+  onScopeChange,
+  onManageFolders,
 }: ChatMemoryControlsProps) {
-  const isPrivate = settings.memory_mode === 'private' || settings.folder_id !== null;
-  const scopeLabel = !settings.memory_enabled
-    ? 'Memory is off for this chat'
-    : settings.folder_id !== null
-      ? 'Stored only in this private folder'
-      : isPrivate
-        ? 'Stored only in this private chat'
-        : 'Eligible for your global profile';
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const folderHeadingId = `${menuId}-folders`;
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const openFocusRef = useRef<'selected' | 'first' | 'last'>('selected');
+  const currentScope = getMemoryScope(settings);
+  const label = triggerLabel(currentScope, folders);
+  const interactionDisabled = disabled || loading;
+
+  const closeMenu = (restoreFocus = false) => {
+    setOpen(false);
+    if (restoreFocus) triggerRef.current?.focus();
+  };
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (interactionDisabled) setOpen(false);
+  }, [interactionDisabled]);
+
+  useEffect(() => {
+    if (!open) return;
+    const menu = rootRef.current?.querySelector<HTMLElement>('[role="menu"]');
+    if (!menu) return;
+    const items = Array.from(
+      menu.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitemradio"]:not(:disabled), [role="menuitem"]:not(:disabled)',
+      ),
+    );
+    const target = openFocusRef.current === 'last'
+      ? items[items.length - 1]
+      : openFocusRef.current === 'first'
+        ? items[0]
+        : menu.querySelector<HTMLButtonElement>('[role="menuitemradio"][aria-checked="true"]')
+          ?? items[0];
+    target?.focus();
+  }, [open]);
+
+  const selectScope = (scope: MemoryScope) => {
+    if (!scopesMatch(scope, currentScope)) onScopeChange(scope);
+    closeMenu(true);
+  };
+
+  const moveMenuFocus = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const items = Array.from(
+      event.currentTarget.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitemradio"]:not(:disabled), [role="menuitem"]:not(:disabled)',
+      ),
+    );
+    if (items.length === 0) return;
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIndex = currentIndex;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = items.length - 1;
+    if (event.key === 'ArrowDown') nextIndex = (currentIndex + 1 + items.length) % items.length;
+    if (event.key === 'ArrowUp') {
+      nextIndex = (currentIndex - 1 + items.length) % items.length;
+    }
+    items[nextIndex].focus();
+  };
+
+  const renderScopeOption = (option: ScopeOption) => {
+    const selected = scopesMatch(option.scope, currentScope);
+    const optionKey = option.scope.kind === 'folder'
+      ? `folder-${option.scope.folderId}`
+      : option.scope.kind;
+    return (
+      <button
+        key={optionKey}
+        type="button"
+        className={`chat-memory-option${selected ? ' is-selected' : ''}`}
+        role="menuitemradio"
+        aria-checked={selected}
+        aria-label={option.label}
+        onClick={() => selectScope(option.scope)}
+      >
+        <span className="chat-memory-option-marker" aria-hidden="true">
+          {selected ? '✓' : ''}
+        </span>
+        <span className="chat-memory-option-copy">
+          <strong>{option.label}</strong>
+          <small>{option.description}</small>
+        </span>
+      </button>
+    );
+  };
 
   return (
-    <section className="chat-memory-controls" aria-label="Chat memory settings">
-      <div className="chat-memory-status">
-        <span className={`chat-memory-orb${settings.memory_enabled ? ' is-active' : ''}`} />
-        <span>
-          <strong>
-            Memory
-            {settings.status && (
-              <em className={`chat-memory-state state-${settings.status}`}>
-                {settings.status.replace(/_/g, ' ')}
-              </em>
-            )}
-          </strong>
-          <small>{scopeLabel}</small>
-        </span>
-      </div>
-      <div className="chat-memory-actions">
-        <MemorySwitch
-          label="Memory enabled"
-          checked={settings.memory_enabled}
-          disabled={loading}
-          onChange={onMemoryEnabledChange}
-        />
-        <MemorySwitch
-          label="Private"
-          checked={isPrivate}
-          disabled={loading || !settings.memory_enabled}
-          onChange={onPrivateChange}
-        />
-        <label className="chat-memory-folder-select">
-          <span>Folder</span>
-          <select
-            aria-label="Memory folder"
-            value={settings.folder_id ?? ''}
-            disabled={loading || !settings.memory_enabled}
-            onChange={event => onFolderChange(event.target.value ? Number(event.target.value) : null)}
+    <div
+      ref={rootRef}
+      className={`chat-memory-scope${compact ? ' is-compact' : ''}`}
+      aria-busy={loading || undefined}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className="chat-memory-trigger"
+        aria-label={`Memory settings: ${label}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        title={compact ? label : undefined}
+        disabled={interactionDisabled}
+        onClick={() => {
+          openFocusRef.current = 'selected';
+          setOpen(value => !value);
+        }}
+        onKeyDown={event => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            openFocusRef.current = event.key === 'ArrowDown' ? 'first' : 'last';
+            setOpen(true);
+          }
+        }}
+      >
+        <StagePanelIcon name="memory" />
+        {!compact && <span className="chat-memory-trigger-label">{label}</span>}
+        <StagePanelIcon name="chevron" />
+      </button>
+
+      {open && (
+        <div
+          className="chat-memory-menu"
+          id={menuId}
+          role="menu"
+          aria-label="Memory options"
+          onKeyDown={event => {
+            if (event.key === 'Tab') setOpen(false);
+            moveMenuFocus(event);
+          }}
+        >
+          <div className="chat-memory-menu-section">
+            {STANDARD_OPTIONS.map(renderScopeOption)}
+          </div>
+
+          <div
+            className="chat-memory-menu-section"
+            role="group"
+            aria-labelledby={folderHeadingId}
           >
-            <option value="">Unfiled</option>
-            {folders.map(folder => (
-              <option key={folder.folder_id} value={folder.folder_id}>{folder.name}</option>
-            ))}
-          </select>
-        </label>
-      </div>
+            <span id={folderHeadingId} className="chat-memory-menu-heading">
+              Folder memory
+            </span>
+            {folders.map(folder => renderScopeOption({
+              scope: { kind: 'folder', folderId: folder.folder_id },
+              label: folder.name,
+              description: `Share memory with chats in ${folder.name}.`,
+            }))}
+          </div>
+
+          <button
+            type="button"
+            className="chat-memory-manage"
+            role="menuitem"
+            onClick={() => {
+              closeMenu(true);
+              onManageFolders();
+            }}
+          >
+            Manage folders…
+          </button>
+        </div>
+      )}
+
       {error && <span className="chat-memory-error" role="alert">{error}</span>}
-    </section>
+    </div>
   );
 }

--- a/client/geist/src/Components/ChatMemoryControls.tsx
+++ b/client/geist/src/Components/ChatMemoryControls.tsx
@@ -15,7 +15,7 @@ interface ChatMemoryControlsProps {
   compact?: boolean;
   error: string | null;
   onScopeChange: (scope: MemoryScope) => void;
-  onManageFolders: () => void;
+  onManageFolders?: () => void;
 }
 
 interface ScopeOption {
@@ -76,6 +76,8 @@ export default function ChatMemoryControls({
   const openFocusRef = useRef<'selected' | 'first' | 'last'>('selected');
   const currentScope = getMemoryScope(settings);
   const label = triggerLabel(currentScope, folders);
+  const memoryEnabled = currentScope.kind !== 'disabled';
+  const compactLabel = memoryEnabled ? 'Memory On' : 'Memory Off';
   const interactionDisabled = disabled || loading;
 
   const closeMenu = (restoreFocus = false) => {
@@ -183,7 +185,7 @@ export default function ChatMemoryControls({
   return (
     <div
       ref={rootRef}
-      className={`chat-memory-scope${compact ? ' is-compact' : ''}`}
+      className={`chat-memory-scope ${memoryEnabled ? 'is-enabled' : 'is-disabled'}${compact ? ' is-compact' : ''}`}
       aria-busy={loading || undefined}
     >
       <button
@@ -195,6 +197,7 @@ export default function ChatMemoryControls({
         aria-expanded={open}
         aria-controls={menuId}
         title={compact ? label : undefined}
+        data-memory-state={memoryEnabled ? 'enabled' : 'disabled'}
         disabled={interactionDisabled}
         onClick={() => {
           openFocusRef.current = 'selected';
@@ -208,8 +211,10 @@ export default function ChatMemoryControls({
           }
         }}
       >
-        <StagePanelIcon name="memory" />
-        {!compact && <span className="chat-memory-trigger-label">{label}</span>}
+        <StagePanelIcon name={memoryEnabled ? 'memory' : 'memory-off'} />
+        <span className="chat-memory-trigger-label">
+          {compact ? compactLabel : label}
+        </span>
         <StagePanelIcon name="chevron" />
       </button>
 
@@ -228,32 +233,36 @@ export default function ChatMemoryControls({
             {STANDARD_OPTIONS.map(renderScopeOption)}
           </div>
 
-          <div
-            className="chat-memory-menu-section"
-            role="group"
-            aria-labelledby={folderHeadingId}
-          >
-            <span id={folderHeadingId} className="chat-memory-menu-heading">
-              Folder memory
-            </span>
-            {folders.map(folder => renderScopeOption({
-              scope: { kind: 'folder', folderId: folder.folder_id },
-              label: folder.name,
-              description: `Share memory with chats in ${folder.name}.`,
-            }))}
-          </div>
+          {folders.length > 0 && (
+            <div
+              className="chat-memory-menu-section"
+              role="group"
+              aria-labelledby={folderHeadingId}
+            >
+              <span id={folderHeadingId} className="chat-memory-menu-heading">
+                Folder memory
+              </span>
+              {folders.map(folder => renderScopeOption({
+                scope: { kind: 'folder', folderId: folder.folder_id },
+                label: folder.name,
+                description: `Share memory with chats in ${folder.name}.`,
+              }))}
+            </div>
+          )}
 
-          <button
-            type="button"
-            className="chat-memory-manage"
-            role="menuitem"
-            onClick={() => {
-              closeMenu(true);
-              onManageFolders();
-            }}
-          >
-            Manage folders…
-          </button>
+          {onManageFolders && (
+            <button
+              type="button"
+              className="chat-memory-manage"
+              role="menuitem"
+              onClick={() => {
+                closeMenu(true);
+                onManageFolders();
+              }}
+            >
+              Manage folders…
+            </button>
+          )}
         </div>
       )}
 

--- a/client/geist/src/Components/EnhancedChatInput.tsx
+++ b/client/geist/src/Components/EnhancedChatInput.tsx
@@ -183,23 +183,25 @@ const EnhancedChatInput: React.FC<EnhancedChatInputProps> = ({
           className="chat-textarea"
         />
 
-        {enableVoice && (
-          <VoiceButton
-            isRecording={isRecording}
-            isProcessing={isProcessing}
-            onClick={toggleRecording}
-            disabled={disabled}
-          />
-        )}
+        <div className="input-actions">
+          {enableVoice && (
+            <VoiceButton
+              isRecording={isRecording}
+              isProcessing={isProcessing}
+              onClick={toggleRecording}
+              disabled={disabled}
+            />
+          )}
 
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={disabled || !value.trim()}
-          className="send-button"
-        >
-          Send
-        </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={disabled || !value.trim()}
+            className="send-button"
+          >
+            Send
+          </button>
+        </div>
       </div>
 
       {showFileSuggestions && (

--- a/client/geist/src/Components/StagePanelIcon.tsx
+++ b/client/geist/src/Components/StagePanelIcon.tsx
@@ -1,4 +1,4 @@
-export type StagePanelIconName = 'plus' | 'maximize' | 'search' | 'folder' | 'more' | 'close' | 'workflow' | 'edit' | 'check' | 'save' | 'play';
+export type StagePanelIconName = 'plus' | 'maximize' | 'search' | 'folder' | 'memory' | 'chevron' | 'more' | 'close' | 'workflow' | 'edit' | 'check' | 'save' | 'play';
 
 export default function StagePanelIcon({ name }: { name: StagePanelIconName }): JSX.Element {
   if (name === 'plus') {
@@ -28,6 +28,22 @@ export default function StagePanelIcon({ name }: { name: StagePanelIconName }): 
     return (
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <path d="M3 6.75C3 5.78 3.78 5 4.75 5h5.1c.46 0 .9.18 1.24.51L12.58 7h6.67c.97 0 1.75.78 1.75 1.75v8.5c0 .97-.78 1.75-1.75 1.75H4.75C3.78 19 3 18.22 3 17.25V6.75Z" />
+      </svg>
+    );
+  }
+
+  if (name === 'memory') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M9.5 3a4.5 4.5 0 0 0-4.28 5.9A4 4 0 0 0 6 16.82V17a4 4 0 0 0 6 3.46A4 4 0 0 0 18 17v-.18a4 4 0 0 0 .78-7.92A4.5 4.5 0 0 0 12 3.77 4.48 4.48 0 0 0 9.5 3Zm0 2c.57 0 1.1.2 1.5.54V9h2V5.54A2.5 2.5 0 0 1 17 7.5c0 .7-.28 1.34-.74 1.8l-1.17 1.18 1.65.24A2 2 0 0 1 16 14.67V13h-2v4a2 2 0 0 1-1 1.73V15h-2v3.73A2 2 0 0 1 8 17v-1.17a3.98 3.98 0 0 0 2-3.46h-2A2 2 0 0 1 6.26 10.4l1.65-.24-1.17-1.18A2.5 2.5 0 0 1 9.5 5Z" />
+      </svg>
+    );
+  }
+
+  if (name === 'chevron') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="m7.4 8.6 4.6 4.58 4.6-4.58L18 10l-6 6-6-6 1.4-1.4Z" />
       </svg>
     );
   }

--- a/client/geist/src/Components/StagePanelIcon.tsx
+++ b/client/geist/src/Components/StagePanelIcon.tsx
@@ -1,4 +1,4 @@
-export type StagePanelIconName = 'plus' | 'maximize' | 'search' | 'folder' | 'memory' | 'chevron' | 'more' | 'close' | 'workflow' | 'edit' | 'check' | 'save' | 'play';
+export type StagePanelIconName = 'plus' | 'maximize' | 'search' | 'folder' | 'memory' | 'memory-off' | 'chevron' | 'more' | 'close' | 'workflow' | 'edit' | 'check' | 'save' | 'play';
 
 export default function StagePanelIcon({ name }: { name: StagePanelIconName }): JSX.Element {
   if (name === 'plus') {
@@ -34,8 +34,41 @@ export default function StagePanelIcon({ name }: { name: StagePanelIconName }): 
 
   if (name === 'memory') {
     return (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M9.5 3a4.5 4.5 0 0 0-4.28 5.9A4 4 0 0 0 6 16.82V17a4 4 0 0 0 6 3.46A4 4 0 0 0 18 17v-.18a4 4 0 0 0 .78-7.92A4.5 4.5 0 0 0 12 3.77 4.48 4.48 0 0 0 9.5 3Zm0 2c.57 0 1.1.2 1.5.54V9h2V5.54A2.5 2.5 0 0 1 17 7.5c0 .7-.28 1.34-.74 1.8l-1.17 1.18 1.65.24A2 2 0 0 1 16 14.67V13h-2v4a2 2 0 0 1-1 1.73V15h-2v3.73A2 2 0 0 1 8 17v-1.17a3.98 3.98 0 0 0 2-3.46h-2A2 2 0 0 1 6.26 10.4l1.65-.24-1.17-1.18A2.5 2.5 0 0 1 9.5 5Z" />
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        data-icon="memory"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ fill: 'none' }}
+      >
+        <ellipse cx="12" cy="5.5" rx="7.5" ry="2.5" />
+        <path d="M4.5 5.5v6c0 1.38 3.36 2.5 7.5 2.5s7.5-1.12 7.5-2.5v-6" />
+        <path d="M4.5 11.5v6c0 1.38 3.36 2.5 7.5 2.5s7.5-1.12 7.5-2.5v-6" />
+      </svg>
+    );
+  }
+
+  if (name === 'memory-off') {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        data-icon="memory-off"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ fill: 'none' }}
+      >
+        <ellipse cx="12" cy="5.5" rx="7.5" ry="2.5" />
+        <path d="M4.5 5.5v6c0 1.38 3.36 2.5 7.5 2.5s7.5-1.12 7.5-2.5v-6" />
+        <path d="M4.5 11.5v6c0 1.38 3.36 2.5 7.5 2.5s7.5-1.12 7.5-2.5v-6" />
+        <path d="m4 4 16 16" strokeWidth="2.4" />
       </svg>
     );
   }

--- a/client/geist/src/Components/__tests__/ChatMemoryControls.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatMemoryControls.test.tsx
@@ -127,12 +127,41 @@ describe('ChatMemoryControls', () => {
     expect(screen.queryByRole('menu', { name: 'Memory options' })).not.toBeInTheDocument();
   });
 
-  it('uses an icon-only but labelled trigger in compact mode', () => {
+  it('does not render an empty folder memory section', () => {
+    render(<ChatMemoryControls {...baseProps} folders={[]} />);
+
+    const menu = openMenu();
+    expect(within(menu).queryByRole('group', { name: 'Folder memory' })).not.toBeInTheDocument();
+    expect(within(menu).queryByText('Folder memory')).not.toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: 'Manage folders…' })).toBeInTheDocument();
+  });
+
+  it('shows an explicit enabled label in compact mode', () => {
     render(<ChatMemoryControls {...baseProps} compact />);
 
     const trigger = screen.getByRole('button', { name: 'Memory settings: Memory Enabled' });
     expect(trigger).toHaveAttribute('title', 'Memory Enabled');
-    expect(screen.queryByText('Memory Enabled')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('data-memory-state', 'enabled');
+    expect(screen.getByText('Memory On')).toBeVisible();
+  });
+
+  it('shows an explicit disabled label and state in compact mode', () => {
+    render(
+      <ChatMemoryControls
+        {...baseProps}
+        compact
+        settings={{
+          ...baseProps.settings,
+          memory_enabled: false,
+          effective_scope: 'disabled',
+          status: 'disabled',
+        }}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Memory settings: Memory Disabled' });
+    expect(trigger).toHaveAttribute('data-memory-state', 'disabled');
+    expect(screen.getByText('Memory Off')).toBeVisible();
   });
 
   it('closes on Escape, restores trigger focus, and closes on outside click', () => {

--- a/client/geist/src/Components/__tests__/ChatMemoryControls.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatMemoryControls.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import ChatMemoryControls from '../ChatMemoryControls';
 
 
 describe('ChatMemoryControls', () => {
+  const onScopeChange = jest.fn();
+  const onManageFolders = jest.fn();
   const baseProps = {
     settings: {
       memory_enabled: true,
@@ -18,57 +20,169 @@ describe('ChatMemoryControls', () => {
         color: 'violet',
         chat_count: 1,
       },
+      {
+        folder_id: 9,
+        name: 'Product ideas',
+        color: 'blue',
+        chat_count: 2,
+      },
     ],
     loading: false,
     error: null,
-    onMemoryEnabledChange: jest.fn(),
-    onPrivateChange: jest.fn(),
-    onFolderChange: jest.fn(),
+    onScopeChange,
+    onManageFolders,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('exposes chat-level memory and privacy switches', () => {
+  function openMenu() {
+    fireEvent.click(screen.getByRole('button', { name: 'Memory settings: Memory Enabled' }));
+    return screen.getByRole('menu', { name: 'Memory options' });
+  }
+
+  it('offers the three memory choices, folder scopes, and folder management', () => {
     render(<ChatMemoryControls {...baseProps} />);
 
-    const memorySwitch = screen.getByRole('switch', { name: 'Memory enabled' });
-    const privateSwitch = screen.getByRole('switch', { name: 'Private' });
-    expect(memorySwitch).toHaveAttribute('aria-checked', 'true');
-    expect(privateSwitch).toHaveAttribute('aria-checked', 'false');
-    expect(screen.getByText('Eligible for your global profile')).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: 'Memory settings: Memory Enabled' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
-    fireEvent.click(memorySwitch);
-    fireEvent.click(privateSwitch);
-
-    expect(baseProps.onMemoryEnabledChange).toHaveBeenCalledWith(false);
-    expect(baseProps.onPrivateChange).toHaveBeenCalledWith(true);
+    const menu = openMenu();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(within(menu).getByRole('menuitemradio', { name: 'Memory Disabled' })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitemradio', { name: 'Memory Enabled' })).toHaveAttribute('aria-checked', 'true');
+    expect(within(menu).getByRole('menuitemradio', { name: 'Memory Enabled (this chat only)' })).toBeInTheDocument();
+    expect(within(menu).getByRole('group', { name: 'Folder memory' })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitemradio', { name: 'Private research' })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitemradio', { name: 'Product ideas' })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: 'Manage folders…' })).toBeInTheDocument();
+    expect(screen.queryByText(/ready/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Eligible for your global profile/i)).not.toBeInTheDocument();
   });
 
-  it('assigns a private folder from the compact control', () => {
+  it.each([
+    ['Memory Disabled', { kind: 'disabled' }],
+    ['Memory Enabled (this chat only)', { kind: 'private' }],
+  ])('changes scope through %s', (choice, expectedScope) => {
     render(<ChatMemoryControls {...baseProps} />);
+    const menu = openMenu();
 
-    fireEvent.change(screen.getByRole('combobox', { name: 'Memory folder' }), {
-      target: { value: '5' },
-    });
+    fireEvent.click(within(menu).getByRole('menuitemradio', { name: new RegExp(`^${choice.replace(/[()]/g, '\\$&')}`) }));
 
-    expect(baseProps.onFolderChange).toHaveBeenCalledWith(5);
+    expect(onScopeChange).toHaveBeenCalledWith(expectedScope);
+    expect(screen.queryByRole('menu', { name: 'Memory options' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Memory settings: Memory Enabled' })).toHaveFocus();
   });
 
-  it('clearly communicates when memory is disabled', () => {
+  it('can return a private chat to shared memory', () => {
     render(
       <ChatMemoryControls
         {...baseProps}
         settings={{
           ...baseProps.settings,
-          memory_enabled: false,
-          effective_scope: 'disabled',
+          memory_mode: 'private',
+          effective_scope: 'private',
         }}
       />,
     );
 
-    expect(screen.getByText('Memory is off for this chat')).toBeInTheDocument();
-    expect(screen.getByRole('switch', { name: 'Private' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', {
+      name: 'Memory settings: Memory Enabled (this chat only)',
+    }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Memory Enabled' }));
+
+    expect(onScopeChange).toHaveBeenCalledWith({ kind: 'public' });
+  });
+
+  it('selects a folder scope and labels the trigger with the active folder', () => {
+    const { rerender } = render(<ChatMemoryControls {...baseProps} />);
+    const menu = openMenu();
+    fireEvent.click(within(menu).getByRole('menuitemradio', { name: 'Private research' }));
+    expect(onScopeChange).toHaveBeenCalledWith({ kind: 'folder', folderId: 5 });
+
+    rerender(
+      <ChatMemoryControls
+        {...baseProps}
+        settings={{
+          ...baseProps.settings,
+          memory_mode: 'private',
+          folder_id: 5,
+          effective_scope: 'folder',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Memory settings: Memory: Private research' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Memory settings: Memory: Private research' }));
+    expect(screen.getByRole('menuitemradio', { name: 'Private research' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('opens folder management and closes the dropdown', () => {
+    render(<ChatMemoryControls {...baseProps} />);
+    fireEvent.click(within(openMenu()).getByRole('menuitem', { name: 'Manage folders…' }));
+
+    expect(onManageFolders).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu', { name: 'Memory options' })).not.toBeInTheDocument();
+  });
+
+  it('uses an icon-only but labelled trigger in compact mode', () => {
+    render(<ChatMemoryControls {...baseProps} compact />);
+
+    const trigger = screen.getByRole('button', { name: 'Memory settings: Memory Enabled' });
+    expect(trigger).toHaveAttribute('title', 'Memory Enabled');
+    expect(screen.queryByText('Memory Enabled')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape, restores trigger focus, and closes on outside click', () => {
+    render(
+      <div>
+        <ChatMemoryControls {...baseProps} />
+        <button type="button">Outside</button>
+      </div>,
+    );
+
+    openMenu();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu', { name: 'Memory options' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Memory settings: Memory Enabled' })).toHaveFocus();
+
+    openMenu();
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }));
+    expect(screen.queryByRole('menu', { name: 'Memory options' })).not.toBeInTheDocument();
+  });
+
+  it('opens and navigates the menu from the keyboard', () => {
+    render(<ChatMemoryControls {...baseProps} />);
+    const trigger = screen.getByRole('button', { name: 'Memory settings: Memory Enabled' });
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    expect(screen.getByRole('menuitemradio', { name: 'Memory Disabled' })).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole('menuitemradio', { name: 'Memory Disabled' }), {
+      key: 'ArrowDown',
+    });
+    expect(screen.getByRole('menuitemradio', { name: 'Memory Enabled' })).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole('menuitemradio', { name: 'Memory Enabled' }), {
+      key: 'End',
+    });
+    expect(screen.getByRole('menuitem', { name: 'Manage folders…' })).toHaveFocus();
+  });
+
+  it('disables interaction while loading or explicitly disabled', () => {
+    const { rerender } = render(<ChatMemoryControls {...baseProps} loading />);
+    expect(screen.getByRole('button', { name: 'Memory settings: Memory Enabled' })).toBeDisabled();
+
+    rerender(<ChatMemoryControls {...baseProps} disabled />);
+    expect(screen.getByRole('button', { name: 'Memory settings: Memory Enabled' })).toBeDisabled();
+  });
+
+  it('reports update errors without restoring the old status badge', () => {
+    render(<ChatMemoryControls {...baseProps} error="Could not update memory settings" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not update memory settings');
+    expect(screen.queryByText(/ready/i)).not.toBeInTheDocument();
   });
 });

--- a/client/geist/src/Hooks/__tests__/useChatMemory.test.tsx
+++ b/client/geist/src/Hooks/__tests__/useChatMemory.test.tsx
@@ -1,0 +1,374 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useChatMemory, {
+  ChatMemorySettings,
+  getMemoryScope,
+} from '../useChatMemory';
+
+type MemoryPatch = {
+  chatId: number;
+  body: Record<string, unknown>;
+};
+
+const DEFAULT_CHAT_SETTINGS: ChatMemorySettings = {
+  chat_session_id: 42,
+  memory_enabled: true,
+  memory_mode: 'public',
+  folder_id: null,
+  effective_scope: 'public',
+  status: 'ready',
+};
+
+function response(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(next => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function applyServerChanges(
+  current: ChatMemorySettings,
+  changes: Record<string, unknown>,
+): ChatMemorySettings {
+  const next = { ...current };
+  if (typeof changes.memory_enabled === 'boolean') {
+    next.memory_enabled = changes.memory_enabled;
+  }
+  if (changes.memory_mode === 'public' || changes.memory_mode === 'private') {
+    next.memory_mode = changes.memory_mode;
+  }
+  if (changes.clear_folder) {
+    next.folder_id = null;
+  } else if (typeof changes.folder_id === 'number') {
+    next.folder_id = changes.folder_id;
+  }
+  if (next.folder_id !== null) {
+    next.memory_mode = 'private';
+  }
+  next.effective_scope = !next.memory_enabled
+    ? 'disabled'
+    : (next.folder_id !== null ? 'folder' : next.memory_mode);
+  next.status = next.memory_enabled ? 'ready' : 'disabled';
+  return next;
+}
+
+function installMemoryApi(initialSettings: ChatMemorySettings[]) {
+  const settingsById = new Map(
+    initialSettings.map(settings => [settings.chat_session_id!, { ...settings }]),
+  );
+  const patches: MemoryPatch[] = [];
+  let patchFailure: string | null = null;
+  const folders = [
+    {
+      folder_id: 7,
+      name: 'Research',
+      color: 'violet',
+      chat_count: 1,
+    },
+    {
+      folder_id: 9,
+      name: 'Planning',
+      color: 'mint',
+      chat_count: 0,
+    },
+  ];
+
+  const fetchMock = jest.fn(async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === '/api/v1/memory/folders' && method === 'GET') {
+      return response(folders);
+    }
+
+    const chatMatch = url.match(/^\/api\/v1\/memory\/chats\/(\d+)$/);
+    if (chatMatch) {
+      const chatId = Number(chatMatch[1]);
+      if (method === 'GET') {
+        return response(settingsById.get(chatId));
+      }
+      if (method === 'PATCH') {
+        const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+        patches.push({ chatId, body });
+        if (patchFailure) {
+          const detail = patchFailure;
+          patchFailure = null;
+          return response({ detail }, false);
+        }
+        const current = settingsById.get(chatId) ?? {
+          ...DEFAULT_CHAT_SETTINGS,
+          chat_session_id: chatId,
+        };
+        const updated = applyServerChanges(current, body);
+        settingsById.set(chatId, updated);
+        return response(updated);
+      }
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+
+  return {
+    fetchMock,
+    patches,
+    failNextPatch(detail: string) {
+      patchFailure = detail;
+    },
+  };
+}
+
+describe('getMemoryScope', () => {
+  it('uses the effective disabled, folder, private, and public scopes', () => {
+    expect(getMemoryScope({
+      ...DEFAULT_CHAT_SETTINGS,
+      memory_enabled: false,
+      folder_id: 7,
+    })).toEqual({ kind: 'disabled' });
+    expect(getMemoryScope({
+      ...DEFAULT_CHAT_SETTINGS,
+      folder_id: 7,
+      memory_mode: 'private',
+    })).toEqual({ kind: 'folder', folderId: 7 });
+    expect(getMemoryScope({
+      ...DEFAULT_CHAT_SETTINGS,
+      memory_mode: 'private',
+    })).toEqual({ kind: 'private' });
+    expect(getMemoryScope(DEFAULT_CHAT_SETTINGS)).toEqual({ kind: 'public' });
+  });
+});
+
+describe('useChatMemory', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('updates a blank-chat draft without sending a PATCH', async () => {
+    const api = installMemoryApi([]);
+    const { result } = renderHook(() => useChatMemory(null));
+    await waitFor(() => expect(result.current.folders).toHaveLength(2));
+
+    act(() => result.current.prepareNewChat({ kind: 'folder', folderId: 7 }));
+    expect(getMemoryScope(result.current.settings)).toEqual({
+      kind: 'folder',
+      folderId: 7,
+    });
+
+    await act(async () => {
+      expect(await result.current.setScope({ kind: 'disabled' })).toBe(true);
+    });
+    expect(result.current.settings.folder_id).toBe(7);
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'disabled' });
+
+    await act(async () => {
+      expect(await result.current.setScope({ kind: 'public' })).toBe(true);
+    });
+    expect(result.current.settings.folder_id).toBeNull();
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'public' });
+    expect(api.patches).toEqual([]);
+  });
+
+  it('prepares a new-chat scope without changing or patching the active chat', async () => {
+    const api = installMemoryApi([DEFAULT_CHAT_SETTINGS]);
+    const { result, rerender } = renderHook(
+      ({ activeChatId }: { activeChatId: number | null }) => useChatMemory(activeChatId),
+      { initialProps: { activeChatId: 42 as number | null } },
+    );
+    await waitFor(() => expect(result.current.settings.chat_session_id).toBe(42));
+
+    act(() => result.current.prepareNewChat({ kind: 'folder', folderId: 9 }));
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'public' });
+    expect(api.patches).toEqual([]);
+
+    rerender({ activeChatId: null });
+    await waitFor(() => expect(getMemoryScope(result.current.settings)).toEqual({
+      kind: 'folder',
+      folderId: 9,
+    }));
+    expect(api.patches).toEqual([]);
+  });
+
+  it('maps every active-chat scope to the expected PATCH payload', async () => {
+    const api = installMemoryApi([{
+      ...DEFAULT_CHAT_SETTINGS,
+      folder_id: 7,
+      memory_mode: 'private',
+      effective_scope: 'folder',
+    }]);
+    const { result } = renderHook(() => useChatMemory(42));
+    await waitFor(() => expect(result.current.settings.chat_session_id).toBe(42));
+
+    await act(async () => {
+      expect(await result.current.setScope({ kind: 'disabled' })).toBe(true);
+    });
+    expect(result.current.settings.folder_id).toBe(7);
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'disabled' });
+
+    await act(async () => {
+      expect(await result.current.setScope({ kind: 'public' })).toBe(true);
+      expect(await result.current.setScope({ kind: 'private' })).toBe(true);
+      expect(await result.current.setScope({ kind: 'folder', folderId: 9 })).toBe(true);
+    });
+
+    expect(api.patches).toEqual([
+      {
+        chatId: 42,
+        body: { memory_enabled: false },
+      },
+      {
+        chatId: 42,
+        body: {
+          memory_enabled: true,
+          memory_mode: 'public',
+          clear_folder: true,
+        },
+      },
+      {
+        chatId: 42,
+        body: {
+          memory_enabled: true,
+          memory_mode: 'private',
+          clear_folder: true,
+        },
+      },
+      {
+        chatId: 42,
+        body: {
+          memory_enabled: true,
+          memory_mode: 'private',
+          folder_id: 9,
+        },
+      },
+    ]);
+    expect(getMemoryScope(result.current.settings)).toEqual({
+      kind: 'folder',
+      folderId: 9,
+    });
+  });
+
+  it('does not overwrite active settings when updating a different chat folder', async () => {
+    const api = installMemoryApi([
+      {
+        ...DEFAULT_CHAT_SETTINGS,
+        folder_id: 7,
+        memory_mode: 'private',
+        effective_scope: 'folder',
+      },
+      {
+        ...DEFAULT_CHAT_SETTINGS,
+        chat_session_id: 99,
+      },
+    ]);
+    const { result } = renderHook(() => useChatMemory(42));
+    await waitFor(() => expect(result.current.settings.chat_session_id).toBe(42));
+
+    await act(async () => {
+      expect(await result.current.setChatFolder(99, 9)).toBe(true);
+    });
+    expect(result.current.settings.chat_session_id).toBe(42);
+    expect(result.current.settings.folder_id).toBe(7);
+
+    await act(async () => {
+      expect(await result.current.setChatFolder(42, null)).toBe(true);
+    });
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'private' });
+    expect(api.patches).toEqual([
+      {
+        chatId: 99,
+        body: {
+          memory_mode: 'private',
+          folder_id: 9,
+        },
+      },
+      {
+        chatId: 42,
+        body: {
+          memory_mode: 'private',
+          clear_folder: true,
+        },
+      },
+    ]);
+  });
+
+  it('returns false and restores active settings when a PATCH fails', async () => {
+    const api = installMemoryApi([DEFAULT_CHAT_SETTINGS]);
+    const { result } = renderHook(() => useChatMemory(42));
+    await waitFor(() => expect(result.current.settings.chat_session_id).toBe(42));
+    api.failNextPatch('Folder not found');
+
+    await act(async () => {
+      expect(await result.current.setScope({ kind: 'folder', folderId: 999 })).toBe(false);
+    });
+
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'public' });
+    expect(result.current.error).toBe('Folder not found');
+  });
+
+  it('keeps the latest scope and remains loading until overlapping PATCH requests settle', async () => {
+    const firstPatch = deferred<Response>();
+    const secondPatch = deferred<Response>();
+    let patchCount = 0;
+    global.fetch = jest.fn((
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/api/v1/memory/folders' && method === 'GET') {
+        return Promise.resolve(response([]));
+      }
+      if (url === '/api/v1/memory/chats/42' && method === 'GET') {
+        return Promise.resolve(response(DEFAULT_CHAT_SETTINGS));
+      }
+      if (url === '/api/v1/memory/chats/42' && method === 'PATCH') {
+        patchCount += 1;
+        return patchCount === 1 ? firstPatch.promise : secondPatch.promise;
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useChatMemory(42));
+    await waitFor(() => expect(result.current.settings.chat_session_id).toBe(42));
+
+    let firstResult!: Promise<boolean>;
+    let secondResult!: Promise<boolean>;
+    act(() => {
+      firstResult = result.current.setScope({ kind: 'private' });
+    });
+    act(() => {
+      secondResult = result.current.setScope({ kind: 'public' });
+    });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      secondPatch.resolve(response({
+        ...DEFAULT_CHAT_SETTINGS,
+        memory_mode: 'public',
+        effective_scope: 'public',
+      }));
+      expect(await secondResult).toBe(true);
+    });
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'public' });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      firstPatch.resolve(response({
+        ...DEFAULT_CHAT_SETTINGS,
+        memory_mode: 'private',
+        effective_scope: 'private',
+      }));
+      expect(await firstResult).toBe(true);
+    });
+    expect(getMemoryScope(result.current.settings)).toEqual({ kind: 'public' });
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/client/geist/src/Hooks/__tests__/useUserSettings.test.tsx
+++ b/client/geist/src/Hooks/__tests__/useUserSettings.test.tsx
@@ -1,11 +1,25 @@
-import { renderHook, act } from '@testing-library/react';
-import { useUserSettings, UserSettings, UserSettingsUpdate } from '../useUserSettings';
+import React, { ReactNode } from 'react';
+import {
+  renderHook,
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import {
+  useUserSettings,
+  UserSettings,
+  UserSettingsProvider,
+  UserSettingsUpdate,
+} from '../useUserSettings';
 
 const mockSettings: UserSettings = {
   user_settings_id: 1,
   user_id: 1,
   default_agent_type: 'local',
   default_local_model: 'Meta-Llama-3.1-8B-Instruct',
+  default_local_artifact_id: 'meta-llama-3.1-8b-instruct',
   default_online_model: 'gpt-4',
   default_online_provider: 'openai',
   default_file_archives: [101, 102],
@@ -21,6 +35,10 @@ const mockSettings: UserSettings = {
   update_date: '2025-01-01T00:00:00Z'
 };
 
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <UserSettingsProvider>{children}</UserSettingsProvider>
+);
+
 describe('useUserSettings', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -34,12 +52,11 @@ describe('useUserSettings', () => {
       json: async () => mockSettings,
     });
 
-    const { result } = renderHook(() => useUserSettings());
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
 
     expect(result.current.loading).toBe(true);
 
-    // wait for effect
-    await act(async () => {});
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
@@ -54,8 +71,8 @@ describe('useUserSettings', () => {
       statusText: 'Server Error',
     });
 
-    const { result } = renderHook(() => useUserSettings());
-    await act(async () => {});
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.loading).toBe(false);
     expect(result.current.settings).toBeNull();
@@ -67,8 +84,8 @@ describe('useUserSettings', () => {
   it('updates settings (PUT success)', async () => {
     // initial fetch
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: async () => mockSettings });
-    const { result } = renderHook(() => useUserSettings());
-    await act(async () => {});
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     // update
     const updated: UserSettings = { ...mockSettings, default_temperature: 0.8 };
@@ -87,8 +104,8 @@ describe('useUserSettings', () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: async () => mockSettings });
-    const { result } = renderHook(() => useUserSettings());
-    await act(async () => {});
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, statusText: 'Bad Request' });
 
@@ -103,8 +120,8 @@ describe('useUserSettings', () => {
 
   it('resets settings (POST success)', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: async () => mockSettings });
-    const { result } = renderHook(() => useUserSettings());
-    await act(async () => {});
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     const resetResponse: UserSettings = { ...mockSettings, default_temperature: 0.5 };
     (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: true, json: async () => resetResponse });
@@ -122,13 +139,54 @@ describe('useUserSettings', () => {
       .mockResolvedValueOnce({ ok: true, json: async () => mockSettings })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ ...mockSettings, default_top_p: 0.95 }) });
 
-    const { result } = renderHook(() => useUserSettings());
-    await act(async () => {});
+    const { result } = renderHook(() => useUserSettings(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
       await result.current.refetch();
     });
 
     expect(result.current.settings?.default_top_p).toBe(0.95);
+  });
+
+  it('shares model updates with every settings consumer', async () => {
+    const updatedSettings: UserSettings = {
+      ...mockSettings,
+      default_local_model: 'Qwen/Qwen3-4B',
+      default_local_artifact_id: 'qwen3-4b-q4-k-m',
+    };
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => mockSettings })
+      .mockResolvedValueOnce({ ok: true, json: async () => updatedSettings });
+
+    const ModelSelector = () => {
+      const { updateSettings } = useUserSettings();
+      return (
+        <button
+          type="button"
+          onClick={() => void updateSettings({
+            default_local_model: updatedSettings.default_local_model,
+            default_local_artifact_id: updatedSettings.default_local_artifact_id,
+          })}
+        >
+          Select Qwen
+        </button>
+      );
+    };
+    const RuntimeBadge = () => {
+      const { settings } = useUserSettings();
+      return <span aria-label="Runtime model">{settings?.default_local_model}</span>;
+    };
+
+    render(
+      <UserSettingsProvider>
+        <ModelSelector />
+        <RuntimeBadge />
+      </UserSettingsProvider>,
+    );
+
+    expect(await screen.findByText(mockSettings.default_local_model)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Select Qwen' }));
+    expect(await screen.findByText(updatedSettings.default_local_model)).toBeInTheDocument();
   });
 });

--- a/client/geist/src/Hooks/useChatMemory.ts
+++ b/client/geist/src/Hooks/useChatMemory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface MemoryFolder {
   folder_id: number;
@@ -17,6 +17,10 @@ export interface ChatMemorySettings {
   status?: string;
 }
 
+export type MemoryScope =
+  | { kind: 'disabled' | 'public' | 'private' }
+  | { kind: 'folder'; folderId: number };
+
 const DEFAULT_SETTINGS: ChatMemorySettings = {
   memory_enabled: true,
   memory_mode: 'public',
@@ -25,11 +29,93 @@ const DEFAULT_SETTINGS: ChatMemorySettings = {
   status: 'ready',
 };
 
+type ChatMemoryChanges = {
+  memory_enabled?: boolean;
+  memory_mode?: 'public' | 'private';
+  folder_id?: number;
+  clear_folder?: boolean;
+};
+
+export function getMemoryScope(settings: ChatMemorySettings): MemoryScope {
+  if (!settings.memory_enabled) {
+    return { kind: 'disabled' };
+  }
+  if (settings.folder_id !== null) {
+    return { kind: 'folder', folderId: settings.folder_id };
+  }
+  return { kind: settings.memory_mode };
+}
+
+function changesForScope(scope: MemoryScope): ChatMemoryChanges {
+  if (scope.kind === 'disabled') {
+    return { memory_enabled: false };
+  }
+  if (scope.kind === 'folder') {
+    return {
+      memory_enabled: true,
+      memory_mode: 'private',
+      folder_id: scope.folderId,
+    };
+  }
+  return {
+    memory_enabled: true,
+    memory_mode: scope.kind,
+    clear_folder: true,
+  };
+}
+
+function applyChanges(
+  current: ChatMemorySettings,
+  changes: ChatMemoryChanges,
+): ChatMemorySettings {
+  const next: ChatMemorySettings = { ...current };
+  if (typeof changes.memory_enabled === 'boolean') {
+    next.memory_enabled = changes.memory_enabled;
+  }
+  if (changes.memory_mode) {
+    next.memory_mode = changes.memory_mode;
+  }
+  if (changes.clear_folder) {
+    next.folder_id = null;
+  } else if (typeof changes.folder_id === 'number') {
+    next.folder_id = changes.folder_id;
+  }
+  if (next.folder_id !== null) {
+    next.memory_mode = 'private';
+  }
+  next.effective_scope = !next.memory_enabled
+    ? 'disabled'
+    : (next.folder_id !== null ? 'folder' : next.memory_mode);
+  next.status = next.memory_enabled ? 'ready' : 'disabled';
+  return next;
+}
+
 export default function useChatMemory(chatId: number | null) {
   const [settings, setSettings] = useState<ChatMemorySettings>(DEFAULT_SETTINGS);
   const [folders, setFolders] = useState<MemoryFolder[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const activeChatIdRef = useRef(chatId);
+  const settingsRef = useRef(settings);
+  const draftSettingsRef = useRef(DEFAULT_SETTINGS);
+  const pendingRequestCountRef = useRef(0);
+  const settingsRequestVersionRef = useRef(0);
+  const errorRequestVersionRef = useRef(0);
+
+  activeChatIdRef.current = chatId;
+  settingsRef.current = settings;
+
+  const beginRequest = useCallback(() => {
+    pendingRequestCountRef.current += 1;
+    setLoading(true);
+  }, []);
+
+  const endRequest = useCallback(() => {
+    pendingRequestCountRef.current = Math.max(0, pendingRequestCountRef.current - 1);
+    if (pendingRequestCountRef.current === 0) {
+      setLoading(false);
+    }
+  }, []);
 
   const refreshFolders = useCallback(async () => {
     try {
@@ -45,39 +131,58 @@ export default function useChatMemory(chatId: number | null) {
     void refreshFolders();
   }, [refreshFolders]);
 
-  const fetchSettings = useCallback(async () => {
+  const fetchSettings = useCallback(async (signal?: AbortSignal) => {
     if (chatId === null) {
       return DEFAULT_SETTINGS;
     }
-    const response = await fetch(`/api/v1/memory/chats/${chatId}`);
+    const response = await fetch(`/api/v1/memory/chats/${chatId}`, { signal });
     if (!response.ok) throw new Error('Could not load chat memory settings');
     const data: ChatMemorySettings = await response.json();
     return data;
   }, [chatId]);
 
   useEffect(() => {
+    const settingsRequestVersion = ++settingsRequestVersionRef.current;
+    const errorRequestVersion = ++errorRequestVersionRef.current;
     if (chatId === null) {
-      setSettings(DEFAULT_SETTINGS);
+      setSettings(draftSettingsRef.current);
+      settingsRef.current = draftSettingsRef.current;
+      setError(null);
       return;
     }
     let cancelled = false;
-    setLoading(true);
-    fetchSettings()
+    const controller = new AbortController();
+    beginRequest();
+    fetchSettings(controller.signal)
       .then(data => {
-        if (!cancelled) setSettings(data);
+        if (
+          !cancelled
+          && settingsRequestVersionRef.current === settingsRequestVersion
+        ) {
+          settingsRef.current = data;
+          setSettings(data);
+          if (errorRequestVersionRef.current === errorRequestVersion) {
+            setError(null);
+          }
+        }
       })
       .catch(requestError => {
-        if (!cancelled) {
+        if (
+          !cancelled
+          && errorRequestVersionRef.current === errorRequestVersion
+          && !(requestError instanceof DOMException && requestError.name === 'AbortError')
+        ) {
           setError(requestError instanceof Error ? requestError.message : 'Could not load memory settings');
         }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        endRequest();
       });
     return () => {
       cancelled = true;
+      controller.abort();
     };
-  }, [chatId, fetchSettings]);
+  }, [beginRequest, chatId, endRequest, fetchSettings]);
 
   useEffect(() => {
     if (
@@ -90,9 +195,16 @@ export default function useChatMemory(chatId: number | null) {
     }
     let cancelled = false;
     const timer = window.setTimeout(() => {
+      const settingsRequestVersion = ++settingsRequestVersionRef.current;
       void fetchSettings()
         .then(data => {
-          if (!cancelled) setSettings(data);
+          if (
+            !cancelled
+            && settingsRequestVersionRef.current === settingsRequestVersion
+          ) {
+            settingsRef.current = data;
+            setSettings(data);
+          }
         })
         .catch(() => undefined);
     }, 1200);
@@ -102,24 +214,25 @@ export default function useChatMemory(chatId: number | null) {
     };
   }, [chatId, fetchSettings, settings.status]);
 
-  const updateSettings = useCallback(async (changes: Record<string, unknown>) => {
-    const next: ChatMemorySettings = {
-      ...settings,
-      ...changes,
-      folder_id: changes.clear_folder ? null : (
-        typeof changes.folder_id === 'number' ? changes.folder_id : settings.folder_id
-      ),
-    };
-    if (next.folder_id !== null) next.memory_mode = 'private';
-    next.effective_scope = !next.memory_enabled
-      ? 'disabled'
-      : (next.folder_id !== null ? 'folder' : next.memory_mode);
-    setSettings(next);
+  const updateChatSettings = useCallback(async (
+    targetChatId: number,
+    changes: ChatMemoryChanges,
+  ): Promise<boolean> => {
+    const updatesActiveChat = activeChatIdRef.current === targetChatId;
+    const previousSettings = settingsRef.current;
+    const settingsRequestVersion = updatesActiveChat
+      ? ++settingsRequestVersionRef.current
+      : null;
+    const errorRequestVersion = ++errorRequestVersionRef.current;
+    if (updatesActiveChat) {
+      const optimisticSettings = applyChanges(previousSettings, changes);
+      settingsRef.current = optimisticSettings;
+      setSettings(optimisticSettings);
+    }
     setError(null);
-    if (chatId === null) return;
-    setLoading(true);
+    beginRequest();
     try {
-      const response = await fetch(`/api/v1/memory/chats/${chatId}`, {
+      const response = await fetch(`/api/v1/memory/chats/${targetChatId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(changes),
@@ -128,15 +241,70 @@ export default function useChatMemory(chatId: number | null) {
         const body = await response.json().catch(() => ({}));
         throw new Error(body.detail || 'Could not update memory settings');
       }
-      setSettings(await response.json());
+      const updatedSettings: ChatMemorySettings = await response.json();
+      if (
+        activeChatIdRef.current === targetChatId
+        && settingsRequestVersionRef.current === settingsRequestVersion
+      ) {
+        settingsRef.current = updatedSettings;
+        setSettings(updatedSettings);
+      }
       await refreshFolders();
+      return true;
     } catch (requestError) {
-      setSettings(settings);
-      setError(requestError instanceof Error ? requestError.message : 'Could not update memory settings');
+      if (
+        updatesActiveChat
+        && activeChatIdRef.current === targetChatId
+        && settingsRequestVersionRef.current === settingsRequestVersion
+      ) {
+        settingsRef.current = previousSettings;
+        setSettings(previousSettings);
+      }
+      if (errorRequestVersionRef.current === errorRequestVersion) {
+        setError(requestError instanceof Error ? requestError.message : 'Could not update memory settings');
+      }
+      return false;
     } finally {
-      setLoading(false);
+      endRequest();
     }
-  }, [chatId, refreshFolders, settings]);
+  }, [beginRequest, endRequest, refreshFolders]);
+
+  const setScope = useCallback(async (scope: MemoryScope): Promise<boolean> => {
+    const changes = changesForScope(scope);
+    const targetChatId = activeChatIdRef.current;
+    if (targetChatId === null) {
+      const next = applyChanges(draftSettingsRef.current, changes);
+      draftSettingsRef.current = next;
+      settingsRef.current = next;
+      setSettings(next);
+      setError(null);
+      return true;
+    }
+    return updateChatSettings(targetChatId, changes);
+  }, [updateChatSettings]);
+
+  const prepareNewChat = useCallback((scope: MemoryScope): void => {
+    const next = applyChanges(DEFAULT_SETTINGS, changesForScope(scope));
+    draftSettingsRef.current = next;
+    if (activeChatIdRef.current === null) {
+      settingsRef.current = next;
+      setSettings(next);
+      setError(null);
+    }
+  }, []);
+
+  const setChatFolder = useCallback(async (
+    targetChatId: number,
+    folderId: number | null,
+  ): Promise<boolean> => updateChatSettings(
+    targetChatId,
+    folderId === null
+      ? { memory_mode: 'private', clear_folder: true }
+      : {
+          memory_mode: 'private',
+          folder_id: folderId,
+        },
+  ), [updateChatSettings]);
 
   const createFolder = useCallback(async (name: string) => {
     const response = await fetch('/api/v1/memory/folders', {
@@ -171,16 +339,23 @@ export default function useChatMemory(chatId: number | null) {
       method: 'DELETE',
     });
     if (!response.ok) throw new Error('Could not delete folder');
-    if (settings.folder_id === folderId) {
-      setSettings(current => ({
-        ...current,
-        folder_id: null,
-        memory_mode: 'private',
-        effective_scope: 'private',
-      }));
+    if (settingsRef.current.folder_id === folderId) {
+      setSettings(current => {
+        const next: ChatMemorySettings = {
+          ...current,
+          folder_id: null,
+          memory_mode: 'private',
+          effective_scope: current.memory_enabled ? 'private' : 'disabled',
+        };
+        settingsRef.current = next;
+        if (activeChatIdRef.current === null) {
+          draftSettingsRef.current = next;
+        }
+        return next;
+      });
     }
     await refreshFolders();
-  }, [refreshFolders, settings.folder_id]);
+  }, [refreshFolders]);
 
   return {
     settings,
@@ -191,13 +366,8 @@ export default function useChatMemory(chatId: number | null) {
     createFolder,
     renameFolder,
     deleteFolder,
-    setMemoryEnabled: (enabled: boolean) => updateSettings({ memory_enabled: enabled }),
-    setPrivate: (isPrivate: boolean) => updateSettings({
-      memory_mode: isPrivate ? 'private' : 'public',
-      ...(isPrivate ? {} : { clear_folder: true }),
-    }),
-    setFolder: (folderId: number | null) => updateSettings(
-      folderId === null ? { clear_folder: true } : { folder_id: folderId, memory_mode: 'private' },
-    ),
+    setScope,
+    prepareNewChat,
+    setChatFolder,
   };
 }

--- a/client/geist/src/Hooks/useOverflowObserver.ts
+++ b/client/geist/src/Hooks/useOverflowObserver.ts
@@ -1,0 +1,56 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+const OVERFLOW_TOLERANCE_PX = 1;
+
+const useOverflowObserver = <T extends HTMLElement>(enabled = true) => {
+  const ref = useRef<T>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  const updateOverflowState = useCallback(() => {
+    const element = ref.current;
+    const nextHasOverflow = Boolean(
+      enabled
+      && element
+      && element.scrollHeight > element.clientHeight + OVERFLOW_TOLERANCE_PX
+    );
+
+    setHasOverflow(current => current === nextHasOverflow ? current : nextHasOverflow);
+  }, [enabled]);
+
+  useLayoutEffect(() => {
+    updateOverflowState();
+  });
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    updateOverflowState();
+    window.addEventListener('resize', updateOverflowState);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => window.removeEventListener('resize', updateOverflowState);
+    }
+
+    const resizeObserver = new ResizeObserver(updateOverflowState);
+    resizeObserver.observe(element);
+
+    const content = element.firstElementChild;
+    if (content) {
+      resizeObserver.observe(content);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateOverflowState);
+    };
+  }, [updateOverflowState]);
+
+  return {
+    ref,
+    hasOverflow,
+    updateOverflowState,
+  };
+};
+
+export default useOverflowObserver;

--- a/client/geist/src/Hooks/useUserSettings.tsx
+++ b/client/geist/src/Hooks/useUserSettings.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 export interface BackupProvider {
   name: string;
@@ -47,7 +54,7 @@ export interface UserSettingsUpdate {
   ui_preferences?: Record<string, any>;
 }
 
-interface UseUserSettingsReturn {
+export interface UseUserSettingsReturn {
   settings: UserSettings | null;
   loading: boolean;
   error: string | null;
@@ -56,7 +63,9 @@ interface UseUserSettingsReturn {
   refetch: () => Promise<void>;
 }
 
-export const useUserSettings = (): UseUserSettingsReturn => {
+const UserSettingsContext = createContext<UseUserSettingsReturn | null>(null);
+
+const useUserSettingsState = (): UseUserSettingsReturn => {
   const [settings, setSettings] = useState<UserSettings | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -151,6 +160,23 @@ export const useUserSettings = (): UseUserSettingsReturn => {
     resetSettings,
     refetch: fetchSettings,
   };
+};
+
+export function UserSettingsProvider({ children }: { children: ReactNode }): JSX.Element {
+  const value = useUserSettingsState();
+  return (
+    <UserSettingsContext.Provider value={value}>
+      {children}
+    </UserSettingsContext.Provider>
+  );
+}
+
+export const useUserSettings = (): UseUserSettingsReturn => {
+  const context = useContext(UserSettingsContext);
+  if (!context) {
+    throw new Error('useUserSettings must be used within UserSettingsProvider');
+  }
+  return context;
 };
 
 export default useUserSettings;

--- a/client/geist/src/Models.test.tsx
+++ b/client/geist/src/Models.test.tsx
@@ -78,6 +78,24 @@ beforeEach(() => {
   }) as jest.Mock;
 });
 
+it('separates local models from model providers', async () => {
+  render(<Models />);
+
+  const localModelsTab = screen.getByRole('tab', { name: 'Local Models' });
+  const modelProvidersTab = screen.getByRole('tab', { name: 'Model Providers' });
+
+  expect(localModelsTab).toHaveAttribute('aria-selected', 'true');
+  expect(await screen.findByRole('region', { name: 'Local model files' })).toBeInTheDocument();
+  expect(screen.queryByText('Active provider')).not.toBeInTheDocument();
+
+  fireEvent.click(modelProvidersTab);
+
+  expect(modelProvidersTab).toHaveAttribute('aria-selected', 'true');
+  expect(screen.queryByRole('region', { name: 'Local model files' })).not.toBeInTheDocument();
+  expect(screen.getByText('Active provider')).toBeInTheDocument();
+  expect(screen.getByRole('region', { name: 'Model providers' })).toBeInTheDocument();
+});
+
 it('shows, selects, and keeps GGUF controls out of the Apple silicon MLX view', async () => {
   availableArtifacts = [
     { ...artifact, supported: false },
@@ -101,6 +119,8 @@ it('shows, selects, and keeps GGUF controls out of the Apple silicon MLX view', 
 it('starts the built-in GGUF download from the Models page', async () => {
   render(<Models />);
 
+  const localModelPanel = await screen.findByRole('region', { name: 'Local model files' });
+  expect(localModelPanel).toHaveClass('local-model-panel');
   const download = await screen.findByRole('button', { name: 'Download' });
   fireEvent.click(download);
   expect(download).toBeDisabled();

--- a/client/geist/src/Models.tsx
+++ b/client/geist/src/Models.tsx
@@ -37,6 +37,8 @@ interface LocalArtifact {
   progress_total?: number | null;
 }
 
+type ModelsTab = 'local' | 'providers';
+
 function formatBytes(value?: number | null): string {
   if (!value) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB'];
@@ -50,6 +52,7 @@ export default function Models(): JSX.Element {
   const [localArtifacts, setLocalArtifacts] = useState<LocalArtifact[]>([]);
   const [localError, setLocalError] = useState<string | null>(null);
   const [localAction, setLocalAction] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<ModelsTab>('local');
 
   const refreshLocalArtifacts = useCallback(async () => {
     try {
@@ -139,37 +142,63 @@ export default function Models(): JSX.Element {
   const ggufSupported = visibleLocalArtifacts.some(artifact => artifact.format === 'gguf');
   const mlxSupported = visibleLocalArtifacts.some(artifact => artifact.backend === 'mlx_llama');
 
-  if (loading && !models) {
-    return (
-      <section className="page-surface page-surface-centered">
-        <h2>Loading models</h2>
-        <p>Gathering local and online provider options.</p>
-      </section>
-    );
-  }
-
   return (
     <section className="models-page">
       <div className="page-header">
         <div>
           <p className="section-eyebrow">Providers</p>
-          <h2>Model inventory</h2>
+          <h2>Models</h2>
           <p>
-            Review available models and the current default runtime without leaving the workbench.
+            Manage models installed on this computer or browse available providers.
           </p>
         </div>
-        <button className="button button-secondary" onClick={() => void refetch()}>
+        <button
+          className="button button-secondary"
+          onClick={() => {
+            void refreshLocalArtifacts();
+            void refetch();
+          }}
+        >
           Refresh
         </button>
       </div>
 
-      {error && (
-        <div className="notice notice-warning">
-          Live model discovery failed, so Geist is showing fallback model data. {error}
-        </div>
-      )}
+      <div className="settings-tabs models-tabs" role="tablist" aria-label="Model sections">
+        <button
+          id="local-models-tab"
+          type="button"
+          className={`settings-tab ${activeTab === 'local' ? 'active' : ''}`}
+          role="tab"
+          aria-selected={activeTab === 'local'}
+          aria-controls="local-models-panel"
+          onClick={() => setActiveTab('local')}
+        >
+          Local Models
+        </button>
+        <button
+          id="model-providers-tab"
+          type="button"
+          className={`settings-tab ${activeTab === 'providers' ? 'active' : ''}`}
+          role="tab"
+          aria-selected={activeTab === 'providers'}
+          aria-controls="model-providers-panel"
+          onClick={() => setActiveTab('providers')}
+        >
+          Model Providers
+        </button>
+      </div>
 
-      <section className="provider-panel" aria-labelledby="local-model-files-heading">
+      {activeTab === 'local' && (
+        <div
+          id="local-models-panel"
+          className="models-tab-panel model-inventory-scroll"
+          role="tabpanel"
+          aria-labelledby="local-models-tab"
+        >
+          <section
+            className="provider-panel local-model-panel"
+            aria-labelledby="local-model-files-heading"
+          >
         <div className="provider-panel-header">
           <div>
             <h3 id="local-model-files-heading">Local model files</h3>
@@ -279,64 +308,90 @@ export default function Models(): JSX.Element {
             );
           })}
         </div>
-      </section>
-
-      <div className="model-summary-grid">
-        <article className="metric-card">
-          <span className="metric-label">Active provider</span>
-          <strong>{activeProvider || 'Not selected'}</strong>
-        </article>
-        <article className="metric-card">
-          <span className="metric-label">Active model</span>
-          <strong>{activeModel || 'Not selected'}</strong>
-        </article>
-        <article className="metric-card">
-          <span className="metric-label">Providers</span>
-          <strong>{providers.length}</strong>
-        </article>
-      </div>
-
-      <div className="model-inventory-scroll" role="region" aria-label="Model inventory">
-        <div className="provider-stack">
-          {providers.map((provider) => {
-            const providerModels = models?.providers[provider] ?? [];
-            return (
-              <section className="provider-panel" key={provider}>
-                <div className="provider-panel-header">
-                  <div>
-                    <h3>{provider}</h3>
-                    <p>{providerModels.length} models</p>
-                  </div>
-                </div>
-
-                <div className="model-table">
-                  <div className="model-table-row model-table-heading">
-                    <span>Model</span>
-                    <span>Context</span>
-                    <span>Output</span>
-                    <span>Capabilities</span>
-                  </div>
-                  {providerModels.map((model) => (
-                    <div className="model-table-row" key={`${provider}-${model.id}`}>
-                      <span>
-                        <strong>{model.name}</strong>
-                        <small>{model.id}</small>
-                      </span>
-                      <span>{formatNumber(model.context_window)}</span>
-                      <span>{formatNumber(model.max_output_tokens)}</span>
-                      <span className="capability-list">
-                        {capabilityLabels(model).map((label) => (
-                          <span className="capability-pill" key={label}>{label}</span>
-                        ))}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            );
-          })}
+          </section>
         </div>
-      </div>
+      )}
+
+      {activeTab === 'providers' && (
+        <div
+          id="model-providers-panel"
+          className="models-tab-panel"
+          role="tabpanel"
+          aria-labelledby="model-providers-tab"
+        >
+          {error && (
+            <div className="notice notice-warning">
+              Live model discovery failed, so Geist is showing fallback model data. {error}
+            </div>
+          )}
+
+          {loading && !models ? (
+            <section className="page-surface page-surface-centered models-providers-loading">
+              <h3>Loading model providers</h3>
+              <p>Gathering local and online provider options.</p>
+            </section>
+          ) : (
+            <>
+              <div className="model-summary-grid">
+                <article className="metric-card">
+                  <span className="metric-label">Active provider</span>
+                  <strong>{activeProvider || 'Not selected'}</strong>
+                </article>
+                <article className="metric-card">
+                  <span className="metric-label">Active model</span>
+                  <strong>{activeModel || 'Not selected'}</strong>
+                </article>
+                <article className="metric-card">
+                  <span className="metric-label">Providers</span>
+                  <strong>{providers.length}</strong>
+                </article>
+              </div>
+
+              <div className="model-inventory-scroll" role="region" aria-label="Model providers">
+                <div className="provider-stack">
+                  {providers.map((provider) => {
+                    const providerModels = models?.providers[provider] ?? [];
+                    return (
+                      <section className="provider-panel" key={provider}>
+                        <div className="provider-panel-header">
+                          <div>
+                            <h3>{provider}</h3>
+                            <p>{providerModels.length} models</p>
+                          </div>
+                        </div>
+
+                        <div className="model-table">
+                          <div className="model-table-row model-table-heading">
+                            <span>Model</span>
+                            <span>Context</span>
+                            <span>Output</span>
+                            <span>Capabilities</span>
+                          </div>
+                          {providerModels.map((model) => (
+                            <div className="model-table-row" key={`${provider}-${model.id}`}>
+                              <span>
+                                <strong>{model.name}</strong>
+                                <small>{model.id}</small>
+                              </span>
+                              <span>{formatNumber(model.context_window)}</span>
+                              <span>{formatNumber(model.max_output_tokens)}</span>
+                              <span className="capability-list">
+                                {capabilityLabels(model).map((label) => (
+                                  <span className="capability-pill" key={label}>{label}</span>
+                                ))}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </section>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -3,6 +3,28 @@
   margin: 0 auto;
 }
 
+.settings-page.settings-page-interactive {
+  --settings-action-clearance: 84px;
+  --settings-glass-fill: color-mix(in srgb, var(--geist-color-surface-strong) 56%, transparent);
+  --settings-glass-highlight: color-mix(in srgb, var(--geist-color-text) 9%, transparent);
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.settings-scroll-region {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 22px 22px var(--settings-action-clearance);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-padding-bottom: var(--settings-action-clearance);
+}
+
 .settings-status-message {
   display: flex;
   align-items: center;
@@ -11,7 +33,51 @@
 }
 
 .settings-tab-panel {
-  min-height: 420px;
+  min-height: 0;
+}
+
+.settings-page-interactive .settings-actions {
+  position: absolute;
+  right: 22px;
+  bottom: 12px;
+  left: 22px;
+  z-index: 10;
+  min-height: 56px;
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--geist-color-surface);
+  background:
+    linear-gradient(135deg, var(--settings-glass-highlight), transparent 52%),
+    var(--settings-glass-fill);
+  border: 1px solid color-mix(in srgb, var(--geist-color-border-strong) 58%, transparent);
+  border-radius: var(--geist-radius-lg);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.11),
+    0 10px 28px rgba(0, 0, 0, 0.16);
+}
+
+@supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .settings-page-interactive .settings-actions {
+    -webkit-backdrop-filter: blur(14px) saturate(145%);
+    backdrop-filter: blur(14px) saturate(145%);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .settings-page-interactive .settings-actions {
+    background: var(--geist-color-surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .settings-page-interactive .settings-actions {
+    background: Canvas;
+    border-color: CanvasText;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
 }
 
 .settings-section {
@@ -349,6 +415,20 @@
 }
 
 @media (max-width: 720px) {
+  .settings-page.settings-page-interactive {
+    --settings-action-clearance: 180px;
+  }
+
+  .settings-scroll-region {
+    padding: 12px 12px var(--settings-action-clearance);
+  }
+
+  .settings-page-interactive .settings-actions {
+    right: 12px;
+    bottom: 10px;
+    left: 12px;
+  }
+
   .settings-field-header,
   .settings-toggle-field,
   .settings-subsection-header,

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -5,6 +5,7 @@
 
 .settings-page.settings-page-interactive {
   --settings-action-clearance: 84px;
+  --settings-scrollbar-lane: 0px;
   --settings-glass-fill: color-mix(in srgb, var(--geist-color-surface-strong) 56%, transparent);
   --settings-glass-highlight: color-mix(in srgb, var(--geist-color-text) 9%, transparent);
   position: relative;
@@ -13,6 +14,10 @@
   min-height: 0;
   padding: 0;
   overflow: hidden;
+}
+
+.settings-page.settings-page-interactive.settings-scrollbar-visible {
+  --settings-scrollbar-lane: 10px;
 }
 
 .settings-scroll-region {
@@ -38,7 +43,7 @@
 
 .settings-page-interactive .settings-actions {
   position: absolute;
-  right: 22px;
+  right: calc(22px + var(--settings-scrollbar-lane));
   bottom: 12px;
   left: 22px;
   z-index: 10;
@@ -424,7 +429,7 @@
   }
 
   .settings-page-interactive .settings-actions {
-    right: 12px;
+    right: calc(12px + var(--settings-scrollbar-lane));
     bottom: 10px;
     left: 12px;
   }

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import Settings from './Settings';
 import { UserSettingsProvider } from './Hooks/useUserSettings';
 
@@ -81,6 +81,30 @@ describe('Settings page', () => {
       expect(screen.getByRole('tab', { name: 'Appearance' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Developer' })).toBeInTheDocument();
     });
+  });
+
+  it('keeps the settings actions outside the scrollable generation content', async () => {
+    // @ts-ignore
+    global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
+
+    const { container } = renderSettings();
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Generation' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Generation' }));
+
+    const page = container.querySelector('.settings-page-interactive');
+    const scrollRegion = container.querySelector('.settings-scroll-region');
+    const actions = screen.getByRole('contentinfo', { name: 'Settings actions' });
+    expect(page).not.toBeNull();
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion).toContainElement(screen.getByText('Generation Parameters'));
+    expect(scrollRegion).not.toContainElement(actions);
+    expect(actions.parentElement).toBe(page);
+    expect(within(actions).getByRole('button', { name: 'Reset to Defaults' })).toBeInTheDocument();
+    expect(within(actions).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(within(actions).getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
   });
 
   it('marks unsaved changes when local values change and saves', async () => {

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import Settings from './Settings';
 import { UserSettingsProvider } from './Hooks/useUserSettings';
+import { installResizeObserverMock } from './testUtils/mockResizeObserver';
 
 const baseSettings = {
   user_settings_id: 1,
@@ -105,6 +106,47 @@ describe('Settings page', () => {
     expect(within(actions).getByRole('button', { name: 'Reset to Defaults' })).toBeInTheDocument();
     expect(within(actions).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(within(actions).getByRole('button', { name: 'Save Changes' })).toBeInTheDocument();
+  });
+
+  it('aligns the settings actions with content when the scroll region overflows', async () => {
+    const resizeObserver = installResizeObserverMock();
+    // @ts-ignore
+    global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
+
+    const renderResult = renderSettings();
+
+    try {
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Generation' })).toBeInTheDocument();
+      });
+
+      const { container } = renderResult;
+      const page = container.querySelector<HTMLDivElement>('.settings-page-interactive');
+      const scrollRegion = container.querySelector<HTMLDivElement>('.settings-scroll-region');
+      expect(page).not.toBeNull();
+      expect(scrollRegion).not.toBeNull();
+      expect(page).not.toHaveClass('settings-scrollbar-visible');
+
+      let scrollHeight = 700;
+      Object.defineProperty(scrollRegion, 'clientHeight', {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(scrollRegion, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      act(() => resizeObserver.trigger(scrollRegion as HTMLDivElement));
+      expect(page).toHaveClass('settings-scrollbar-visible');
+
+      scrollHeight = 500;
+      act(() => resizeObserver.trigger(scrollRegion as HTMLDivElement));
+      expect(page).not.toHaveClass('settings-scrollbar-visible');
+    } finally {
+      renderResult.unmount();
+      resizeObserver.restore();
+    }
   });
 
   it('marks unsaved changes when local values change and saves', async () => {

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Settings from './Settings';
+import { UserSettingsProvider } from './Hooks/useUserSettings';
 
 const baseSettings = {
   user_settings_id: 1,
@@ -51,6 +52,12 @@ const createFetchMock = (settingsResponses: any[]) => {
   });
 };
 
+const renderSettings = () => render(
+  <UserSettingsProvider>
+    <Settings />
+  </UserSettingsProvider>,
+);
+
 describe('Settings page', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
@@ -62,7 +69,7 @@ describe('Settings page', () => {
     // @ts-ignore
     global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
 
-    render(<Settings />);
+    renderSettings();
     expect(screen.getByText(/Loading settings/i)).toBeInTheDocument();
 
     await waitFor(() => {
@@ -83,7 +90,7 @@ describe('Settings page', () => {
       { ok: true, json: async () => ({ ...baseSettings, default_temperature: 0.8 }) }, // PUT
     ]);
 
-    render(<Settings />);
+    renderSettings();
 
     // Wait for the Generation tab to be visible (indicating loading is complete)
     await waitFor(() => {
@@ -111,7 +118,7 @@ describe('Settings page', () => {
     // @ts-ignore
     global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
 
-    render(<Settings />);
+    renderSettings();
 
     // Wait for the Generation tab to be visible (indicating loading is complete)
     await waitFor(() => {
@@ -137,7 +144,7 @@ describe('Settings page', () => {
     // confirm window
     jest.spyOn(window, 'confirm').mockReturnValue(true);
 
-    render(<Settings />);
+    renderSettings();
 
     // Wait for the Reset button to be visible (indicating loading is complete)
     await waitFor(() => {
@@ -165,7 +172,7 @@ describe('Settings page', () => {
       return Promise.resolve({ ok: true, json: async () => baseSettings });
     });
 
-    render(<Settings />);
+    renderSettings();
     await waitFor(() => screen.getByText(/Error loading settings/i));
 
     fireEvent.click(screen.getByText('Retry'));
@@ -187,7 +194,7 @@ describe('Settings page', () => {
         return Promise.resolve({ ok: true, json: async () => baseSettings });
       });
 
-      render(<Settings />);
+      renderSettings();
 
       await waitFor(() => {
         expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();
@@ -227,7 +234,7 @@ describe('Settings page', () => {
         return Promise.resolve({ ok: true, json: async () => baseSettings });
       });
 
-      render(<Settings />);
+      renderSettings();
 
       await waitFor(() => {
         expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();
@@ -268,7 +275,7 @@ describe('Settings page', () => {
         return Promise.resolve({ ok: true, json: async () => onlineSettings });
       });
 
-      render(<Settings />);
+      renderSettings();
 
       await waitFor(() => {
         expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -141,136 +141,138 @@ const Settings: React.FC = () => {
   }
 
   return (
-    <div className="settings-page page-surface">
-      <header className="settings-header">
-        <div>
-          <p className="section-eyebrow">Workspace</p>
-          <h1>Settings</h1>
+    <div className="settings-page page-surface settings-page-interactive">
+      <div className="settings-scroll-region">
+        <header className="settings-header">
+          <div>
+            <p className="section-eyebrow">Workspace</p>
+            <h1>Settings</h1>
+          </div>
+          {hasUnsavedChanges && <span className="unsaved-pill">Unsaved Changes</span>}
+        </header>
+
+        {statusMessage && (
+          <div className={`notice ${saveStatus === 'success' ? 'notice-success' : 'notice-error'} settings-status-message`}>
+            <span>{statusMessage}</span>
+            <button className="icon-action" type="button" onClick={() => setStatusMessage('')} aria-label="Dismiss status">
+              X
+            </button>
+          </div>
+        )}
+
+        <div className="settings-tabs" role="tablist" aria-label="Settings sections">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={`settings-tab ${activeTab === tab.id ? 'active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
-        {hasUnsavedChanges && <span className="unsaved-pill">Unsaved Changes</span>}
-      </header>
 
-      {statusMessage && (
-        <div className={`notice ${saveStatus === 'success' ? 'notice-success' : 'notice-error'} settings-status-message`}>
-          <span>{statusMessage}</span>
-          <button className="icon-action" type="button" onClick={() => setStatusMessage('')} aria-label="Dismiss status">
-            X
-          </button>
-        </div>
-      )}
+        <div className="settings-tab-panel">
+          {activeTab === 'general' && (
+            <section className="settings-section">
+              <header className="settings-section-header">
+                <h3>General</h3>
+                <p>Choose the default runtime mode for new conversations.</p>
+              </header>
+              <SettingsSelect
+                label="Default Agent Type"
+                value={localSettings.default_agent_type}
+                options={agentTypeOptions}
+                onChange={(value) => updateLocalSetting('default_agent_type', value)}
+                description="Choose whether to use a local or online language model by default."
+              />
+            </section>
+          )}
 
-      <div className="settings-tabs" role="tablist" aria-label="Settings sections">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setActiveTab(tab.id)}
-            className={`settings-tab ${activeTab === tab.id ? 'active' : ''}`}
-            role="tab"
-            aria-selected={activeTab === tab.id}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="settings-tab-panel">
-        {activeTab === 'general' && (
-          <section className="settings-section">
-            <header className="settings-section-header">
-              <h3>General</h3>
-              <p>Choose the default runtime mode for new conversations.</p>
-            </header>
-            <SettingsSelect
-              label="Default Agent Type"
-              value={localSettings.default_agent_type}
-              options={agentTypeOptions}
-              onChange={(value) => updateLocalSetting('default_agent_type', value)}
-              description="Choose whether to use a local or online language model by default."
+          {activeTab === 'models' && (
+            <AgentConfigSection
+              agentType={localSettings.default_agent_type}
+              localModel={localSettings.default_local_model}
+              onlineProvider={localSettings.default_online_provider}
+              onlineModel={localSettings.default_online_model}
+              onLocalModelChange={(value) => {
+                updateLocalSetting('default_local_model', value);
+                updateLocalSetting('default_local_artifact_id', null);
+                if (localSettings.default_agent_type !== 'local') {
+                  updateLocalSetting('default_agent_type', 'local');
+                }
+              }}
+              onOnlineProviderChange={(value) => {
+                updateLocalSetting('default_online_provider', value);
+                if (localSettings.default_agent_type !== 'online') {
+                  updateLocalSetting('default_agent_type', 'online');
+                }
+              }}
+              onOnlineModelChange={(value) => {
+                updateLocalSetting('default_online_model', value);
+                if (localSettings.default_agent_type !== 'online') {
+                  updateLocalSetting('default_agent_type', 'online');
+                }
+              }}
             />
-          </section>
-        )}
+          )}
 
-        {activeTab === 'models' && (
-          <AgentConfigSection
-            agentType={localSettings.default_agent_type}
-            localModel={localSettings.default_local_model}
-            onlineProvider={localSettings.default_online_provider}
-            onlineModel={localSettings.default_online_model}
-            onLocalModelChange={(value) => {
-              updateLocalSetting('default_local_model', value);
-              updateLocalSetting('default_local_artifact_id', null);
-              if (localSettings.default_agent_type !== 'local') {
-                updateLocalSetting('default_agent_type', 'local');
-              }
-            }}
-            onOnlineProviderChange={(value) => {
-              updateLocalSetting('default_online_provider', value);
-              if (localSettings.default_agent_type !== 'online') {
-                updateLocalSetting('default_agent_type', 'online');
-              }
-            }}
-            onOnlineModelChange={(value) => {
-              updateLocalSetting('default_online_model', value);
-              if (localSettings.default_agent_type !== 'online') {
-                updateLocalSetting('default_agent_type', 'online');
-              }
-            }}
-          />
-        )}
+          {activeTab === 'generation' && (
+            <GenerationParamsSection
+              temperature={localSettings.default_temperature}
+              maxTokens={localSettings.default_max_tokens}
+              topP={localSettings.default_top_p}
+              frequencyPenalty={localSettings.default_frequency_penalty}
+              presencePenalty={localSettings.default_presence_penalty}
+              onTemperatureChange={(value) => updateLocalSetting('default_temperature', value)}
+              onMaxTokensChange={(value) => updateLocalSetting('default_max_tokens', value)}
+              onTopPChange={(value) => updateLocalSetting('default_top_p', value)}
+              onFrequencyPenaltyChange={(value) => updateLocalSetting('default_frequency_penalty', value)}
+              onPresencePenaltyChange={(value) => updateLocalSetting('default_presence_penalty', value)}
+            />
+          )}
 
-        {activeTab === 'generation' && (
-          <GenerationParamsSection
-            temperature={localSettings.default_temperature}
-            maxTokens={localSettings.default_max_tokens}
-            topP={localSettings.default_top_p}
-            frequencyPenalty={localSettings.default_frequency_penalty}
-            presencePenalty={localSettings.default_presence_penalty}
-            onTemperatureChange={(value) => updateLocalSetting('default_temperature', value)}
-            onMaxTokensChange={(value) => updateLocalSetting('default_max_tokens', value)}
-            onTopPChange={(value) => updateLocalSetting('default_top_p', value)}
-            onFrequencyPenaltyChange={(value) => updateLocalSetting('default_frequency_penalty', value)}
-            onPresencePenaltyChange={(value) => updateLocalSetting('default_presence_penalty', value)}
-          />
-        )}
+          {activeTab === 'rag' && (
+            <RAGSettingsSection
+              enableRagByDefault={localSettings.enable_rag_by_default}
+              defaultFileArchives={localSettings.default_file_archives}
+              onEnableRagChange={(value) => updateLocalSetting('enable_rag_by_default', value)}
+              onFileArchivesChange={(value) => updateLocalSetting('default_file_archives', value)}
+            />
+          )}
 
-        {activeTab === 'rag' && (
-          <RAGSettingsSection
-            enableRagByDefault={localSettings.enable_rag_by_default}
-            defaultFileArchives={localSettings.default_file_archives}
-            onEnableRagChange={(value) => updateLocalSetting('enable_rag_by_default', value)}
-            onFileArchivesChange={(value) => updateLocalSetting('default_file_archives', value)}
-          />
-        )}
+          {activeTab === 'ui' && (
+            <UIPreferencesSection
+              uiPreferences={localSettings.ui_preferences}
+              onUiPreferencesChange={(value) => updateLocalSetting('ui_preferences', value)}
+            />
+          )}
 
-        {activeTab === 'ui' && (
-          <UIPreferencesSection
-            uiPreferences={localSettings.ui_preferences}
-            onUiPreferencesChange={(value) => updateLocalSetting('ui_preferences', value)}
-          />
-        )}
-
-        {activeTab === 'developer' && (
-          <section className="settings-section">
-            <header className="settings-section-header">
-              <h3>Developer</h3>
-              <p>Inspect host branding and runtime integration defaults.</p>
-            </header>
-            <div className="settings-readonly-grid">
-              <div className="settings-readonly-item">
-                <span className="settings-label">Branding Source</span>
-                <span className="settings-description">Host override with neutral fallback</span>
+          {activeTab === 'developer' && (
+            <section className="settings-section">
+              <header className="settings-section-header">
+                <h3>Developer</h3>
+                <p>Inspect host branding and runtime integration defaults.</p>
+              </header>
+              <div className="settings-readonly-grid">
+                <div className="settings-readonly-item">
+                  <span className="settings-label">Branding Source</span>
+                  <span className="settings-description">Host override with neutral fallback</span>
+                </div>
+                <div className="settings-readonly-item">
+                  <span className="settings-label">Theme Contract</span>
+                  <span className="settings-description">Semantic CSS variables</span>
+                </div>
               </div>
-              <div className="settings-readonly-item">
-                <span className="settings-label">Theme Contract</span>
-                <span className="settings-description">Semantic CSS variables</span>
-              </div>
-            </div>
-          </section>
-        )}
+            </section>
+          )}
+        </div>
       </div>
 
-      <footer className="settings-actions">
+      <footer className="settings-actions" aria-label="Settings actions">
         <button className="button button-danger" onClick={handleReset} disabled={saveStatus === 'saving'}>
           Reset to Defaults
         </button>

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -6,6 +6,7 @@ import GenerationParamsSection from './Components/GenerationParamsSection';
 import RAGSettingsSection from './Components/RAGSettingsSection';
 import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
+import useOverflowObserver from './Hooks/useOverflowObserver';
 
 type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer';
 
@@ -21,6 +22,10 @@ const Settings: React.FC = () => {
   const [localSettings, setLocalSettings] = useState<any>(null);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
   const [statusMessage, setStatusMessage] = useState<string>('');
+  const {
+    ref: settingsScrollRef,
+    hasOverflow: hasSettingsScrollbar,
+  } = useOverflowObserver<HTMLDivElement>(Boolean(localSettings));
 
   useEffect(() => {
     if (settings) {
@@ -141,8 +146,8 @@ const Settings: React.FC = () => {
   }
 
   return (
-    <div className="settings-page page-surface settings-page-interactive">
-      <div className="settings-scroll-region">
+    <div className={`settings-page page-surface settings-page-interactive${hasSettingsScrollbar ? ' settings-scrollbar-visible' : ''}`}>
+      <div className="settings-scroll-region" ref={settingsScrollRef}>
         <header className="settings-header">
           <div>
             <p className="section-eyebrow">Workspace</p>

--- a/client/geist/src/WorkflowBuilder.test.tsx
+++ b/client/geist/src/WorkflowBuilder.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import WorkflowBuilder from './WorkflowBuilder';
+import { installResizeObserverMock } from './testUtils/mockResizeObserver';
 
 jest.mock('reactflow', () => {
   const React = require('react');
@@ -60,6 +61,44 @@ describe('Workflow library panel', () => {
       name: 'Morning routine',
       steps: [],
     });
+  });
+
+  it('only adds an external scrollbar gap while the workflow drawer overflows', () => {
+    const resizeObserver = installResizeObserverMock();
+    const renderResult = render(
+      <MemoryRouter initialEntries={['/workflows']}>
+        <WorkflowBuilder />
+      </MemoryRouter>
+    );
+
+    try {
+      const library = screen.getByRole('complementary', { name: 'Workflow library' });
+      const libraryScroll = library.querySelector<HTMLDivElement>('.stage-panel-surface');
+      expect(libraryScroll).not.toBeNull();
+      expect(library).not.toHaveClass('stage-panel-scrollbar-visible');
+
+      fireEvent.click(within(library).getByRole('button', { name: 'Expand workflow library' }));
+
+      let scrollHeight = 700;
+      Object.defineProperty(libraryScroll, 'clientHeight', {
+        configurable: true,
+        get: () => 500,
+      });
+      Object.defineProperty(libraryScroll, 'scrollHeight', {
+        configurable: true,
+        get: () => scrollHeight,
+      });
+
+      act(() => resizeObserver.trigger(libraryScroll as HTMLDivElement));
+      expect(library).toHaveClass('stage-panel-scrollbar-visible');
+
+      scrollHeight = 500;
+      act(() => resizeObserver.trigger(libraryScroll as HTMLDivElement));
+      expect(library).not.toHaveClass('stage-panel-scrollbar-visible');
+    } finally {
+      renderResult.unmount();
+      resizeObserver.restore();
+    }
   });
 
   it('uses the same compact-to-stage panel interaction and inline renaming as Chat', async () => {

--- a/client/geist/src/WorkflowBuilder.tsx
+++ b/client/geist/src/WorkflowBuilder.tsx
@@ -16,6 +16,7 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import useWorkflows, { WorkflowStep, WorkflowCreate, WorkflowUpdate } from './Hooks/useWorkflows';
+import useOverflowObserver from './Hooks/useOverflowObserver';
 import { NavLink, useParams, useNavigate } from 'react-router-dom';
 import StagePanelIcon from './Components/StagePanelIcon';
 import './WorkflowBuilder.css';
@@ -78,6 +79,10 @@ const WorkflowBuilder: React.FC = () => {
   const [workflowTitleDraft, setWorkflowTitleDraft] = useState('');
   const [workflowTitleError, setWorkflowTitleError] = useState('');
   const [workflowTitleSaving, setWorkflowTitleSaving] = useState(false);
+  const {
+    ref: workflowDrawerScrollRef,
+    hasOverflow: hasWorkflowDrawerScrollbar,
+  } = useOverflowObserver<HTMLDivElement>(workflowPanelState === 'expanded');
 
   const loadWorkflow = useCallback(async (id: number) => {
     const workflow = await getWorkflow(id);
@@ -348,11 +353,11 @@ const WorkflowBuilder: React.FC = () => {
           )}
 
           <aside
-            className={`WorkflowLibrary stage-panel workflow-library-panel-host stage-panel-${workflowPanelState}`}
+            className={`WorkflowLibrary stage-panel workflow-library-panel-host stage-panel-${workflowPanelState}${hasWorkflowDrawerScrollbar ? ' stage-panel-scrollbar-visible' : ''}`}
             aria-label="Workflow library"
             data-state={workflowPanelState}
           >
-            <div className="stage-panel-surface">
+            <div className="stage-panel-surface" ref={workflowDrawerScrollRef}>
               {workflowPanelState === 'minimized' ? (
                 <div className="workflow-minimized-controls stage-panel-compact-controls" aria-label="Workflow shortcuts">
                   <button className="button workflow-minimized-new-button stage-panel-primary-button" type="button" onClick={handleNewWorkflow} aria-label="New workflow" title="New workflow">

--- a/client/geist/src/__tests__/Chat.test.tsx
+++ b/client/geist/src/__tests__/Chat.test.tsx
@@ -5,6 +5,7 @@ import Chat, { turnBelongsToChatSelection } from '../Chat';
 
 const mockCancelGeneration = jest.fn();
 const mockResetChatSession = jest.fn();
+const mockPrepareNewChat = jest.fn();
 const mockChatSessions: never[] = [];
 const mockLoadMore = jest.fn();
 const mockNavigate = jest.fn();
@@ -59,6 +60,17 @@ jest.mock('../Hooks/useUserSettings', () => ({
 
 jest.mock('../Hooks/useChatMemory', () => ({
   __esModule: true,
+  getMemoryScope: (settings: {
+    memory_enabled: boolean;
+    memory_mode: 'public' | 'private';
+    folder_id: number | null;
+  }) => {
+    if (!settings.memory_enabled) return { kind: 'disabled' };
+    if (settings.folder_id !== null) {
+      return { kind: 'folder', folderId: settings.folder_id };
+    }
+    return { kind: settings.memory_mode };
+  },
   default: () => ({
     settings: {
       memory_enabled: true,
@@ -70,12 +82,13 @@ jest.mock('../Hooks/useChatMemory', () => ({
     folders: [],
     loading: false,
     error: null,
+    refreshFolders: jest.fn(),
     createFolder: jest.fn(),
     renameFolder: jest.fn(),
     deleteFolder: jest.fn(),
-    setMemoryEnabled: jest.fn(),
-    setPrivate: jest.fn(),
-    setFolder: jest.fn(),
+    setScope: jest.fn(async () => true),
+    prepareNewChat: mockPrepareNewChat,
+    setChatFolder: jest.fn(async () => true),
   }),
 }));
 
@@ -92,6 +105,7 @@ describe('Chat live run controls', () => {
   beforeEach(() => {
     mockCancelGeneration.mockClear();
     mockResetChatSession.mockClear();
+    mockPrepareNewChat.mockClear();
   });
 
   it('renders a Stop control and cancels the active generation', () => {
@@ -107,6 +121,7 @@ describe('Chat live run controls', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
 
+    expect(mockPrepareNewChat).toHaveBeenCalledWith({ kind: 'public' });
     expect(mockResetChatSession).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/chat');
   });

--- a/client/geist/src/testUtils/mockResizeObserver.ts
+++ b/client/geist/src/testUtils/mockResizeObserver.ts
@@ -1,0 +1,54 @@
+export const installResizeObserverMock = () => {
+  const originalResizeObserver = window.ResizeObserver;
+  const callbacks = new Map<Element, ResizeObserverCallback>();
+
+  class MockResizeObserver {
+    private readonly observedTargets = new Set<Element>();
+
+    constructor(private readonly callback: ResizeObserverCallback) {}
+
+    observe(target: Element) {
+      this.observedTargets.add(target);
+      callbacks.set(target, this.callback);
+    }
+
+    unobserve(target: Element) {
+      this.observedTargets.delete(target);
+      if (callbacks.get(target) === this.callback) {
+        callbacks.delete(target);
+      }
+    }
+
+    disconnect() {
+      this.observedTargets.forEach(target => {
+        if (callbacks.get(target) === this.callback) {
+          callbacks.delete(target);
+        }
+      });
+      this.observedTargets.clear();
+    }
+  }
+
+  Object.defineProperty(window, 'ResizeObserver', {
+    configurable: true,
+    writable: true,
+    value: MockResizeObserver,
+  });
+
+  return {
+    trigger(target: Element) {
+      const callback = callbacks.get(target);
+      if (!callback) {
+        throw new Error('No ResizeObserver callback registered for the target.');
+      }
+      callback([], {} as ResizeObserver);
+    },
+    restore() {
+      Object.defineProperty(window, 'ResizeObserver', {
+        configurable: true,
+        writable: true,
+        value: originalResizeObserver,
+      });
+    },
+  };
+};

--- a/scripts/build_native_sidecar.py
+++ b/scripts/build_native_sidecar.py
@@ -29,6 +29,7 @@ FRONTEND_ROOT = PROJECT_ROOT / "client" / "geist"
 FRONTEND_BUILD = FRONTEND_ROOT / "build"
 ENTRYPOINT = PROJECT_ROOT / "scripts" / "geist_frozen_entrypoint.py"
 DEFAULT_SOURCE_DATE_EPOCH = "315532800"  # 1980-01-01, valid for ZIP timestamps.
+CONFLICTING_WINDOWS_RUNTIME_DLLS = ("MSVCP140.dll",)
 
 
 @dataclass(frozen=True)
@@ -370,7 +371,36 @@ def verify_runtime_output(runtime_dir: Path, target: NativeTarget) -> Path:
         )
     if executable.stat().st_size == 0:
         raise RuntimeError(f"Frozen Geist executable is empty: {executable}")
+    if target.key == "win32-x64":
+        conflicts = [
+            str(internal / filename)
+            for filename in CONFLICTING_WINDOWS_RUNTIME_DLLS
+            if (internal / filename).is_file()
+        ]
+        if conflicts:
+            raise RuntimeError(
+                "Frozen Geist runtime contains host-resolved MSVC DLLs that can "
+                "contaminate external runtimes:\n- " + "\n- ".join(conflicts)
+            )
     return executable
+
+
+def remove_conflicting_windows_runtime_dlls(
+    runtime_dir: Path,
+    target: NativeTarget,
+) -> tuple[Path, ...]:
+    """Remove MSVC libraries that PyInstaller may resolve from unrelated host tools."""
+
+    if target.key != "win32-x64":
+        return ()
+    removed = []
+    internal = runtime_dir / "_internal"
+    for filename in CONFLICTING_WINDOWS_RUNTIME_DLLS:
+        candidate = internal / filename
+        if candidate.is_file():
+            candidate.unlink()
+            removed.append(candidate)
+    return tuple(removed)
 
 
 def build_manifest(
@@ -448,6 +478,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         _run(command, PROJECT_ROOT, deterministic_environment())
 
         runtime_dir = dist_dir / "geist"
+        removed_runtime_dlls = remove_conflicting_windows_runtime_dlls(
+            runtime_dir,
+            target,
+        )
+        for removed in removed_runtime_dlls:
+            print(f"Removed host-resolved runtime DLL: {removed}")
         verify_runtime_output(runtime_dir, target)
         manifest_path = write_manifest(runtime_dir, build_manifest(target))
         print(f"Geist native sidecar: {runtime_dir}")

--- a/tests/agents/test_llama_server_process.py
+++ b/tests/agents/test_llama_server_process.py
@@ -90,6 +90,7 @@ def test_auto_prefers_vulkan_and_uses_private_authenticated_flags(tmp_path):
     assert "--jinja" in args
     assert args[args.index("--ctx-size") + 1] == "32768"
     assert args[args.index("--n-gpu-layers") + 1] == "999"
+    assert options["cwd"] == str(runtime / "vulkan")
     assert options["shell"] is False
     if os.name == "nt":
         assert options["creationflags"]

--- a/tests/scripts/test_build_native_sidecar.py
+++ b/tests/scripts/test_build_native_sidecar.py
@@ -14,6 +14,7 @@ from scripts.build_native_sidecar import (
     deterministic_environment,
     missing_freezer_modules,
     pyinstaller_arguments,
+    remove_conflicting_windows_runtime_dlls,
     verify_inputs,
     verify_runtime_output,
     write_manifest,
@@ -168,6 +169,21 @@ def test_verify_runtime_output_requires_complete_onedir_tree(tmp_path: Path) -> 
     assert "client" in message and "index.html" in message
     assert "alembic.ini" in message
     assert f"versions{os.sep}*.py" in message
+
+
+def test_windows_runtime_removes_host_resolved_msvcp(tmp_path: Path) -> None:
+    runtime = tmp_path / "geist"
+    conflicting = runtime / "_internal" / "MSVCP140.dll"
+    conflicting.parent.mkdir(parents=True)
+    conflicting.write_bytes(b"host JDK runtime")
+
+    removed = remove_conflicting_windows_runtime_dlls(
+        runtime,
+        TARGETS["win32-x64"],
+    )
+
+    assert removed == (conflicting,)
+    assert not conflicting.exists()
 
 
 def test_build_manifest_records_locked_inputs_without_timestamps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Reworks Geist's model-management and chat-memory experiences while improving native inference isolation, chat presentation, drawer scrolling, and Settings usability.

This combines the model/runtime reliability work with the requested memory controls and frosted-glass UI treatment.

## Changes

### Models and native inference

- Split the Models page into two tabs:
  - Local Models
  - Model Providers
- Updated refresh behavior to reload both local model artifacts and the provider catalogue.
- Improved local-model selection and default-state handling.
- Removed the redundant local-provider badge from the runtime header.
- Moved user settings into a shared provider so the selected model and runtime badge update throughout the UI.
- Hardened Windows native inference startup:
  - Frozen Geist builds no longer retain a host-resolved `MSVCP140.dll`.
  - `llama-server` is launched from its own runtime directory so DLL resolution remains isolated from Geist's bundled dependencies.
- Added tests covering DLL cleanup and the llama-server working directory.

### Memory experience

- Replaced the previous memory UI with a dropdown beside New Chat.
- Added three explicit modes:
  - Memory Disabled
  - Memory Enabled
  - Memory Enabled (this chat only)
- Added persistent text and icon cues so the current memory state is visible without opening the dropdown.
- Added folder-aware memory scopes and private folder management.
- Hide Manage folders and Folder memory controls when the relevant drawer is already open.
- Reworked the chat library and memory drawer with:
  - Search
  - Folder organization
  - Profile memory management
  - Rename and move actions
  - Keyboard and accessibility improvements
- Added component, hook, and end-to-end coverage for scope transitions, folder behavior, and memory privacy.

### Chat and drawer presentation

- Added frosted-glass surfaces to the chat toolbar and composer.
- Stacked and correctly spaced the microphone and send controls.
- Allowed conversation content to scroll underneath the glass surfaces without becoming occluded.
- Moved the main chat scrollbar visually outside the bordered conversation surface.
- Made scrollbar space conditional so no empty gutter remains when content does not overflow.
- Applied the same external, overflow-aware scrollbar behavior to the Chat and Workflow drawers.
- Added a shared overflow observer and tests covering fit → overflow → fit transitions.

### Settings

- Added a bounded Settings scrolling region.
- Fixed scrolling on the Generation page.
- Converted the Save, Cancel, and Reset to defaults area into a persistent frosted-glass action bar.
- Allowed Settings content to scroll underneath the action bar while keeping its controls available.
- Removed the forced minimum panel height that caused the large bottom gap.
- Added responsive action-area clearance plus reduced-transparency and forced-colors fallbacks.

## Testing

- Focused Jest validation:
  - Chat
  - Workflow Builder
  - Settings
  - Chat memory controls
  - Chat text area
  - 5 suites and 38/38 tests passed
- `npm run build` — production frontend build completed successfully
- `git diff --check` — passed
- Live Electron smoke testing confirmed:
  - Chat drawer scrollbar appears only during overflow
  - Filtering the drawer removes the scrollbar and restores full width
  - Empty Workflow drawers reserve no scrollbar space
  - Generation Settings scroll correctly
  - The Settings action bar remains fixed while content scrolls underneath
  - The main chat scrollbar continues to work