### PR TITLE
Unify tool registry, add MCP server configuration, and doom-loop interrupt

### DIFF
--- a/agents/models/tool_calling.py
+++ b/agents/models/tool_calling.py
@@ -136,8 +136,8 @@ ToolAvailability = Callable[[ToolContext], bool]
 class ToolDefinition:
     name: str
     description: str
-    arguments_model: type[BaseModel]
-    handler: ToolHandler
+    arguments_model: type[BaseModel] | None = None
+    handler: ToolHandler | None = None
     side_effect: ToolSideEffect = "read"
     requires_approval: bool = False
     enabled_by_default: bool = True
@@ -145,10 +145,27 @@ class ToolDefinition:
     max_result_chars: int = 20_000
     source_adapter: str | None = None
     availability: ToolAvailability | None = None
+    # Raw JSON-schema alternative to arguments_model for tools whose schemas
+    # arrive at runtime (MCP servers, reflected adapters). Exactly one of the
+    # two must be provided; handlers on this path receive a plain dict.
+    arguments_schema: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.handler is None:
+            raise ValueError(f"Tool '{self.name}' requires a handler")
+        if (self.arguments_model is None) == (self.arguments_schema is None):
+            raise ValueError(
+                f"Tool '{self.name}' requires exactly one of arguments_model or arguments_schema"
+            )
 
     def parameters_schema(self) -> dict[str, Any]:
-        schema = self.arguments_model.model_json_schema()
-        schema.pop("title", None)
+        if self.arguments_model is not None:
+            schema = self.arguments_model.model_json_schema()
+            schema.pop("title", None)
+            return schema
+        schema = dict(self.arguments_schema or {})
+        schema.setdefault("type", "object")
+        schema.setdefault("properties", {})
         return schema
 
     def to_openai(self, provider_name: str | None = None) -> dict[str, Any]:

--- a/app/api/v1/endpoints/mcp.py
+++ b/app/api/v1/endpoints/mcp.py
@@ -1,0 +1,242 @@
+"""
+API endpoints for configuring MCP (Model Context Protocol) servers.
+
+Configured servers are persisted per user; only servers explicitly marked
+enabled contribute tools to chat via the registry's MCP tool source.
+"""
+import logging
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.database.geist_user import get_default_user
+from app.models.database.mcp_server import (
+    McpServerModel,
+    create_mcp_server,
+    delete_mcp_server,
+    get_mcp_server,
+    list_mcp_servers,
+    update_mcp_server,
+)
+from app.services.mcp_client import McpError
+from app.services.mcp_tool_source import (
+    config_from_model,
+    get_mcp_manager,
+    get_mcp_tool_source,
+)
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_NAME_PATTERN = r"^[A-Za-z0-9_-]{1,64}$"
+
+
+def get_current_user():
+    """Get current user (placeholder - should integrate with actual auth system)."""
+    return get_default_user()
+
+
+def _validate_transport_fields(transport: str, command: str | None, url: str | None) -> None:
+    if transport == "stdio":
+        if not (command or "").strip():
+            raise ValueError("stdio servers require a command")
+    elif transport == "http" and (
+        not url or not url.lower().startswith(("http://", "https://"))
+    ):
+        raise ValueError("http servers require an http(s) URL")
+
+
+class McpServerCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(pattern=_NAME_PATTERN)
+    transport: Literal["stdio", "http"] = "stdio"
+    command: str | None = Field(default=None, max_length=1024)
+    args: list[str] = Field(default_factory=list, max_length=64)
+    env: dict[str, str] = Field(default_factory=dict)
+    url: str | None = Field(default=None, max_length=2048)
+    headers: dict[str, str] = Field(default_factory=dict)
+    enabled: bool = False
+    timeout_seconds: float = Field(default=30.0, ge=1.0, le=600.0)
+
+    @model_validator(mode="after")
+    def _check_transport(self) -> "McpServerCreate":
+        _validate_transport_fields(self.transport, self.command, self.url)
+        return self
+
+
+class McpServerUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None, pattern=_NAME_PATTERN)
+    transport: Literal["stdio", "http"] | None = None
+    command: str | None = Field(default=None, max_length=1024)
+    args: list[str] | None = Field(default=None, max_length=64)
+    env: dict[str, str] | None = None
+    url: str | None = Field(default=None, max_length=2048)
+    headers: dict[str, str] | None = None
+    enabled: bool | None = None
+    timeout_seconds: float | None = Field(default=None, ge=1.0, le=600.0)
+
+
+class McpServerResponse(BaseModel):
+    mcp_server_id: int
+    user_id: int
+    name: str
+    transport: str
+    command: str | None
+    args: list[str]
+    env: dict[str, str]
+    url: str | None
+    headers: dict[str, str]
+    enabled: bool
+    timeout_seconds: float
+    create_date: Any
+    update_date: Any
+
+
+class McpToolInfo(BaseModel):
+    name: str
+    description: str = ""
+
+
+class McpServerTestResponse(BaseModel):
+    ok: bool
+    error: str | None = None
+    tools: list[McpToolInfo] = Field(default_factory=list)
+
+
+def _response(server: McpServerModel) -> McpServerResponse:
+    return McpServerResponse(**server.__dict__)
+
+
+def _invalidate(server_id: int | None = None) -> None:
+    if server_id is not None:
+        get_mcp_manager().invalidate(server_id)
+    get_mcp_tool_source().invalidate()
+
+
+@router.get("/servers", response_model=list[McpServerResponse])
+async def list_servers():
+    try:
+        user = get_current_user()
+        return [_response(server) for server in list_mcp_servers(user.user_id)]
+    except Exception as e:
+        logger.error(f"Error listing MCP servers: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/servers", response_model=McpServerResponse, status_code=201)
+async def create_server(request: McpServerCreate):
+    try:
+        user = get_current_user()
+        if any(server.name == request.name for server in list_mcp_servers(user.user_id)):
+            raise HTTPException(
+                status_code=409, detail=f"An MCP server named '{request.name}' already exists"
+            )
+        server = create_mcp_server(user.user_id, request.model_dump())
+        _invalidate()
+        return _response(server)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating MCP server: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.get("/servers/{mcp_server_id}", response_model=McpServerResponse)
+async def get_server(mcp_server_id: int):
+    server = get_mcp_server(mcp_server_id)
+    if not server:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+    return _response(server)
+
+
+@router.put("/servers/{mcp_server_id}", response_model=McpServerResponse)
+async def update_server(mcp_server_id: int, request: McpServerUpdate):
+    try:
+        existing = get_mcp_server(mcp_server_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="MCP server not found")
+        updates = request.model_dump(exclude_unset=True)
+
+        merged_transport = updates.get("transport", existing.transport)
+        merged_command = updates.get("command", existing.command)
+        merged_url = updates.get("url", existing.url)
+        try:
+            _validate_transport_fields(merged_transport, merged_command, merged_url)
+        except ValueError as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
+        new_name = updates.get("name")
+        if new_name and new_name != existing.name and any(
+            server.name == new_name for server in list_mcp_servers(existing.user_id)
+        ):
+            raise HTTPException(
+                status_code=409, detail=f"An MCP server named '{new_name}' already exists"
+            )
+
+        server = update_mcp_server(mcp_server_id, updates)
+        if not server:
+            raise HTTPException(status_code=404, detail="MCP server not found")
+        _invalidate(mcp_server_id)
+        return _response(server)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating MCP server {mcp_server_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.delete("/servers/{mcp_server_id}", status_code=204)
+async def delete_server(mcp_server_id: int):
+    try:
+        if not delete_mcp_server(mcp_server_id):
+            raise HTTPException(status_code=404, detail="MCP server not found")
+        _invalidate(mcp_server_id)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting MCP server {mcp_server_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e
+
+
+@router.post("/servers/{mcp_server_id}/test", response_model=McpServerTestResponse)
+async def test_server(mcp_server_id: int):
+    """Connect to the server and list its tools without enabling it."""
+    server = get_mcp_server(mcp_server_id)
+    if not server:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+    try:
+        tools = get_mcp_manager().list_tools(config_from_model(server))
+    except McpError as error:
+        return McpServerTestResponse(ok=False, error=str(error))
+    except Exception as e:
+        logger.error(f"Unexpected error testing MCP server {mcp_server_id}: {e}")
+        return McpServerTestResponse(ok=False, error="Unexpected connection failure")
+    return McpServerTestResponse(
+        ok=True,
+        tools=[
+            McpToolInfo(
+                name=str(tool.get("name", "")),
+                description=str(tool.get("description") or ""),
+            )
+            for tool in tools
+        ],
+    )
+
+
+@router.get("/tools", response_model=list[McpToolInfo])
+async def list_mounted_tools():
+    """List the MCP tools currently mounted into the chat tool registry."""
+    try:
+        return [
+            McpToolInfo(name=definition.name, description=definition.description)
+            for definition in get_mcp_tool_source().definitions()
+        ]
+    except Exception as e:
+        logger.error(f"Error listing mounted MCP tools: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from agents.online_agent import OnlineAgent
 from agents.prompt.prompt import AGENT_PROMPTS, TOOL_USE_PROMPT
 from app.api.v1.endpoints.files import router as files_router
 from app.api.v1.endpoints.jobs import router as jobs_router
+from app.api.v1.endpoints.mcp import router as mcp_router
 from app.api.v1.endpoints.memory import router as memory_router
 from app.api.v1.endpoints.models import router as models_router
 from app.api.v1.endpoints.user_settings import router as user_settings_router
@@ -48,6 +49,7 @@ from app.models.user_settings import AgentConfigRequest, AgentFactoryConfig
 from app.runtime_config import application_version
 from app.services.chat_orchestrator import ChatOrchestrator, RunControlRegistry
 from app.services.job_queue import start_worker, stop_worker
+from app.services.mcp_tool_source import get_mcp_tool_source
 from app.services.memory_context import build_memory_context
 from app.services.memory_scheduler import MEMORY_JOB_KIND  # noqa: F401
 from app.services.memory_service import get_chat_memory_settings
@@ -93,8 +95,12 @@ AGENT_TYPE_TO_FACTORY_TYPE = {
 api_version = 1.0
 default_agent_type = AgentType.LLAMA
 run_controls = RunControlRegistry()
+_tool_registry = build_default_tool_registry()
+# Enabled MCP servers contribute their tools through the same registry as the
+# curated defaults; configuration lives behind /api/v1/mcp.
+_tool_registry.add_source(get_mcp_tool_source())
 chat_orchestrator = ChatOrchestrator(
-    build_default_tool_registry(),
+    _tool_registry,
     run_controls=run_controls,
 )
 
@@ -603,6 +609,7 @@ def create_app(
     app.include_router(models_router, prefix="/api/v1/models", tags=["models"])
     app.include_router(jobs_router, prefix="/api/v1/jobs", tags=["jobs"])
     app.include_router(memory_router, prefix="/api/v1/memory", tags=["memory"])
+    app.include_router(mcp_router, prefix="/api/v1/mcp", tags=["mcp"])
 
     @app.get("/health", include_in_schema=False)
     def health():

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -5,6 +5,7 @@ from app.models.database.chat_session import ChatSession
 from app.models.database.file_upload import FileUpload
 from app.models.database.geist_user import GeistUser
 from app.models.database.job import Job
+from app.models.database.mcp_server import McpServer
 from app.models.database.memory import MemoryEmbedding, MemoryFolder, MemoryRecord
 from app.models.database.user_settings import UserSettings
 from app.models.database.workflow import Workflow, WorkflowRun, WorkflowStep, WorkflowStepResult

--- a/app/models/database/mcp_server.py
+++ b/app/models/database/mcp_server.py
@@ -1,0 +1,158 @@
+"""
+McpServer database model: operator-configured MCP servers whose tools are
+mounted into the chat tool registry when enabled.
+"""
+import datetime
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.models.database.database import Base, SessionLocal
+
+
+class McpServer(Base):
+    """Connection settings for one MCP server (stdio or streamable HTTP)."""
+
+    __tablename__ = 'mcp_server'
+
+    mcp_server_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('geist_user.user_id'), nullable=False)
+
+    name = Column(String, nullable=False)
+    transport = Column(String, nullable=False, default='stdio')  # 'stdio' or 'http'
+
+    # stdio transport
+    command = Column(String, nullable=True)
+    args = Column(JSON, default=list)
+    env = Column(JSON, default=dict)
+
+    # http (streamable HTTP) transport
+    url = Column(String, nullable=True)
+    headers = Column(JSON, default=dict)
+
+    # Servers are disabled until an operator explicitly enables them; only
+    # enabled servers contribute tools to chat.
+    enabled = Column(Boolean, nullable=False, default=False)
+    timeout_seconds = Column(Float, nullable=False, default=30.0)
+
+    create_date = Column(DateTime, default=datetime.datetime.utcnow)
+    update_date = Column(
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+    )
+
+    user = relationship("GeistUser", backref="mcp_servers")
+
+
+@dataclass
+class McpServerModel:
+    """Data model for a configured MCP server."""
+
+    mcp_server_id: int
+    user_id: int
+    name: str
+    transport: str
+    command: str | None
+    args: list[str]
+    env: dict[str, str]
+    url: str | None
+    headers: dict[str, str]
+    enabled: bool
+    timeout_seconds: float
+    create_date: datetime.datetime
+    update_date: datetime.datetime
+
+
+_MUTABLE_FIELDS = (
+    "name",
+    "transport",
+    "command",
+    "args",
+    "env",
+    "url",
+    "headers",
+    "enabled",
+    "timeout_seconds",
+)
+
+
+def _to_model(server: McpServer) -> McpServerModel:
+    return McpServerModel(
+        mcp_server_id=server.mcp_server_id,
+        user_id=server.user_id,
+        name=server.name,
+        transport=server.transport,
+        command=server.command,
+        args=list(server.args or []),
+        env=dict(server.env or {}),
+        url=server.url,
+        headers=dict(server.headers or {}),
+        enabled=bool(server.enabled),
+        timeout_seconds=float(server.timeout_seconds or 30.0),
+        create_date=server.create_date,
+        update_date=server.update_date,
+    )
+
+
+def list_mcp_servers(user_id: int | None = None) -> list[McpServerModel]:
+    """List configured MCP servers, optionally scoped to one user."""
+    with SessionLocal() as session:
+        query = session.query(McpServer)
+        if user_id is not None:
+            query = query.filter_by(user_id=user_id)
+        return [_to_model(server) for server in query.order_by(McpServer.mcp_server_id).all()]
+
+
+def list_enabled_mcp_servers() -> list[McpServerModel]:
+    """List every enabled MCP server (the set mounted into the tool registry)."""
+    with SessionLocal() as session:
+        servers = (
+            session.query(McpServer)
+            .filter_by(enabled=True)
+            .order_by(McpServer.mcp_server_id)
+            .all()
+        )
+        return [_to_model(server) for server in servers]
+
+
+def get_mcp_server(mcp_server_id: int) -> McpServerModel | None:
+    with SessionLocal() as session:
+        server = session.query(McpServer).filter_by(mcp_server_id=mcp_server_id).first()
+        return _to_model(server) if server else None
+
+
+def create_mcp_server(user_id: int, values: dict[str, Any]) -> McpServerModel:
+    with SessionLocal() as session:
+        server = McpServer(
+            user_id=user_id,
+            **{key: values[key] for key in _MUTABLE_FIELDS if key in values},
+        )
+        session.add(server)
+        session.commit()
+        session.refresh(server)
+        return _to_model(server)
+
+
+def update_mcp_server(mcp_server_id: int, updates: dict[str, Any]) -> McpServerModel | None:
+    with SessionLocal() as session:
+        server = session.query(McpServer).filter_by(mcp_server_id=mcp_server_id).first()
+        if not server:
+            return None
+        for key in _MUTABLE_FIELDS:
+            if key in updates:
+                setattr(server, key, updates[key])
+        server.update_date = datetime.datetime.utcnow()
+        session.commit()
+        session.refresh(server)
+        return _to_model(server)
+
+
+def delete_mcp_server(mcp_server_id: int) -> bool:
+    with SessionLocal() as session:
+        server = session.query(McpServer).filter_by(mcp_server_id=mcp_server_id).first()
+        if not server:
+            return False
+        session.delete(server)
+        session.commit()
+        return True

--- a/app/services/adapter_tool_source.py
+++ b/app/services/adapter_tool_source.py
@@ -1,0 +1,99 @@
+"""Bridge adapter reflection schemas into the unified chat ToolRegistry.
+
+This is the migration path off the legacy ``agents.tool_calling.ToolDispatcher``
+split: instead of a second dispatch mechanism, adapter actions become ordinary
+``ToolDefinition`` entries served through a registry source. Bridged tools are
+disabled by default and named ``adapter.<Adapter>.<action>`` so operators must
+opt in per action via ``GEIST_ENABLED_CHAT_TOOLS``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from adapters.async_tool import is_async_tool
+from adapters.base_adapter import BaseAdapter
+from adapters.tool_schema import ToolSchema, enumerate_tool_schemas
+from agents.models.tool_calling import ToolContext, ToolDefinition, ToolExecutionOutput
+
+
+logger = logging.getLogger(__name__)
+
+
+class AdapterToolSource:
+    """Expose initialized adapter instances as schema-validated chat tools."""
+
+    name = "adapters"
+
+    def __init__(
+        self,
+        adapters: list[BaseAdapter],
+        *,
+        enabled_by_default: bool = False,
+        timeout_seconds: float = 30.0,
+    ):
+        self._adapters = list(adapters)
+        self._enabled_by_default = enabled_by_default
+        self._timeout_seconds = timeout_seconds
+
+    def definitions(self) -> list[ToolDefinition]:
+        definitions: list[ToolDefinition] = []
+        for adapter in self._adapters:
+            try:
+                schemas = enumerate_tool_schemas(adapter)
+            except Exception:
+                logger.exception(
+                    "Could not enumerate tool schemas for adapter %s", type(adapter).__name__
+                )
+                continue
+            for schema in schemas:
+                definitions.append(self._definition(adapter, schema))
+        return definitions
+
+    def _definition(self, adapter: BaseAdapter, schema: ToolSchema) -> ToolDefinition:
+        method = getattr(adapter, schema.action)
+
+        def handler(context: ToolContext, arguments: dict) -> ToolExecutionOutput:
+            if is_async_tool(method):
+                output = self._enqueue_async(schema, arguments)
+            else:
+                output = method(**arguments)
+            try:
+                content = json.dumps(output, ensure_ascii=False, default=str)
+            except (TypeError, ValueError):
+                content = str(output)
+            return ToolExecutionOutput(
+                content=content,
+                summary=f"Ran {schema.adapter}.{schema.action}",
+            )
+
+        return ToolDefinition(
+            name=f"adapter.{schema.adapter}.{schema.action}",
+            description=schema.description,
+            arguments_schema=schema.parameters,
+            handler=handler,
+            side_effect="external_write",
+            enabled_by_default=self._enabled_by_default,
+            timeout_seconds=self._timeout_seconds,
+            source_adapter=f"{schema.adapter}.{schema.action}",
+        )
+
+    @staticmethod
+    def _enqueue_async(schema: ToolSchema, arguments: dict) -> dict:
+        from app.services.job_queue import enqueue
+
+        job = enqueue(
+            "tool.call",
+            payload={
+                "adapter": schema.adapter,
+                "function": schema.action,
+                "arguments": arguments,
+            },
+        )
+        return {
+            "async": True,
+            "job_id": job.job_id,
+            "status": "queued",
+            "check_with": "adapter.JobStatusAdapter.check_async_tool",
+        }

--- a/app/services/chat_orchestrator.py
+++ b/app/services/chat_orchestrator.py
@@ -105,6 +105,7 @@ class ChatOrchestrator:
         run_controls: RunControlRegistry | None = None,
         max_rounds: int = 6,
         max_tool_calls: int = 10,
+        doom_loop_threshold: int = 3,
         max_history_entries: int = 20,
         max_history_chars: int = 80_000,
         max_tool_result_chars_total: int = 40_000,
@@ -115,6 +116,7 @@ class ChatOrchestrator:
         self.run_controls = run_controls or RunControlRegistry()
         self.max_rounds = max_rounds
         self.max_tool_calls = max_tool_calls
+        self.doom_loop_threshold = doom_loop_threshold
         self.max_history_entries = max_history_entries
         self.max_history_chars = max_history_chars
         self.max_tool_result_chars_total = max_tool_result_chars_total
@@ -276,6 +278,7 @@ class ChatOrchestrator:
                 "Tool call limit exceeded",
                 "Model backend did not complete its turn",
                 "Model backend returned an invalid event",
+                "Doom loop detected",
             )
         ):
             return message
@@ -364,6 +367,9 @@ class ChatOrchestrator:
                 {"run_id": run.run_id, "chat_id": conversation.chat_id},
             )
 
+            doom_signature: str | None = None
+            doom_count = 0
+
             for _round_number in range(self.max_rounds):
                 if cancellation.is_set():
                     yield ChatStreamEvent("cancelled", cancelled_payload())
@@ -400,6 +406,24 @@ class ChatOrchestrator:
                     raise RuntimeError(f"Tool call limit exceeded ({self.max_tool_calls})")
 
                 for call in completed_turn.tool_calls:
+                    # Interrupt runs stuck re-issuing the same call: the model
+                    # has stopped making progress and each repeat burns tokens
+                    # (and possibly side effects) for an identical answer.
+                    signature = (
+                        f"{call.name}:"
+                        f"{json.dumps(call.arguments, sort_keys=True, default=str)}"
+                    )
+                    if signature == doom_signature:
+                        doom_count += 1
+                    else:
+                        doom_signature = signature
+                        doom_count = 1
+                    if doom_count >= self.doom_loop_threshold:
+                        raise RuntimeError(
+                            f"Doom loop detected: tool '{call.name}' was called "
+                            f"{doom_count} times in a row with identical arguments"
+                        )
+
                     definition = self.registry.get(call.name)
                     requires_approval = bool(definition and definition.requires_approval)
                     proposed = self._tool_state(

--- a/app/services/mcp_client.py
+++ b/app/services/mcp_client.py
@@ -1,0 +1,442 @@
+"""Minimal synchronous MCP (Model Context Protocol) client.
+
+Speaks JSON-RPC 2.0 over the two standard MCP transports:
+
+- ``stdio``: a locally spawned server process, newline-delimited JSON-RPC.
+- ``http``: Streamable HTTP; each request is a POST that may answer with a
+  plain JSON body or a text/event-stream containing the response message.
+
+Only the client surface Geist needs is implemented — ``initialize``,
+``tools/list`` (paginated), and ``tools/call``. Server-initiated requests
+(sampling, elicitation) are answered with JSON-RPC "method not found" so
+well-behaved servers degrade gracefully. Like the provider clients in
+``agents.online_agent``, this intentionally avoids an SDK dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = "2025-06-18"
+CLIENT_INFO = {"name": "geist", "version": "0.1.0"}
+_MAX_TOOL_LIST_PAGES = 25
+
+
+class McpError(RuntimeError):
+    """A transport, protocol, or server-reported MCP failure."""
+
+
+@dataclass(frozen=True)
+class McpServerConfig:
+    """Connection settings for one configured MCP server."""
+
+    server_id: int
+    name: str
+    transport: str  # "stdio" | "http"
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    url: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout_seconds: float = 30.0
+
+    @property
+    def fingerprint(self) -> str:
+        return json.dumps(
+            {
+                "transport": self.transport,
+                "command": self.command,
+                "args": list(self.args),
+                "env": self.env,
+                "url": self.url,
+                "headers": self.headers,
+            },
+            sort_keys=True,
+        )
+
+
+class _StdioTransport:
+    """Newline-delimited JSON-RPC over a spawned server process."""
+
+    def __init__(self, config: McpServerConfig):
+        if not config.command:
+            raise McpError(f"MCP server '{config.name}' has no command configured")
+        try:
+            self._process = subprocess.Popen(
+                [config.command, *config.args],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env={**os.environ, **config.env},
+                text=True,
+                bufsize=1,
+            )
+        except OSError as error:
+            raise McpError(f"Could not start MCP server '{config.name}': {error}") from error
+        self._write_lock = threading.Lock()
+        self._pending: dict[str, dict[str, Any]] = {}
+        self._pending_events: dict[str, threading.Event] = {}
+        self._pending_lock = threading.Lock()
+        self._stderr_tail: deque[str] = deque(maxlen=20)
+        threading.Thread(target=self._read_stdout, daemon=True).start()
+        threading.Thread(target=self._read_stderr, daemon=True).start()
+
+    def _read_stdout(self) -> None:
+        stdout = self._process.stdout
+        if stdout is None:
+            return
+        for line in stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Discarding non-JSON MCP stdio line: %.200s", line)
+                continue
+            self._handle_message(message)
+        # EOF: wake every waiter so requests fail fast instead of timing out.
+        with self._pending_lock:
+            for event in self._pending_events.values():
+                event.set()
+
+    def _read_stderr(self) -> None:
+        stderr = self._process.stderr
+        if stderr is None:
+            return
+        for line in stderr:
+            self._stderr_tail.append(line.rstrip())
+
+    def _handle_message(self, message: dict[str, Any]) -> None:
+        message_id = message.get("id")
+        if message_id is not None and "method" in message:
+            # Server-initiated request (sampling/elicitation): decline politely.
+            self._write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "error": {"code": -32601, "message": "Method not supported by this client"},
+                }
+            )
+            return
+        if message_id is None:
+            return  # notification
+        key = str(message_id)
+        with self._pending_lock:
+            event = self._pending_events.get(key)
+            if event is not None:
+                self._pending[key] = message
+                event.set()
+
+    def _write(self, message: dict[str, Any]) -> None:
+        stdin = self._process.stdin
+        if stdin is None or self._process.poll() is not None:
+            raise McpError(f"MCP server process exited: {self._stderr_summary()}")
+        payload = json.dumps(message, ensure_ascii=False)
+        with self._write_lock:
+            try:
+                stdin.write(payload + "\n")
+                stdin.flush()
+            except (BrokenPipeError, OSError) as error:
+                raise McpError(
+                    f"MCP server pipe closed: {self._stderr_summary()}"
+                ) from error
+
+    def _stderr_summary(self) -> str:
+        return " | ".join(self._stderr_tail) or "no stderr output"
+
+    def request(self, method: str, params: dict[str, Any] | None, timeout: float) -> Any:
+        request_id = uuid.uuid4().hex
+        event = threading.Event()
+        with self._pending_lock:
+            self._pending_events[request_id] = event
+        try:
+            message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+            if params is not None:
+                message["params"] = params
+            self._write(message)
+            if not event.wait(timeout):
+                raise McpError(f"MCP request '{method}' timed out after {timeout:g}s")
+            with self._pending_lock:
+                response = self._pending.pop(request_id, None)
+            if response is None:
+                raise McpError(
+                    f"MCP server closed the connection during '{method}': "
+                    f"{self._stderr_summary()}"
+                )
+            return _unwrap_response(response, method)
+        finally:
+            with self._pending_lock:
+                self._pending_events.pop(request_id, None)
+                self._pending.pop(request_id, None)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        message: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self._write(message)
+
+    def close(self) -> None:
+        try:
+            if self._process.poll() is None:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+        except OSError:
+            logger.warning("Could not terminate MCP server process", exc_info=True)
+
+
+class _HttpTransport:
+    """Streamable HTTP: JSON-RPC over POST with JSON or SSE responses."""
+
+    def __init__(self, config: McpServerConfig):
+        if not config.url:
+            raise McpError(f"MCP server '{config.name}' has no URL configured")
+        self._url = config.url
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                **config.headers,
+            }
+        )
+        self._mcp_session_id: str | None = None
+
+    def request(self, method: str, params: dict[str, Any] | None, timeout: float) -> Any:
+        request_id = uuid.uuid4().hex
+        message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        response = self._post(message, timeout, stream=True)
+        with response:
+            session_id = response.headers.get("Mcp-Session-Id")
+            if session_id:
+                self._mcp_session_id = session_id
+                self._session.headers["Mcp-Session-Id"] = session_id
+            content_type = (response.headers.get("Content-Type") or "").split(";")[0].strip()
+            if content_type == "text/event-stream":
+                payload = self._read_sse_response(response, request_id, method)
+            else:
+                try:
+                    payload = response.json()
+                except ValueError as error:
+                    raise McpError(
+                        f"MCP server returned a non-JSON response to '{method}'"
+                    ) from error
+        return _unwrap_response(payload, method)
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        message: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        response = self._post(message, timeout=10, stream=False)
+        response.close()
+
+    def _post(self, message: dict[str, Any], timeout: float, stream: bool) -> requests.Response:
+        try:
+            response = self._session.post(
+                self._url,
+                data=json.dumps(message, ensure_ascii=False).encode("utf-8"),
+                timeout=timeout,
+                stream=stream,
+            )
+        except requests.RequestException as error:
+            raise McpError(f"MCP server request failed: {error}") from error
+        if response.status_code >= 400:
+            body = response.text[:500]
+            response.close()
+            raise McpError(f"MCP server returned HTTP {response.status_code}: {body}")
+        return response
+
+    @staticmethod
+    def _read_sse_response(
+        response: requests.Response, request_id: str, method: str
+    ) -> dict[str, Any]:
+        data_lines: list[str] = []
+        for raw_line in response.iter_lines(decode_unicode=True):
+            if raw_line is None:
+                continue
+            line = raw_line.rstrip("\r") if isinstance(raw_line, str) else ""
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+                continue
+            if line:
+                continue  # other SSE fields (event:, id:) are irrelevant here
+            if not data_lines:
+                continue
+            data = "\n".join(data_lines)
+            data_lines = []
+            try:
+                message = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if (
+                isinstance(message, dict)
+                and message.get("id") == request_id
+                and ("result" in message or "error" in message)
+            ):
+                return cast(dict[str, Any], message)
+        raise McpError(f"MCP event stream ended without a response to '{method}'")
+
+    def close(self) -> None:
+        self._session.close()
+
+
+def _unwrap_response(message: Any, method: str) -> Any:
+    if not isinstance(message, dict):
+        raise McpError(f"MCP server returned an invalid response to '{method}'")
+    if "error" in message:
+        error = message["error"] or {}
+        raise McpError(
+            f"MCP server error for '{method}': "
+            f"{error.get('message', 'unknown error')} (code {error.get('code')})"
+        )
+    return message.get("result")
+
+
+class McpConnection:
+    """One initialized MCP session over either transport."""
+
+    def __init__(self, config: McpServerConfig):
+        self.config = config
+        if config.transport == "stdio":
+            self._transport: _StdioTransport | _HttpTransport = _StdioTransport(config)
+        elif config.transport == "http":
+            self._transport = _HttpTransport(config)
+        else:
+            raise McpError(f"Unknown MCP transport '{config.transport}'")
+        try:
+            result = self._transport.request(
+                "initialize",
+                {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": CLIENT_INFO,
+                },
+                timeout=config.timeout_seconds,
+            )
+            self.server_info = (result or {}).get("serverInfo", {})
+            self.instructions = (result or {}).get("instructions")
+            negotiated = (result or {}).get("protocolVersion") or PROTOCOL_VERSION
+            if isinstance(self._transport, _HttpTransport):
+                self._transport._session.headers["MCP-Protocol-Version"] = str(negotiated)
+            self._transport.notify("notifications/initialized")
+        except Exception:
+            self._transport.close()
+            raise
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        tools: list[dict[str, Any]] = []
+        cursor: str | None = None
+        for _ in range(_MAX_TOOL_LIST_PAGES):
+            params: dict[str, Any] = {"cursor": cursor} if cursor else {}
+            result = self._transport.request(
+                "tools/list", params, timeout=self.config.timeout_seconds
+            )
+            page = (result or {}).get("tools") or []
+            tools.extend(tool for tool in page if isinstance(tool, dict))
+            cursor = (result or {}).get("nextCursor")
+            if not cursor:
+                break
+        return tools
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        result = self._transport.request(
+            "tools/call",
+            {"name": name, "arguments": arguments},
+            timeout=self.config.timeout_seconds,
+        )
+        result = result or {}
+        parts: list[str] = []
+        for item in result.get("content") or []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+            else:
+                parts.append(f"[unsupported {item.get('type', 'unknown')} content omitted]")
+        if not parts and result.get("structuredContent") is not None:
+            parts.append(json.dumps(result["structuredContent"], ensure_ascii=False))
+        content = "\n".join(part for part in parts if part)
+        if result.get("isError"):
+            raise McpError(content or f"MCP tool '{name}' reported an error")
+        return content
+
+    def close(self) -> None:
+        self._transport.close()
+
+
+class McpClientManager:
+    """Caches one live connection per configured server, reconnecting on change."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._connections: dict[int, McpConnection] = {}
+
+    def _connection(self, config: McpServerConfig) -> McpConnection:
+        with self._lock:
+            existing = self._connections.get(config.server_id)
+            if existing is not None and existing.config.fingerprint == config.fingerprint:
+                return existing
+            if existing is not None:
+                existing.close()
+                del self._connections[config.server_id]
+        connection = McpConnection(config)
+        with self._lock:
+            current = self._connections.get(config.server_id)
+            if current is not None and current.config.fingerprint == config.fingerprint:
+                connection.close()
+                return current
+            if current is not None:
+                current.close()
+            self._connections[config.server_id] = connection
+        return connection
+
+    def list_tools(self, config: McpServerConfig) -> list[dict[str, Any]]:
+        try:
+            return self._connection(config).list_tools()
+        except McpError:
+            self.invalidate(config.server_id)
+            raise
+        except Exception as error:
+            self.invalidate(config.server_id)
+            raise McpError(f"MCP server '{config.name}' failed: {error}") from error
+
+    def call_tool(self, config: McpServerConfig, name: str, arguments: dict[str, Any]) -> str:
+        try:
+            return self._connection(config).call_tool(name, arguments)
+        except McpError:
+            self.invalidate(config.server_id)
+            raise
+        except Exception as error:
+            self.invalidate(config.server_id)
+            raise McpError(f"MCP server '{config.name}' failed: {error}") from error
+
+    def invalidate(self, server_id: int) -> None:
+        with self._lock:
+            connection = self._connections.pop(server_id, None)
+        if connection is not None:
+            connection.close()
+
+    def shutdown(self) -> None:
+        with self._lock:
+            connections = list(self._connections.values())
+            self._connections.clear()
+        for connection in connections:
+            connection.close()

--- a/app/services/mcp_tool_source.py
+++ b/app/services/mcp_tool_source.py
@@ -1,0 +1,146 @@
+"""Mount enabled MCP servers' tools into the unified chat ToolRegistry.
+
+Each enabled server contributes its tools as ``mcp.<server>.<tool>``
+definitions with the server-provided JSON input schema. Discovery results are
+cached briefly so chat turns do not hammer servers; configuration changes
+invalidate the cache immediately. A failing server logs and contributes no
+tools instead of breaking chat.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from agents.models.tool_calling import ToolContext, ToolDefinition, ToolExecutionOutput
+from app.models.database.mcp_server import McpServerModel, list_enabled_mcp_servers
+from app.services.mcp_client import McpClientManager, McpError, McpServerConfig
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_TTL_SECONDS = 60.0
+
+
+def config_from_model(server: McpServerModel) -> McpServerConfig:
+    return McpServerConfig(
+        server_id=server.mcp_server_id,
+        name=server.name,
+        transport=server.transport,
+        command=server.command,
+        args=tuple(server.args or []),
+        env=dict(server.env or {}),
+        url=server.url,
+        headers=dict(server.headers or {}),
+        timeout_seconds=server.timeout_seconds,
+    )
+
+
+class McpToolSource:
+    """ToolSource serving definitions discovered from enabled MCP servers."""
+
+    name = "mcp"
+
+    def __init__(
+        self,
+        manager: McpClientManager,
+        servers_loader: Callable[[], list[McpServerModel]] = list_enabled_mcp_servers,
+        cache_ttl_seconds: float = _DEFAULT_CACHE_TTL_SECONDS,
+    ):
+        self._manager = manager
+        self._servers_loader = servers_loader
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._lock = threading.Lock()
+        self._cached: list[ToolDefinition] | None = None
+        self._cache_expires_at = 0.0
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._cached = None
+            self._cache_expires_at = 0.0
+
+    def definitions(self) -> list[ToolDefinition]:
+        with self._lock:
+            if self._cached is not None and time.monotonic() < self._cache_expires_at:
+                return list(self._cached)
+
+        definitions: list[ToolDefinition] = []
+        try:
+            servers = self._servers_loader()
+        except Exception:
+            logger.exception("Could not load MCP server configurations")
+            servers = []
+        for server in servers:
+            config = config_from_model(server)
+            try:
+                tools = self._manager.list_tools(config)
+            except McpError as error:
+                logger.warning("Skipping MCP server '%s': %s", server.name, error)
+                continue
+            for tool in tools:
+                definition = self._definition(config, tool)
+                if definition is not None:
+                    definitions.append(definition)
+
+        with self._lock:
+            self._cached = list(definitions)
+            self._cache_expires_at = time.monotonic() + self._cache_ttl_seconds
+        return definitions
+
+    def _definition(self, config: McpServerConfig, tool: dict) -> ToolDefinition | None:
+        name_value = tool.get("name")
+        if not isinstance(name_value, str) or not name_value:
+            logger.warning("MCP server '%s' returned a tool without a name", config.name)
+            return None
+        tool_name: str = name_value
+        schema = tool.get("inputSchema")
+        if not isinstance(schema, dict):
+            schema = {"type": "object", "properties": {}}
+        description = tool.get("description") or tool_name
+
+        def handler(
+            context: ToolContext,
+            arguments: dict,
+            *,
+            _config: McpServerConfig = config,
+            _tool: str = tool_name,
+        ) -> ToolExecutionOutput:
+            content = self._manager.call_tool(_config, _tool, arguments)
+            return ToolExecutionOutput(
+                content=content or "(empty tool result)",
+                summary=f"Called {_tool} on MCP server {_config.name}",
+            )
+
+        return ToolDefinition(
+            name=f"mcp.{config.name}.{tool_name}",
+            description=f"[MCP: {config.name}] {description}",
+            arguments_schema=schema,
+            handler=handler,
+            side_effect="external_write",
+            timeout_seconds=config.timeout_seconds + 5.0,
+            source_adapter=f"mcp:{config.name}",
+        )
+
+
+_manager: McpClientManager | None = None
+_source: McpToolSource | None = None
+_singleton_lock = threading.Lock()
+
+
+def get_mcp_manager() -> McpClientManager:
+    global _manager
+    with _singleton_lock:
+        if _manager is None:
+            _manager = McpClientManager()
+        return _manager
+
+
+def get_mcp_tool_source() -> McpToolSource:
+    global _source
+    manager = get_mcp_manager()
+    with _singleton_lock:
+        if _source is None:
+            _source = McpToolSource(manager)
+        return _source

--- a/app/services/tool_registry.py
+++ b/app/services/tool_registry.py
@@ -7,11 +7,12 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
-from typing import Literal
+from typing import Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from adapters.image_generation_adapter import ImageGenerationAdapter
+from adapters.job_status_adapter import JobStatusAdapter
 from adapters.markdown_file_adapter import MarkdownFileAdapter
 from adapters.search_adapter import SearchAdapter
 from agents.models.tool_calling import (
@@ -76,6 +77,57 @@ class SmsSendArguments(StrictToolArguments):
     idempotency_key: str = Field(min_length=8, max_length=128)
 
 
+@runtime_checkable
+class ToolSource(Protocol):
+    """A dynamic provider of tool definitions (MCP servers, adapter bridges).
+
+    Sources are consulted on every catalog/dispatch so their tool lists can
+    change at runtime without rebuilding the registry. A failing source must
+    degrade to an empty list rather than break chat.
+    """
+
+    name: str
+
+    def definitions(self) -> list[ToolDefinition]: ...
+
+
+_JSON_TYPE_CHECKS: dict[str, type | tuple[type, ...]] = {
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def _schema_argument_errors(arguments: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+    """Minimal structural validation for raw-JSON-schema tools.
+
+    Required keys and primitive property types are checked here so obviously
+    malformed calls fail fast with a message the model can act on; full
+    constraint enforcement stays with the tool's own backend.
+    """
+    errors: list[str] = []
+    properties = schema.get("properties") or {}
+    for name in schema.get("required") or []:
+        if name not in arguments:
+            errors.append(f"Missing required argument '{name}'")
+    for name, value in arguments.items():
+        declared = properties.get(name)
+        if not isinstance(declared, dict):
+            continue
+        expected_type = declared.get("type")
+        if not isinstance(expected_type, str):
+            continue
+        expected = _JSON_TYPE_CHECKS.get(expected_type)
+        if expected is None or value is None:
+            continue
+        if isinstance(value, bool) and expected_type in ("integer", "number") or not isinstance(value, expected):
+            errors.append(f"Argument '{name}' must be of type {expected_type}")
+    return errors
+
+
 class ToolRegistry:
     def __init__(
         self,
@@ -83,6 +135,7 @@ class ToolRegistry:
         max_concurrent_executions: int = 4,
     ):
         self._definitions: dict[str, ToolDefinition] = {}
+        self._sources: list[ToolSource] = []
         self._explicitly_enabled = explicitly_enabled or set()
         self._executor = ThreadPoolExecutor(
             max_workers=max_concurrent_executions,
@@ -94,18 +147,50 @@ class ToolRegistry:
             raise ValueError(f"Tool already registered: {definition.name}")
         self._definitions[definition.name] = definition
 
+    def add_source(self, source: ToolSource) -> None:
+        if any(existing.name == source.name for existing in self._sources):
+            raise ValueError(f"Tool source already registered: {source.name}")
+        self._sources.append(source)
+
+    def remove_source(self, name: str) -> None:
+        self._sources = [source for source in self._sources if source.name != name]
+
+    def _source_definitions(self) -> dict[str, ToolDefinition]:
+        merged: dict[str, ToolDefinition] = {}
+        for source in self._sources:
+            try:
+                definitions = source.definitions()
+            except Exception:
+                logger.exception("Tool source %s failed; skipping its tools", source.name)
+                continue
+            for definition in definitions:
+                if definition.name in self._definitions or definition.name in merged:
+                    logger.warning(
+                        "Tool source %s tool %s collides with an existing tool; skipping",
+                        source.name,
+                        definition.name,
+                    )
+                    continue
+                merged[definition.name] = definition
+        return merged
+
     def get(self, name: str) -> ToolDefinition | None:
-        return self._definitions.get(name)
+        definition = self._definitions.get(name)
+        if definition is not None:
+            return definition
+        if not self._sources:
+            return None
+        return self._source_definitions().get(name)
 
     def catalog(self) -> list[ToolDefinition]:
-        return list(self._definitions.values())
+        return list(self._definitions.values()) + list(self._source_definitions().values())
 
     def is_enabled(self, definition: ToolDefinition) -> bool:
         return definition.enabled_by_default or definition.name in self._explicitly_enabled
 
     def definitions_for_context(self, context: ToolContext) -> list[ToolDefinition]:
         definitions = []
-        for definition in self._definitions.values():
+        for definition in self.catalog():
             enabled = self.is_enabled(definition)
             available = definition.availability is None or definition.availability(context)
             if enabled and available:
@@ -143,17 +228,31 @@ class ToolRegistry:
                 error="approval_required",
             )
 
-        try:
-            arguments = definition.arguments_model.model_validate(call.arguments)
-        except ValidationError as error:
-            return ToolResult(
-                call=call,
-                status="failed",
-                content=f"Invalid arguments for {call.name}: {error}",
-                error="invalid_arguments",
-            )
+        arguments: Any
+        if definition.arguments_model is not None:
+            try:
+                arguments = definition.arguments_model.model_validate(call.arguments)
+            except ValidationError as error:
+                return ToolResult(
+                    call=call,
+                    status="failed",
+                    content=f"Invalid arguments for {call.name}: {error}",
+                    error="invalid_arguments",
+                )
+        else:
+            errors = _schema_argument_errors(call.arguments, definition.parameters_schema())
+            if errors:
+                return ToolResult(
+                    call=call,
+                    status="failed",
+                    content=f"Invalid arguments for {call.name}: {'; '.join(errors)}",
+                    error="invalid_arguments",
+                )
+            arguments = call.arguments
 
-        future = self._executor.submit(definition.handler, context, arguments)
+        handler = definition.handler
+        assert handler is not None  # guaranteed by ToolDefinition.__post_init__
+        future = self._executor.submit(handler, context, arguments)
         try:
             output = future.result(timeout=definition.timeout_seconds)
         except FutureTimeoutError:
@@ -393,4 +492,12 @@ def build_default_tool_registry() -> ToolRegistry:
             availability=lambda context: False,
         )
     )
+
+    # Reflected adapter actions ride through the same registry as the curated
+    # tools above (one registry, several sources) but stay disabled until an
+    # operator opts in by name via GEIST_ENABLED_CHAT_TOOLS, e.g.
+    # adapter.JobStatusAdapter.check_async_tool.
+    from app.services.adapter_tool_source import AdapterToolSource
+
+    registry.add_source(AdapterToolSource([JobStatusAdapter()]))
     return registry

--- a/client/geist/src/Components/McpServersSection.tsx
+++ b/client/geist/src/Components/McpServersSection.tsx
@@ -1,0 +1,407 @@
+import React, { useState } from 'react';
+import SettingsSelect from './SettingsSelect';
+import SettingsToggle from './SettingsToggle';
+import {
+  McpServer,
+  McpServerInput,
+  McpTestResult,
+  useMcpServers,
+} from '../Hooks/useMcpServers';
+
+const transportOptions = [
+  { value: 'stdio', label: 'Local process (stdio)' },
+  { value: 'http', label: 'Remote server (HTTP)' },
+];
+
+interface FormState {
+  name: string;
+  transport: 'stdio' | 'http';
+  command: string;
+  args: string;
+  env: string;
+  url: string;
+  headers: string;
+  timeout_seconds: string;
+}
+
+const emptyForm: FormState = {
+  name: '',
+  transport: 'stdio',
+  command: '',
+  args: '',
+  env: '',
+  url: '',
+  headers: '',
+  timeout_seconds: '30',
+};
+
+const linesToList = (value: string): string[] =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const linesToRecord = (value: string): Record<string, string> => {
+  const record: Record<string, string> = {};
+  for (const line of linesToList(value)) {
+    const separator = line.indexOf('=');
+    if (separator > 0) {
+      record[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+    }
+  }
+  return record;
+};
+
+const recordToLines = (record: Record<string, string>): string =>
+  Object.entries(record)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+
+const formFromServer = (server: McpServer): FormState => ({
+  name: server.name,
+  transport: server.transport,
+  command: server.command ?? '',
+  args: (server.args || []).join('\n'),
+  env: recordToLines(server.env || {}),
+  url: server.url ?? '',
+  headers: recordToLines(server.headers || {}),
+  timeout_seconds: String(server.timeout_seconds),
+});
+
+const inputFromForm = (form: FormState): McpServerInput => ({
+  name: form.name.trim(),
+  transport: form.transport,
+  command: form.transport === 'stdio' ? form.command.trim() : null,
+  args: form.transport === 'stdio' ? linesToList(form.args) : [],
+  env: form.transport === 'stdio' ? linesToRecord(form.env) : {},
+  url: form.transport === 'http' ? form.url.trim() : null,
+  headers: form.transport === 'http' ? linesToRecord(form.headers) : {},
+  timeout_seconds: Number(form.timeout_seconds) || 30,
+});
+
+const McpServersSection: React.FC = () => {
+  const {
+    servers,
+    loading,
+    error,
+    createServer,
+    updateServer,
+    deleteServer,
+    testServer,
+  } = useMcpServers();
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testingId, setTestingId] = useState<number | null>(null);
+  const [testResults, setTestResults] = useState<Record<number, McpTestResult>>({});
+
+  const updateForm = (key: keyof FormState, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const openCreateForm = () => {
+    setForm(emptyForm);
+    setEditingId(null);
+    setFormError(null);
+    setFormOpen(true);
+  };
+
+  const openEditForm = (server: McpServer) => {
+    setForm(formFromServer(server));
+    setEditingId(server.mcp_server_id);
+    setFormError(null);
+    setFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setFormOpen(false);
+    setEditingId(null);
+    setForm(emptyForm);
+    setFormError(null);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      setSaving(true);
+      setFormError(null);
+      const input = inputFromForm(form);
+      if (!input.name) {
+        throw new Error('Name is required');
+      }
+      if (input.transport === 'stdio' && !input.command) {
+        throw new Error('Local servers require a command');
+      }
+      if (input.transport === 'http' && !input.url) {
+        throw new Error('Remote servers require a URL');
+      }
+      if (editingId !== null) {
+        await updateServer(editingId, input);
+      } else {
+        await createServer(input);
+      }
+      closeForm();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to save MCP server');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (server: McpServer) => {
+    if (!window.confirm(`Delete MCP server "${server.name}"? Its tools will disappear from chat.`)) {
+      return;
+    }
+    try {
+      await deleteServer(server.mcp_server_id);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to delete MCP server');
+    }
+  };
+
+  const handleToggleEnabled = async (server: McpServer, enabled: boolean) => {
+    try {
+      await updateServer(server.mcp_server_id, { enabled });
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to update MCP server');
+    }
+  };
+
+  const handleTest = async (server: McpServer) => {
+    try {
+      setTestingId(server.mcp_server_id);
+      const result = await testServer(server.mcp_server_id);
+      setTestResults((prev) => ({ ...prev, [server.mcp_server_id]: result }));
+    } catch (err) {
+      setTestResults((prev) => ({
+        ...prev,
+        [server.mcp_server_id]: {
+          ok: false,
+          error: err instanceof Error ? err.message : 'Connection test failed',
+          tools: [],
+        },
+      }));
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  return (
+    <section className="settings-section">
+      <header className="settings-section-header">
+        <h3>MCP Servers</h3>
+        <p>
+          Connect Model Context Protocol servers to add their tools to chat. Tools from
+          enabled servers appear to the model as mcp.&lt;server&gt;.&lt;tool&gt;.
+        </p>
+      </header>
+
+      {error && <div className="notice notice-error">{error}</div>}
+      {formError && !formOpen && <div className="notice notice-error">{formError}</div>}
+
+      {loading ? (
+        <div className="empty-state">Loading MCP servers...</div>
+      ) : servers.length === 0 && !formOpen ? (
+        <div className="empty-state">No MCP servers configured yet.</div>
+      ) : (
+        <ul className="mcp-server-list" data-testid="mcp-server-list">
+          {servers.map((server) => {
+            const testResult = testResults[server.mcp_server_id];
+            return (
+              <li key={server.mcp_server_id} className="mcp-server-item settings-field">
+                <div className="mcp-server-row">
+                  <div className="mcp-server-copy">
+                    <span className="settings-label">{server.name}</span>
+                    <p className="settings-description">
+                      {server.transport === 'stdio'
+                        ? `${server.command ?? ''} ${(server.args || []).join(' ')}`.trim()
+                        : server.url}
+                    </p>
+                  </div>
+                  <div className="mcp-server-actions">
+                    <button
+                      className="button button-small"
+                      type="button"
+                      disabled={testingId === server.mcp_server_id}
+                      onClick={() => void handleTest(server)}
+                    >
+                      {testingId === server.mcp_server_id ? 'Testing...' : 'Test'}
+                    </button>
+                    <button
+                      className="button button-small"
+                      type="button"
+                      onClick={() => openEditForm(server)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="button button-small"
+                      type="button"
+                      onClick={() => void handleDelete(server)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                <SettingsToggle
+                  label="Enabled"
+                  checked={server.enabled}
+                  onChange={(checked) => void handleToggleEnabled(server, checked)}
+                  description="Only enabled servers expose tools to chat."
+                />
+                {testResult && (
+                  <div
+                    className={`notice ${testResult.ok ? 'notice-success' : 'notice-error'}`}
+                    data-testid={`mcp-test-result-${server.mcp_server_id}`}
+                  >
+                    {testResult.ok ? (
+                      <span>
+                        Connected. {testResult.tools.length} tool
+                        {testResult.tools.length === 1 ? '' : 's'} available
+                        {testResult.tools.length > 0 && (
+                          <>: {testResult.tools.map((tool) => tool.name).join(', ')}</>
+                        )}
+                      </span>
+                    ) : (
+                      <span>Connection failed: {testResult.error}</span>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {formOpen ? (
+        <div className="mcp-server-form" data-testid="mcp-server-form">
+          <header className="settings-section-header">
+            <h3>{editingId !== null ? 'Edit MCP Server' : 'Add MCP Server'}</h3>
+          </header>
+
+          {formError && <div className="notice notice-error">{formError}</div>}
+
+          <div className="settings-field">
+            <label className="settings-label" htmlFor="mcp-name">Name</label>
+            <p className="settings-description">
+              Letters, numbers, dashes, and underscores. Used to namespace the server's tools.
+            </p>
+            <input
+              id="mcp-name"
+              className="form-control"
+              type="text"
+              value={form.name}
+              onChange={(e) => updateForm('name', e.target.value)}
+            />
+          </div>
+
+          <SettingsSelect
+            label="Transport"
+            value={form.transport}
+            options={transportOptions}
+            onChange={(value) => updateForm('transport', value)}
+            description="Local servers are spawned as a process; remote servers speak streamable HTTP."
+          />
+
+          {form.transport === 'stdio' ? (
+            <>
+              <div className="settings-field">
+                <label className="settings-label" htmlFor="mcp-command">Command</label>
+                <input
+                  id="mcp-command"
+                  className="form-control"
+                  type="text"
+                  placeholder="npx"
+                  value={form.command}
+                  onChange={(e) => updateForm('command', e.target.value)}
+                />
+              </div>
+              <div className="settings-field">
+                <label className="settings-label" htmlFor="mcp-args">Arguments (one per line)</label>
+                <textarea
+                  id="mcp-args"
+                  className="form-control"
+                  rows={3}
+                  placeholder={'-y\n@modelcontextprotocol/server-filesystem'}
+                  value={form.args}
+                  onChange={(e) => updateForm('args', e.target.value)}
+                />
+              </div>
+              <div className="settings-field">
+                <label className="settings-label" htmlFor="mcp-env">
+                  Environment variables (KEY=value, one per line)
+                </label>
+                <textarea
+                  id="mcp-env"
+                  className="form-control"
+                  rows={2}
+                  value={form.env}
+                  onChange={(e) => updateForm('env', e.target.value)}
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="settings-field">
+                <label className="settings-label" htmlFor="mcp-url">Server URL</label>
+                <input
+                  id="mcp-url"
+                  className="form-control"
+                  type="text"
+                  placeholder="https://example.com/mcp"
+                  value={form.url}
+                  onChange={(e) => updateForm('url', e.target.value)}
+                />
+              </div>
+              <div className="settings-field">
+                <label className="settings-label" htmlFor="mcp-headers">
+                  Headers (KEY=value, one per line)
+                </label>
+                <textarea
+                  id="mcp-headers"
+                  className="form-control"
+                  rows={2}
+                  placeholder="Authorization=Bearer my-token"
+                  value={form.headers}
+                  onChange={(e) => updateForm('headers', e.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          <div className="settings-field">
+            <label className="settings-label" htmlFor="mcp-timeout">Timeout (seconds)</label>
+            <input
+              id="mcp-timeout"
+              className="form-control"
+              type="number"
+              min={1}
+              max={600}
+              value={form.timeout_seconds}
+              onChange={(e) => updateForm('timeout_seconds', e.target.value)}
+            />
+          </div>
+
+          <div className="mcp-server-actions">
+            <button className="button" type="button" disabled={saving} onClick={() => void handleSubmit()}>
+              {saving ? 'Saving...' : editingId !== null ? 'Save Server' : 'Add Server'}
+            </button>
+            <button className="button button-small" type="button" onClick={closeForm}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mcp-server-actions">
+          <button className="button" type="button" onClick={openCreateForm}>
+            Add MCP Server
+          </button>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default McpServersSection;

--- a/client/geist/src/Components/__tests__/McpServersSection.test.tsx
+++ b/client/geist/src/Components/__tests__/McpServersSection.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import McpServersSection from '../McpServersSection';
+
+const stdioServer = {
+  mcp_server_id: 1,
+  user_id: 1,
+  name: 'filesystem',
+  transport: 'stdio',
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-filesystem'],
+  env: {},
+  url: null,
+  headers: {},
+  enabled: true,
+  timeout_seconds: 30,
+  create_date: '2026-07-28T00:00:00Z',
+  update_date: '2026-07-28T00:00:00Z',
+};
+
+const jsonResponse = (body: any, status = 200) =>
+  Promise.resolve({
+    ok: status < 400,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+describe('McpServersSection', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('renders the configured servers returned by the API', async () => {
+    global.fetch = jest.fn(() => jsonResponse([stdioServer])) as any;
+
+    render(<McpServersSection />);
+
+    expect(await screen.findByText('filesystem')).toBeInTheDocument();
+    expect(
+      screen.getByText('npx -y @modelcontextprotocol/server-filesystem')
+    ).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/api/v1/mcp/servers');
+  });
+
+  it('shows an empty state when no servers are configured', async () => {
+    global.fetch = jest.fn(() => jsonResponse([])) as any;
+
+    render(<McpServersSection />);
+
+    expect(await screen.findByText('No MCP servers configured yet.')).toBeInTheDocument();
+  });
+
+  it('creates a server through the form', async () => {
+    const fetchMock = jest.fn((url: string, options?: RequestInit) => {
+      if (url === '/api/v1/mcp/servers' && options?.method === 'POST') {
+        return jsonResponse({ ...stdioServer, mcp_server_id: 2, name: 'my-server' }, 201);
+      }
+      return jsonResponse([]);
+    });
+    global.fetch = fetchMock as any;
+
+    render(<McpServersSection />);
+    await screen.findByText('No MCP servers configured yet.');
+
+    fireEvent.click(screen.getByText('Add MCP Server'));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-server' } });
+    fireEvent.change(screen.getByLabelText('Command'), { target: { value: 'npx' } });
+    fireEvent.click(screen.getByText('Add Server'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/mcp/servers',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+    const [, options] = fetchMock.mock.calls.find(
+      ([url, opts]: [string, RequestInit?]) => opts?.method === 'POST'
+    )!;
+    expect(JSON.parse((options as RequestInit).body as string)).toMatchObject({
+      name: 'my-server',
+      transport: 'stdio',
+      command: 'npx',
+    });
+  });
+
+  it('requires a command before submitting a stdio server', async () => {
+    global.fetch = jest.fn(() => jsonResponse([])) as any;
+
+    render(<McpServersSection />);
+    await screen.findByText('No MCP servers configured yet.');
+
+    fireEvent.click(screen.getByText('Add MCP Server'));
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'my-server' } });
+    fireEvent.click(screen.getByText('Add Server'));
+
+    expect(await screen.findByText('Local servers require a command')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(1); // only the initial list fetch
+  });
+
+  it('runs a connection test and lists the discovered tools', async () => {
+    const fetchMock = jest.fn((url: string, options?: RequestInit) => {
+      if (url.endsWith('/test')) {
+        return jsonResponse({
+          ok: true,
+          error: null,
+          tools: [
+            { name: 'read_file', description: '' },
+            { name: 'write_file', description: '' },
+          ],
+        });
+      }
+      return jsonResponse([stdioServer]);
+    });
+    global.fetch = fetchMock as any;
+
+    render(<McpServersSection />);
+    await screen.findByText('filesystem');
+
+    fireEvent.click(screen.getByText('Test'));
+
+    const result = await screen.findByTestId('mcp-test-result-1');
+    expect(result.textContent).toContain('2 tools available');
+    expect(result.textContent).toContain('read_file');
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/mcp/servers/1/test', { method: 'POST' });
+  });
+
+  it('surfaces a failed connection test', async () => {
+    const fetchMock = jest.fn((url: string) => {
+      if (url.endsWith('/test')) {
+        return jsonResponse({ ok: false, error: 'Could not start MCP server', tools: [] });
+      }
+      return jsonResponse([stdioServer]);
+    });
+    global.fetch = fetchMock as any;
+
+    render(<McpServersSection />);
+    await screen.findByText('filesystem');
+
+    fireEvent.click(screen.getByText('Test'));
+
+    const result = await screen.findByTestId('mcp-test-result-1');
+    expect(result.textContent).toContain('Connection failed: Could not start MCP server');
+  });
+});

--- a/client/geist/src/Hooks/useMcpServers.tsx
+++ b/client/geist/src/Hooks/useMcpServers.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface McpServer {
+  mcp_server_id: number;
+  user_id: number;
+  name: string;
+  transport: 'stdio' | 'http';
+  command: string | null;
+  args: string[];
+  env: Record<string, string>;
+  url: string | null;
+  headers: Record<string, string>;
+  enabled: boolean;
+  timeout_seconds: number;
+  create_date: string;
+  update_date: string;
+}
+
+export interface McpServerInput {
+  name: string;
+  transport: 'stdio' | 'http';
+  command?: string | null;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string | null;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+  timeout_seconds?: number;
+}
+
+export interface McpToolInfo {
+  name: string;
+  description: string;
+}
+
+export interface McpTestResult {
+  ok: boolean;
+  error?: string | null;
+  tools: McpToolInfo[];
+}
+
+const BASE_URL = '/api/v1/mcp';
+
+const parseError = async (response: Response): Promise<string> => {
+  try {
+    const body = await response.json();
+    if (typeof body?.detail === 'string') {
+      return body.detail;
+    }
+    return JSON.stringify(body?.detail ?? body);
+  } catch {
+    return `Request failed with status ${response.status}`;
+  }
+};
+
+export interface UseMcpServersReturn {
+  servers: McpServer[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  createServer: (input: McpServerInput) => Promise<McpServer>;
+  updateServer: (id: number, updates: Partial<McpServerInput>) => Promise<McpServer>;
+  deleteServer: (id: number) => Promise<void>;
+  testServer: (id: number) => Promise<McpTestResult>;
+}
+
+export const useMcpServers = (): UseMcpServersReturn => {
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetch(`${BASE_URL}/servers`);
+      if (!response.ok) {
+        throw new Error(await parseError(response));
+      }
+      setServers(await response.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load MCP servers');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  const createServer = useCallback(
+    async (input: McpServerInput): Promise<McpServer> => {
+      const response = await fetch(`${BASE_URL}/servers`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!response.ok) {
+        throw new Error(await parseError(response));
+      }
+      const created = await response.json();
+      await refetch();
+      return created;
+    },
+    [refetch]
+  );
+
+  const updateServer = useCallback(
+    async (id: number, updates: Partial<McpServerInput>): Promise<McpServer> => {
+      const response = await fetch(`${BASE_URL}/servers/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      if (!response.ok) {
+        throw new Error(await parseError(response));
+      }
+      const updated = await response.json();
+      await refetch();
+      return updated;
+    },
+    [refetch]
+  );
+
+  const deleteServer = useCallback(
+    async (id: number): Promise<void> => {
+      const response = await fetch(`${BASE_URL}/servers/${id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        throw new Error(await parseError(response));
+      }
+      await refetch();
+    },
+    [refetch]
+  );
+
+  const testServer = useCallback(async (id: number): Promise<McpTestResult> => {
+    const response = await fetch(`${BASE_URL}/servers/${id}/test`, { method: 'POST' });
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+    return response.json();
+  }, []);
+
+  return { servers, loading, error, refetch, createServer, updateServer, deleteServer, testServer };
+};

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -466,3 +466,46 @@
     grid-template-columns: 1fr;
   }
 }
+
+.mcp-server-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.mcp-server-item {
+  padding: 12px;
+  background: var(--geist-color-surface-muted);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
+}
+
+.mcp-server-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.mcp-server-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.mcp-server-copy .settings-description {
+  overflow-wrap: anywhere;
+}
+
+.mcp-server-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mcp-server-form {
+  display: grid;
+  gap: 14px;
+}

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -4,11 +4,12 @@ import { useUserSettings, UserSettingsUpdate } from './Hooks/useUserSettings';
 import AgentConfigSection from './Components/AgentConfigSection';
 import GenerationParamsSection from './Components/GenerationParamsSection';
 import RAGSettingsSection from './Components/RAGSettingsSection';
+import McpServersSection from './Components/McpServersSection';
 import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
 import useOverflowObserver from './Hooks/useOverflowObserver';
 
-type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer';
+type Tab = 'general' | 'models' | 'generation' | 'rag' | 'mcp' | 'ui' | 'developer';
 
 const agentTypeOptions = [
   { value: 'local', label: 'Local Model' },
@@ -118,6 +119,7 @@ const Settings: React.FC = () => {
     { id: 'models' as Tab, label: 'Models and Providers' },
     { id: 'generation' as Tab, label: 'Generation' },
     { id: 'rag' as Tab, label: 'Files and RAG' },
+    { id: 'mcp' as Tab, label: 'MCP Servers' },
     { id: 'ui' as Tab, label: 'Appearance' },
     { id: 'developer' as Tab, label: 'Developer' }
   ];
@@ -248,6 +250,8 @@ const Settings: React.FC = () => {
               onFileArchivesChange={(value) => updateLocalSetting('default_file_archives', value)}
             />
           )}
+
+          {activeTab === 'mcp' && <McpServersSection />}
 
           {activeTab === 'ui' && (
             <UIPreferencesSection

--- a/docs/CHAT_TOOL_REGISTRY.md
+++ b/docs/CHAT_TOOL_REGISTRY.md
@@ -6,6 +6,17 @@ executes exact registry handlers, appends normalized tool results to the model
 transcript, and persists the turn once. It does not route through the legacy
 adapter reflection mechanism.
 
+`ToolRegistry` is the single registry for every tool exposed to chat. Besides
+the statically registered defaults below, it accepts pluggable *tool sources*
+(`ToolSource` in `app/services/tool_registry.py`) whose definitions are merged
+into the catalog on every turn: MCP servers (`app/services/mcp_tool_source.py`)
+and bridged adapter actions (`app/services/adapter_tool_source.py`). Statically
+registered names win collisions, and a failing source contributes no tools
+instead of breaking chat. Source-provided tools carry raw JSON schemas
+(`ToolDefinition.arguments_schema`); the registry checks required keys and
+primitive types before dispatch and leaves full constraint enforcement to the
+tool's own backend.
+
 The default registry is intentionally explicit:
 
 | Tool | Backing implementation | Default | Policy |
@@ -68,3 +79,39 @@ remain unavailable.
 A future authenticated approve/reject-and-resume endpoint plus durable
 idempotency is required before filesystem writes, email, or SMS can become
 operational chat tools.
+
+## MCP servers
+
+Operators can mount external tools from MCP (Model Context Protocol) servers,
+configured in Settings → MCP Servers or via `/api/v1/mcp/servers`. Two
+transports are supported: `stdio` (a locally spawned process) and `http`
+(streamable HTTP). Configured servers are persisted in the `mcp_server` table
+and **start disabled**; only explicitly enabled servers contribute tools, and
+a test-connection endpoint (`POST /api/v1/mcp/servers/{id}/test`) lists a
+server's tools without enabling it.
+
+Mounted tools are named `mcp.<server>.<tool>`, labelled with the
+`external_write` side effect, and executed through the same bounded worker
+pool, timeouts, and result budgets as every other chat tool. The client in
+`app/services/mcp_client.py` is a deliberately minimal synchronous JSON-RPC
+implementation (initialize, paginated `tools/list`, `tools/call`); server
+initiated requests such as sampling are declined. Tool descriptions and
+results from MCP servers are untrusted third-party content — enable only
+servers you trust, since their tool output re-enters the model context.
+
+## Bridged adapter actions
+
+`AdapterToolSource` converts adapter reflection schemas
+(`adapters/tool_schema.py`) into ordinary registry definitions named
+`adapter.<Adapter>.<action>`, replacing the need for a second dispatch
+mechanism. Bridged actions are disabled by default and must be opted into by
+name through `GEIST_ENABLED_CHAT_TOOLS`; the default registry bridges only the
+read-only `JobStatusAdapter`. Migrating the legacy agent tick loop onto the
+unified registry is follow-up work.
+
+## Doom-loop interrupt
+
+`ChatOrchestrator` interrupts a run when the model issues the same tool call
+(identical name and arguments) three times consecutively. The repeated call is
+not executed; the run fails with a `Doom loop detected` error so a stuck model
+cannot burn its round and tool budgets on identical requests.

--- a/migrations/versions/b3e5d7f9a1c3_add_mcp_server_table.py
+++ b/migrations/versions/b3e5d7f9a1c3_add_mcp_server_table.py
@@ -1,0 +1,40 @@
+"""add_mcp_server_table
+
+Revision ID: b3e5d7f9a1c3
+Revises: f5c8a1d3e7b9
+Create Date: 2026-07-28 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b3e5d7f9a1c3'
+down_revision = 'f5c8a1d3e7b9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'mcp_server',
+        sa.Column('mcp_server_id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('transport', sa.String(), nullable=False),
+        sa.Column('command', sa.String(), nullable=True),
+        sa.Column('args', sa.JSON(), nullable=True),
+        sa.Column('env', sa.JSON(), nullable=True),
+        sa.Column('url', sa.String(), nullable=True),
+        sa.Column('headers', sa.JSON(), nullable=True),
+        sa.Column('enabled', sa.Boolean(), nullable=False),
+        sa.Column('timeout_seconds', sa.Float(), nullable=False),
+        sa.Column('create_date', sa.DateTime(), nullable=True),
+        sa.Column('update_date', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['geist_user.user_id'], ),
+        sa.PrimaryKeyConstraint('mcp_server_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('mcp_server')

--- a/tests/api/test_mcp_api.py
+++ b/tests/api/test_mcp_api.py
@@ -1,0 +1,184 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.database.database import (
+    DATABASE_CONFIG,
+    Base,
+    Session,
+    SessionLocal,
+    configure_database,
+)
+from app.models.database.database_config import DatabaseConfig
+from app.models.database.geist_user import GeistUser
+from app.services.mcp_client import McpError
+
+
+@pytest.fixture()
+def mcp_client(tmp_path, monkeypatch):
+    original_config = DATABASE_CONFIG
+    engine = configure_database(
+        DatabaseConfig(
+            provider="sqlite",
+            database_url=f"sqlite:///{tmp_path / 'mcp-api.sqlite3'}",
+        )
+    )
+    importlib.import_module("app.models.database")
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setenv("GEIST_JOB_WORKER_ENABLED", "false")
+    with SessionLocal() as session:
+        session.add(
+            GeistUser(
+                user_id=1,
+                username="ddworetzky",
+                name="David Dworetzky",
+                email="david@phantasmal.ai",
+                password="",
+            )
+        )
+        session.commit()
+    from app.main import create_app
+
+    with TestClient(create_app()) as client:
+        yield client
+    Session.remove()
+    Base.metadata.drop_all(bind=engine)
+    configure_database(original_config)
+
+
+def _stdio_payload(name: str = "filesystem") -> dict:
+    return {
+        "name": name,
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+        "env": {"HOME": "/tmp"},
+    }
+
+
+def test_mcp_server_crud_flow(mcp_client):
+    created = mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload())
+    assert created.status_code == 201
+    body = created.json()
+    server_id = body["mcp_server_id"]
+    assert body["name"] == "filesystem"
+    assert body["enabled"] is False  # servers start disabled
+
+    listed = mcp_client.get("/api/v1/mcp/servers")
+    assert listed.status_code == 200
+    assert [server["name"] for server in listed.json()] == ["filesystem"]
+
+    updated = mcp_client.put(
+        f"/api/v1/mcp/servers/{server_id}",
+        json={"enabled": True, "timeout_seconds": 45},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["enabled"] is True
+    assert updated.json()["timeout_seconds"] == 45
+
+    fetched = mcp_client.get(f"/api/v1/mcp/servers/{server_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["enabled"] is True
+
+    deleted = mcp_client.delete(f"/api/v1/mcp/servers/{server_id}")
+    assert deleted.status_code == 204
+    assert mcp_client.get(f"/api/v1/mcp/servers/{server_id}").status_code == 404
+    assert mcp_client.get("/api/v1/mcp/servers").json() == []
+
+
+def test_stdio_server_requires_command(mcp_client):
+    response = mcp_client.post(
+        "/api/v1/mcp/servers",
+        json={"name": "broken", "transport": "stdio"},
+    )
+    assert response.status_code == 422
+
+
+def test_http_server_requires_http_url(mcp_client):
+    response = mcp_client.post(
+        "/api/v1/mcp/servers",
+        json={"name": "remote", "transport": "http", "url": "ftp://example.com"},
+    )
+    assert response.status_code == 422
+
+    ok = mcp_client.post(
+        "/api/v1/mcp/servers",
+        json={"name": "remote", "transport": "http", "url": "https://example.com/mcp"},
+    )
+    assert ok.status_code == 201
+
+
+def test_invalid_name_rejected(mcp_client):
+    response = mcp_client.post(
+        "/api/v1/mcp/servers",
+        json={"name": "bad name!", "transport": "stdio", "command": "npx"},
+    )
+    assert response.status_code == 422
+
+
+def test_duplicate_name_conflicts(mcp_client):
+    assert mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload()).status_code == 201
+    duplicate = mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload())
+    assert duplicate.status_code == 409
+
+
+def test_update_cannot_break_transport_invariant(mcp_client):
+    created = mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload())
+    server_id = created.json()["mcp_server_id"]
+
+    response = mcp_client.put(
+        f"/api/v1/mcp/servers/{server_id}",
+        json={"transport": "http"},  # no URL configured
+    )
+    assert response.status_code == 422
+
+
+class _FakeManager:
+    def __init__(self, tools=None, error=None):
+        self.tools = tools or []
+        self.error = error
+
+    def list_tools(self, config):
+        if self.error:
+            raise McpError(self.error)
+        return self.tools
+
+    def invalidate(self, server_id):
+        pass
+
+
+def test_test_route_reports_discovered_tools(mcp_client, monkeypatch):
+    import app.api.v1.endpoints.mcp as mcp_endpoints
+
+    created = mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload())
+    server_id = created.json()["mcp_server_id"]
+
+    fake = _FakeManager(tools=[{"name": "read_file", "description": "Read a file"}])
+    monkeypatch.setattr(mcp_endpoints, "get_mcp_manager", lambda: fake)
+
+    response = mcp_client.post(f"/api/v1/mcp/servers/{server_id}/test")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["tools"] == [{"name": "read_file", "description": "Read a file"}]
+
+
+def test_test_route_reports_connection_failure(mcp_client, monkeypatch):
+    import app.api.v1.endpoints.mcp as mcp_endpoints
+
+    created = mcp_client.post("/api/v1/mcp/servers", json=_stdio_payload())
+    server_id = created.json()["mcp_server_id"]
+
+    fake = _FakeManager(error="connection refused")
+    monkeypatch.setattr(mcp_endpoints, "get_mcp_manager", lambda: fake)
+
+    response = mcp_client.post(f"/api/v1/mcp/servers/{server_id}/test")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is False
+    assert "connection refused" in body["error"]
+
+
+def test_test_route_missing_server_404(mcp_client):
+    assert mcp_client.post("/api/v1/mcp/servers/999/test").status_code == 404

--- a/tests/services/test_chat_orchestrator.py
+++ b/tests/services/test_chat_orchestrator.py
@@ -434,3 +434,113 @@ def test_persistence_failure_does_not_emit_unpersisted_final():
     assert error_event.payload["message"] == "Chat completion failed"
     assert "database unavailable" not in error_event.payload["message"]
     assert [attempt["status"] for attempt in write_attempts] == ["completed", "failed"]
+
+
+def test_doom_loop_interrupts_repeated_identical_tool_calls():
+    executions = []
+
+    def lookup(context, arguments):
+        executions.append(arguments.query)
+        return ToolExecutionOutput(content='{"answer": "same thing"}')
+
+    registry = ToolRegistry()
+    registry.register(
+        ToolDefinition(
+            name="documents.search",
+            description="Search documents",
+            arguments_model=LookupArguments,
+            handler=lookup,
+        )
+    )
+
+    def repeated_turn(call_id):
+        return ModelTurn(
+            tool_calls=[
+                ToolCall(id=call_id, name="documents.search", arguments={"query": "loop"})
+            ],
+            finish_reason="tool_calls",
+        )
+
+    backend = ScriptedBackend(
+        [repeated_turn("call_1"), repeated_turn("call_2"), repeated_turn("call_3")]
+    )
+    writes = []
+
+    def write_history(**kwargs):
+        writes.append(kwargs)
+        return SimpleNamespace(chat_session_id=42)
+
+    orchestrator = ChatOrchestrator(
+        registry,
+        history_loader=lambda chat_id: [],
+        history_writer=write_history,
+    )
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="Loop forever",
+            user_id=7,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    # The third identical call is interrupted before execution.
+    assert executions == ["loop", "loop"]
+    error = next(event.payload for event in events if event.event == "error")
+    assert error["message"].startswith("Doom loop detected")
+    assert "documents.search" in error["message"]
+    assert writes[0]["status"] == "failed"
+
+
+def test_doom_loop_not_triggered_by_varied_arguments():
+    def lookup(context, arguments):
+        return ToolExecutionOutput(content='{"answer": "ok"}')
+
+    registry = ToolRegistry()
+    registry.register(
+        ToolDefinition(
+            name="documents.search",
+            description="Search documents",
+            arguments_model=LookupArguments,
+            handler=lookup,
+        )
+    )
+
+    def turn(call_id, query):
+        return ModelTurn(
+            tool_calls=[
+                ToolCall(id=call_id, name="documents.search", arguments={"query": query})
+            ],
+            finish_reason="tool_calls",
+        )
+
+    backend = ScriptedBackend(
+        [
+            turn("call_1", "alpha"),
+            turn("call_2", "beta"),
+            turn("call_3", "alpha"),
+            ModelTurn(text="Done.", finish_reason="stop"),
+        ]
+    )
+
+    orchestrator = ChatOrchestrator(
+        registry,
+        history_loader=lambda chat_id: [],
+        history_writer=lambda **kwargs: SimpleNamespace(chat_session_id=42),
+    )
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="Search a few things",
+            user_id=7,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    completion = next(event.payload for event in events if event.event == "final")
+    assert completion.message == ["Done."]
+    assert not [event for event in events if event.event == "error"]

--- a/tests/services/test_mcp_client.py
+++ b/tests/services/test_mcp_client.py
@@ -1,0 +1,214 @@
+"""Tests for the minimal synchronous MCP client (stdio transport + parsing)."""
+
+import sys
+
+import pytest
+
+from app.services.mcp_client import (
+    McpClientManager,
+    McpConnection,
+    McpError,
+    McpServerConfig,
+    _HttpTransport,
+    _unwrap_response,
+)
+
+
+# A minimal MCP server speaking newline-delimited JSON-RPC over stdio.
+FAKE_SERVER_SCRIPT = """
+import json, sys
+
+def send(message):
+    sys.stdout.write(json.dumps(message) + "\\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    message = json.loads(line)
+    method = message.get("method")
+    message_id = message.get("id")
+    if method == "initialize":
+        send({
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake-server", "version": "1.0"},
+            },
+        })
+    elif method == "tools/list":
+        send({
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "result": {
+                "tools": [
+                    {
+                        "name": "echo",
+                        "description": "Echo text back",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"text": {"type": "string"}},
+                            "required": ["text"],
+                        },
+                    }
+                ]
+            },
+        })
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        if params.get("name") == "echo":
+            text = (params.get("arguments") or {}).get("text")
+            send({
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {"content": [{"type": "text", "text": "echo: " + str(text)}]},
+            })
+        elif params.get("name") == "slow":
+            pass  # never answer; used to exercise timeouts
+        else:
+            send({
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "unknown tool"}],
+                },
+            })
+    elif message_id is not None:
+        send({
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "error": {"code": -32601, "message": "Method not found"},
+        })
+"""
+
+
+def _stdio_config(timeout_seconds: float = 10.0) -> McpServerConfig:
+    return McpServerConfig(
+        server_id=1,
+        name="fake",
+        transport="stdio",
+        command=sys.executable,
+        args=("-c", FAKE_SERVER_SCRIPT),
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def test_stdio_initialize_list_and_call():
+    connection = McpConnection(_stdio_config())
+    try:
+        assert connection.server_info.get("name") == "fake-server"
+        tools = connection.list_tools()
+        assert [tool["name"] for tool in tools] == ["echo"]
+        assert tools[0]["inputSchema"]["required"] == ["text"]
+        assert connection.call_tool("echo", {"text": "hello"}) == "echo: hello"
+    finally:
+        connection.close()
+
+
+def test_stdio_tool_error_raises():
+    connection = McpConnection(_stdio_config())
+    try:
+        with pytest.raises(McpError, match="unknown tool"):
+            connection.call_tool("missing", {})
+    finally:
+        connection.close()
+
+
+def test_stdio_request_timeout():
+    connection = McpConnection(_stdio_config(timeout_seconds=1.0))
+    try:
+        with pytest.raises(McpError, match="timed out"):
+            connection.call_tool("slow", {})
+    finally:
+        connection.close()
+
+
+def test_missing_command_fails_fast():
+    config = McpServerConfig(server_id=2, name="broken", transport="stdio", command=None)
+    with pytest.raises(McpError, match="no command"):
+        McpConnection(config)
+
+
+def test_unknown_transport_rejected():
+    config = McpServerConfig(server_id=3, name="odd", transport="carrier-pigeon")
+    with pytest.raises(McpError, match="Unknown MCP transport"):
+        McpConnection(config)
+
+
+def test_manager_reuses_and_invalidates_connections():
+    manager = McpClientManager()
+    config = _stdio_config()
+    try:
+        first = manager._connection(config)
+        assert manager._connection(config) is first
+
+        manager.invalidate(config.server_id)
+        second = manager._connection(config)
+        assert second is not first
+        assert second.call_tool("echo", {"text": "again"}) == "echo: again"
+    finally:
+        manager.shutdown()
+
+
+def test_manager_reconnects_when_fingerprint_changes():
+    manager = McpClientManager()
+    config = _stdio_config()
+    try:
+        first = manager._connection(config)
+        changed = McpServerConfig(
+            server_id=config.server_id,
+            name=config.name,
+            transport=config.transport,
+            command=config.command,
+            args=config.args,
+            env={"EXTRA": "1"},
+            timeout_seconds=config.timeout_seconds,
+        )
+        second = manager._connection(changed)
+        assert second is not first
+    finally:
+        manager.shutdown()
+
+
+def test_unwrap_response_surfaces_server_errors():
+    with pytest.raises(McpError, match="boom .code -32000."):
+        _unwrap_response(
+            {"jsonrpc": "2.0", "id": "1", "error": {"code": -32000, "message": "boom"}},
+            "tools/list",
+        )
+    assert _unwrap_response({"jsonrpc": "2.0", "id": "1", "result": {"ok": True}}, "x") == {
+        "ok": True
+    }
+
+
+class _FakeSseResponse:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def iter_lines(self, decode_unicode=True):
+        return iter(self._lines)
+
+
+def test_sse_response_parsing_finds_matching_message():
+    lines = [
+        ": comment",
+        "event: message",
+        'data: {"jsonrpc": "2.0", "method": "notifications/progress"}',
+        "",
+        "event: message",
+        'data: {"jsonrpc": "2.0", "id": "req-1",',
+        'data:  "result": {"tools": []}}',
+        "",
+    ]
+    message = _HttpTransport._read_sse_response(_FakeSseResponse(lines), "req-1", "tools/list")
+    assert message["result"] == {"tools": []}
+
+
+def test_sse_response_without_answer_raises():
+    lines = ['data: {"jsonrpc": "2.0", "method": "noise"}', ""]
+    with pytest.raises(McpError, match="ended without a response"):
+        _HttpTransport._read_sse_response(_FakeSseResponse(lines), "req-1", "tools/list")

--- a/tests/services/test_mcp_tool_source.py
+++ b/tests/services/test_mcp_tool_source.py
@@ -1,0 +1,153 @@
+"""Tests for mounting MCP server tools into the unified ToolRegistry."""
+
+import datetime
+
+from agents.models.tool_calling import ToolCall, ToolContext
+from app.models.database.mcp_server import McpServerModel
+from app.services.mcp_client import McpError
+from app.services.mcp_tool_source import McpToolSource, config_from_model
+from app.services.tool_registry import ToolRegistry
+
+
+ECHO_TOOL = {
+    "name": "echo",
+    "description": "Echo text back",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"text": {"type": "string"}},
+        "required": ["text"],
+    },
+}
+
+
+def _server_model(server_id: int = 1, name: str = "fake") -> McpServerModel:
+    now = datetime.datetime(2026, 7, 28)
+    return McpServerModel(
+        mcp_server_id=server_id,
+        user_id=1,
+        name=name,
+        transport="stdio",
+        command="fake-command",
+        args=[],
+        env={},
+        url=None,
+        headers={},
+        enabled=True,
+        timeout_seconds=10.0,
+        create_date=now,
+        update_date=now,
+    )
+
+
+class FakeManager:
+    def __init__(self, tools_by_server=None, errors_by_server=None):
+        self.tools_by_server = tools_by_server or {}
+        self.errors_by_server = errors_by_server or {}
+        self.calls = []
+
+    def list_tools(self, config):
+        if config.name in self.errors_by_server:
+            raise McpError(self.errors_by_server[config.name])
+        return self.tools_by_server.get(config.name, [])
+
+    def call_tool(self, config, name, arguments):
+        self.calls.append((config.name, name, arguments))
+        return f"{name} says: {arguments.get('text', '')}"
+
+
+def _context() -> ToolContext:
+    return ToolContext(user_id=1, chat_id=None, run_id="run-test")
+
+
+def test_definitions_namespace_and_schema_passthrough():
+    manager = FakeManager(tools_by_server={"fake": [ECHO_TOOL]})
+    source = McpToolSource(manager, servers_loader=lambda: [_server_model()])
+
+    definitions = source.definitions()
+    assert [definition.name for definition in definitions] == ["mcp.fake.echo"]
+    definition = definitions[0]
+    assert definition.arguments_schema == ECHO_TOOL["inputSchema"]
+    assert definition.parameters_schema()["required"] == ["text"]
+    assert definition.side_effect == "external_write"
+    assert "[MCP: fake]" in definition.description
+
+
+def test_registry_executes_mcp_tool_through_source():
+    manager = FakeManager(tools_by_server={"fake": [ECHO_TOOL]})
+    source = McpToolSource(manager, servers_loader=lambda: [_server_model()])
+    registry = ToolRegistry()
+    registry.add_source(source)
+
+    call = ToolCall.create("mcp.fake.echo", {"text": "hello"})
+    result = registry.execute(call, _context())
+
+    assert result.status == "succeeded"
+    assert result.content == "echo says: hello"
+    assert manager.calls == [("fake", "echo", {"text": "hello"})]
+
+
+def test_registry_rejects_missing_required_argument():
+    manager = FakeManager(tools_by_server={"fake": [ECHO_TOOL]})
+    source = McpToolSource(manager, servers_loader=lambda: [_server_model()])
+    registry = ToolRegistry()
+    registry.add_source(source)
+
+    result = registry.execute(ToolCall.create("mcp.fake.echo", {}), _context())
+
+    assert result.status == "failed"
+    assert result.error == "invalid_arguments"
+    assert manager.calls == []
+
+
+def test_registry_rejects_wrong_argument_type():
+    manager = FakeManager(tools_by_server={"fake": [ECHO_TOOL]})
+    source = McpToolSource(manager, servers_loader=lambda: [_server_model()])
+    registry = ToolRegistry()
+    registry.add_source(source)
+
+    result = registry.execute(ToolCall.create("mcp.fake.echo", {"text": 7}), _context())
+
+    assert result.status == "failed"
+    assert result.error == "invalid_arguments"
+
+
+def test_failing_server_is_skipped():
+    manager = FakeManager(
+        tools_by_server={"good": [ECHO_TOOL]},
+        errors_by_server={"bad": "connection refused"},
+    )
+    source = McpToolSource(
+        manager,
+        servers_loader=lambda: [_server_model(1, "bad"), _server_model(2, "good")],
+    )
+
+    definitions = source.definitions()
+    assert [definition.name for definition in definitions] == ["mcp.good.echo"]
+
+
+def test_definitions_cached_until_invalidated():
+    loads = []
+
+    def loader():
+        loads.append(1)
+        return [_server_model()]
+
+    manager = FakeManager(tools_by_server={"fake": [ECHO_TOOL]})
+    source = McpToolSource(manager, servers_loader=loader, cache_ttl_seconds=3600)
+
+    source.definitions()
+    source.definitions()
+    assert len(loads) == 1
+
+    source.invalidate()
+    source.definitions()
+    assert len(loads) == 2
+
+
+def test_config_from_model_maps_fields():
+    config = config_from_model(_server_model())
+    assert config.server_id == 1
+    assert config.name == "fake"
+    assert config.transport == "stdio"
+    assert config.command == "fake-command"
+    assert config.timeout_seconds == 10.0

--- a/tests/services/test_tool_registry.py
+++ b/tests/services/test_tool_registry.py
@@ -61,8 +61,10 @@ def test_default_catalog_and_context_definitions(monkeypatch, tmp_path):
         "workspace.write_markdown",
         "communication.email.send",
         "communication.sms.send",
+        "adapter.JobStatusAdapter.check_async_tool",
     }
     assert catalog["web.search"].enabled_by_default is True
+    assert catalog["adapter.JobStatusAdapter.check_async_tool"].enabled_by_default is False
     assert catalog["documents.search"].enabled_by_default is True
     assert catalog["image.generate"].enabled_by_default is True
     assert catalog["workspace.read_markdown"].enabled_by_default is False
@@ -219,3 +221,111 @@ def test_execute_hides_handler_exception_details(caplog):
     assert result.content == "Tool failed: failing.search"
     assert "provider secret response" not in result.content
     assert "provider secret response" in caplog.text
+
+
+class StaticSource:
+    """Minimal ToolSource for tests."""
+
+    name = "static-source"
+
+    def __init__(self, definitions, fail=False):
+        self._definitions = definitions
+        self.fail = fail
+
+    def definitions(self):
+        if self.fail:
+            raise RuntimeError("source exploded")
+        return list(self._definitions)
+
+
+def _schema_definition(name: str, handler) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        description=f"Schema definition for {name}",
+        arguments_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string"}, "count": {"type": "integer"}},
+            "required": ["text"],
+        },
+        handler=handler,
+    )
+
+
+def test_source_tools_merge_into_catalog_and_dispatch():
+    def handler(context, arguments):
+        assert isinstance(arguments, dict)
+        return ToolExecutionOutput(content=f"got {arguments['text']}")
+
+    registry = ToolRegistry()
+    registry.add_source(StaticSource([_schema_definition("source.echo", handler)]))
+
+    assert registry.get("source.echo") is not None
+    assert "source.echo" in [definition.name for definition in registry.catalog()]
+    assert "source.echo" in [
+        definition.name for definition in registry.definitions_for_context(_context())
+    ]
+
+    result = registry.execute(ToolCall.create("source.echo", {"text": "hi"}), _context())
+    assert result.status == "succeeded"
+    assert result.content == "got hi"
+
+
+def test_schema_validation_rejects_missing_and_mistyped_arguments():
+    handler = Mock()
+    registry = ToolRegistry()
+    registry.add_source(StaticSource([_schema_definition("source.echo", handler)]))
+
+    missing = registry.execute(ToolCall.create("source.echo", {}), _context())
+    assert missing.status == "failed"
+    assert missing.error == "invalid_arguments"
+
+    mistyped = registry.execute(
+        ToolCall.create("source.echo", {"text": "ok", "count": "three"}), _context()
+    )
+    assert mistyped.status == "failed"
+    assert mistyped.error == "invalid_arguments"
+    handler.assert_not_called()
+
+
+def test_static_registration_wins_source_collisions():
+    static_handler = Mock(return_value=ToolExecutionOutput(content="static"))
+    registry = ToolRegistry()
+    registry.register(_definition("web.search", static_handler))
+    registry.add_source(StaticSource([_schema_definition("web.search", Mock())]))
+
+    definition = registry.get("web.search")
+    assert definition.arguments_model is WebSearchArguments
+    assert len([d for d in registry.catalog() if d.name == "web.search"]) == 1
+
+
+def test_failing_source_does_not_break_catalog():
+    registry = ToolRegistry()
+    registry.register(_definition("web.search", Mock()))
+    registry.add_source(StaticSource([], fail=True))
+
+    assert [definition.name for definition in registry.catalog()] == ["web.search"]
+    assert registry.get("missing.tool") is None
+
+
+def test_duplicate_source_names_rejected():
+    registry = ToolRegistry()
+    registry.add_source(StaticSource([]))
+    with pytest.raises(ValueError, match="already registered"):
+        registry.add_source(StaticSource([]))
+    registry.remove_source("static-source")
+    registry.add_source(StaticSource([]))
+
+
+def test_tool_definition_requires_exactly_one_argument_contract():
+    with pytest.raises(ValueError, match="exactly one"):
+        ToolDefinition(name="broken", description="broken", handler=Mock())
+    with pytest.raises(ValueError, match="exactly one"):
+        ToolDefinition(
+            name="broken",
+            description="broken",
+            handler=Mock(),
+            arguments_model=WebSearchArguments,
+            arguments_schema={"type": "object"},
+        )
+    with pytest.raises(ValueError, match="requires a handler"):
+        ToolDefinition(name="broken", description="broken", arguments_model=WebSearchArguments)


### PR DESCRIPTION
## Description

Follow-up to the Hermes-agent / opencode comparison: this PR makes `ToolRegistry` the single registry every chat tool flows through, adds MCP (Model Context Protocol) server support end to end, and adds a doom-loop interrupt to the chat orchestrator.

**One tool registry.** `ToolRegistry` now accepts pluggable `ToolSource` providers whose definitions merge into the catalog on every turn (statically registered names win collisions; a failing source contributes no tools instead of breaking chat). `ToolDefinition` gains a raw JSON-schema arguments contract (`arguments_schema`) alongside the existing Pydantic path, with required-key and primitive-type validation before dispatch. `AdapterToolSource` bridges adapter reflection schemas into the registry as `adapter.<Adapter>.<action>` (disabled by default, opt-in via `GEIST_ENABLED_CHAT_TOOLS`), replacing the need for a second dispatch mechanism; migrating the legacy agent tick loop onto the unified registry is noted as follow-up work in the docs.

**MCP support.** `app/services/mcp_client.py` is a deliberately minimal synchronous JSON-RPC client (initialize, paginated `tools/list`, `tools/call`) over stdio and streamable HTTP — no SDK dependency, consistent with how `OnlineAgent` hand-rolls its provider HTTP. Configured servers persist in a new `mcp_server` table (Alembic migration `b3e5d7f9a1c3`, head-chained to `f5c8a1d3e7b9`) and are managed through new routes under `/api/v1/mcp` (CRUD plus `POST /servers/{id}/test`, which connects and lists tools without enabling the server). `McpToolSource` mounts enabled servers' tools as `mcp.<server>.<tool>` with the `external_write` side-effect label, short-TTL discovery caching, and immediate invalidation on config changes. Servers start disabled; tools re-enter the model context only for servers an operator explicitly enables.

**MCP configuration screen.** New "MCP Servers" tab in Settings (`McpServersSection` + `useMcpServers` hook): list/add/edit/delete servers, per-server enable toggle, and a connection test that shows the discovered tools inline. Transport-specific forms for stdio (command/args/env) and HTTP (URL/headers).

**Doom-loop interrupt.** `ChatOrchestrator` interrupts a run when the model issues the same tool call (identical name and canonicalized arguments) three times consecutively — the repeated call is not executed and the run fails with a user-visible `Doom loop detected` error.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- `uv run python -m pytest tests` — 485 passed; the 37 failures/12 errors also occur on the base commit (verified by diffing failure lists against a clean worktree of `main`; they are environment issues: missing optional model deps, network-dependent agent tests, uninitialized workflow DB).
- 34 new tests: registry sources/collisions/schema validation, MCP client round-trips against a real spawned stdio JSON-RPC server subprocess (list/call/error/timeout), SSE response parsing, `McpToolSource` mounting/caching/failure isolation, `/api/v1/mcp` CRUD + validation + test-connection routes, and doom-loop trigger/non-trigger orchestrator runs.
- `uv run ruff check .` and `uv run mypy .` both clean (as run by CI).
- Frontend: added `McpServersSection.test.tsx` (render, create, validation, test-connection success/failure). **Not executed locally** — `npm ci` requires dependency-install approval this session; syntax-validated with standalone `tsc`. Please run `cd client/geist && npm ci && CI=true npm test` or let CI cover it.

- [x] Tests pass locally
- [x] Added new tests for new functionality
- [x] Updated existing tests

## Security Checklist

- [x] No secrets or credentials committed
- [x] Code reviewed for security issues (SQL injection, XSS, etc.)
- [x] Input validation added where necessary
- [ ] Authentication/authorization properly implemented (routes use the same default-user placeholder as existing endpoints)

Notes: MCP servers are operator-configured; stdio commands and HTTP URLs are only reachable through explicit configuration, servers start disabled, and mounted tools run under the existing bounded worker pool, timeouts, and result budgets. MCP tool descriptions/results are third-party content — documented as untrusted in `docs/CHAT_TOOL_REGISTRY.md`. Stored env/headers may contain tokens and are returned by the GET routes (same posture as existing `backup_providers` API keys).

## Code Quality

- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## CI/CD Pipeline

- [ ] All CI checks pass (pending)
- [ ] Docker images build successfully (if applicable)

## Additional Notes

- Swapping the hand-rolled MCP client for the official `mcp` Python SDK (and gaining OAuth, notifications-driven tool refresh, sampling/elicitation) is a natural follow-up once adding the dependency is approved.
- Docker backend tests and native MLX validation were not run in this session (no Docker daemon available in the remote environment); the full native pytest suite was run instead as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgRr66iQPKNSPZrnwrqCV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgRr66iQPKNSPZrnwrqCV4)_