### PR TITLE
feat: add branded About settings page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ import dataclasses
 import json
 import logging
 import os
+import platform
 import threading
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -628,6 +629,15 @@ def create_app(
             "version": application_version(),
             "apiVersion": f"{api_version}",
             "spa": web_dir is not None,
+            "platform": {
+                "system": platform.system(),
+                "release": platform.release(),
+                "machine": platform.machine(),
+            },
+            "python": {
+                "version": platform.python_version(),
+            },
+            "inference": _configured_inference_info(),
         }
 
     if web_dir is None:
@@ -640,6 +650,57 @@ def create_app(
         app.state.web_dir = install_spa(app, web_dir)
 
     return app
+
+
+def _configured_inference_info() -> dict[str, str | None]:
+    try:
+        settings = UserSettingsService.get_default_user_settings()
+        factory_config = AgentFactoryConfig.from_user_settings(settings)
+    except Exception as error:
+        logger.warning("Unable to read configured inference settings: %s", error)
+        runner_type = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip()
+        runner_type = runner_type or AgentFactory._infer_runner_type(DEFAULT_LOCAL_MODEL)
+        return {
+            "mode": "local",
+            "engine": runner_type,
+            "model": DEFAULT_LOCAL_MODEL,
+            "provider": None,
+            "acceleration": _llama_acceleration(runner_type),
+        }
+
+    if factory_config.agent_type == "online":
+        return {
+            "mode": "online",
+            "engine": "Remote API",
+            "model": factory_config.model,
+            "provider": settings.default_online_provider,
+            "acceleration": None,
+        }
+
+    runner_type = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip() or factory_config.runner_type
+    artifact_id = settings.default_local_artifact_id
+    if artifact_id:
+        try:
+            from app.services.local_models import get_local_model_manager
+
+            runner_type = get_local_model_manager().get_artifact(artifact_id).backend
+        except KeyError:
+            logger.warning("Configured local artifact %s is not available", artifact_id)
+
+    runner_type = runner_type or AgentFactory._infer_runner_type(factory_config.model)
+    return {
+        "mode": "local",
+        "engine": runner_type,
+        "model": factory_config.model,
+        "provider": None,
+        "acceleration": _llama_acceleration(runner_type),
+    }
+
+
+def _llama_acceleration(runner_type: str) -> str | None:
+    if runner_type != "llama_server":
+        return None
+    return (os.getenv("GEIST_LLAMA_ACCELERATION") or "auto").strip().lower()
 
 
 def _parse_agent_type(agent_type: str) -> AgentType:

--- a/app/main.py
+++ b/app/main.py
@@ -658,14 +658,14 @@ def _configured_inference_info() -> dict[str, str | None]:
         factory_config = AgentFactoryConfig.from_user_settings(settings)
     except Exception as error:
         logger.warning("Unable to read configured inference settings: %s", error)
-        runner_type = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip()
-        runner_type = runner_type or AgentFactory._infer_runner_type(DEFAULT_LOCAL_MODEL)
+        fallback_runner_type = (os.getenv("GEIST_LOCAL_RUNNER") or "").strip()
+        fallback_runner_type = fallback_runner_type or AgentFactory._infer_runner_type(DEFAULT_LOCAL_MODEL)
         return {
             "mode": "local",
-            "engine": runner_type,
+            "engine": fallback_runner_type,
             "model": DEFAULT_LOCAL_MODEL,
             "provider": None,
-            "acceleration": _llama_acceleration(runner_type),
+            "acceleration": _llama_acceleration(fallback_runner_type),
         }
 
     if factory_config.agent_type == "online":

--- a/client/geist/src/Components/AboutSection.tsx
+++ b/client/geist/src/Components/AboutSection.tsx
@@ -1,0 +1,365 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useBranding } from '../branding';
+
+interface SystemInfo {
+  version: string;
+  platform?: {
+    system: string;
+    release: string;
+    machine: string;
+  };
+  python?: {
+    version: string;
+  };
+  inference?: {
+    mode: 'local' | 'online';
+    engine: string;
+    model: string;
+    provider?: string | null;
+    acceleration?: string | null;
+  };
+}
+
+interface Detail {
+  label: string;
+  value: string;
+}
+
+const engineNames: Record<string, string> = {
+  llama_server: 'llama.cpp',
+  mlx_llama: 'MLX',
+  transformers: 'Transformers',
+};
+
+function displayEngine(engine: string): string {
+  return engineNames[engine] ?? engine;
+}
+
+function displayValue(value?: string | null): string {
+  return value?.trim() || 'Not reported';
+}
+
+function AboutAuroraBackground(): JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || typeof WebGLRenderingContext === 'undefined') {
+      return undefined;
+    }
+
+    const gl = canvas.getContext('webgl', {
+      alpha: false,
+      antialias: false,
+      depth: false,
+      powerPreference: 'low-power',
+    });
+    if (!gl) {
+      return undefined;
+    }
+
+    const vertexSource = `
+      attribute vec2 aPosition;
+      void main() {
+        gl_Position = vec4(aPosition, 0.0, 1.0);
+      }
+    `;
+    const fragmentSource = `
+      precision highp float;
+      uniform vec2 uResolution;
+      uniform float uTime;
+      uniform vec3 uDeepColor;
+      uniform vec3 uSurfaceColor;
+      uniform vec3 uAccentColor;
+
+      float random(vec2 point) {
+        return fract(sin(dot(point, vec2(127.1, 311.7))) * 43758.5453123);
+      }
+
+      float noise(vec2 point) {
+        vec2 cell = floor(point);
+        vec2 local = fract(point);
+        vec2 blend = local * local * (3.0 - 2.0 * local);
+        return mix(
+          mix(random(cell), random(cell + vec2(1.0, 0.0)), blend.x),
+          mix(random(cell + vec2(0.0, 1.0)), random(cell + vec2(1.0, 1.0)), blend.x),
+          blend.y
+        );
+      }
+
+      float flowingNoise(vec2 point) {
+        float value = 0.0;
+        float amplitude = 0.5;
+        mat2 rotation = mat2(0.8, 0.6, -0.6, 0.8);
+        for (int octave = 0; octave < 3; octave++) {
+          value += noise(point) * amplitude;
+          point = rotation * point * 2.02 + vec2(8.3, 3.7);
+          amplitude *= 0.5;
+        }
+        return value;
+      }
+
+      float auroraRibbon(
+        vec2 uv,
+        float time,
+        float center,
+        float frequency,
+        float amplitude,
+        float width,
+        float phase
+      ) {
+        float turbulence = flowingNoise(vec2(uv.x * 1.8 + phase, time * 0.09 + phase)) - 0.44;
+        float wave = sin(uv.x * frequency + time * 0.58 + phase) * amplitude;
+        wave += sin(uv.x * frequency * 0.46 - time * 0.34 + phase * 1.7) * amplitude * 0.52;
+        wave += turbulence * amplitude * 1.35;
+
+        float distanceToRibbon = abs(uv.y - center - wave);
+        float core = exp(-distanceToRibbon * distanceToRibbon / (width * width));
+        float bloom = exp(-distanceToRibbon * distanceToRibbon / (width * width * 6.0));
+        return core * 0.72 + bloom * 0.28;
+      }
+
+      void main() {
+        vec2 uv = gl_FragCoord.xy / uResolution.xy;
+        float time = uTime * 0.46;
+
+        float upperRibbon = auroraRibbon(uv, time, 0.7, 6.1, 0.12, 0.058, 0.4);
+        float middleRibbon = auroraRibbon(uv, time, 0.48, 7.4, 0.15, 0.067, 2.35);
+        float lowerRibbon = auroraRibbon(uv, time, 0.27, 5.3, 0.1, 0.052, 4.8);
+
+        float atmosphere = flowingNoise(vec2(uv.x * 2.3 - time * 0.05, uv.y * 1.4 + time * 0.035));
+        float verticalFade = smoothstep(0.0, 0.24, uv.y) * smoothstep(1.0, 0.7, uv.y);
+
+        vec3 coolColor = mix(uAccentColor, vec3(0.34, 0.58, 1.0), 0.38);
+        vec3 warmColor = mix(uAccentColor, vec3(1.0, 0.38, 0.82), 0.2);
+        vec3 color = mix(uDeepColor, uSurfaceColor, 0.28 + uv.y * 0.11);
+        color += uAccentColor * upperRibbon * 0.2;
+        color += coolColor * middleRibbon * 0.25;
+        color += warmColor * lowerRibbon * 0.17;
+        color += uAccentColor * max(atmosphere - 0.5, 0.0) * 0.07 * verticalFade;
+
+        float centerGlow = exp(-length((uv - vec2(0.32, 0.52)) * vec2(0.72, 1.0)) * 2.8);
+        color += uAccentColor * centerGlow * 0.045;
+
+        float vignette = smoothstep(0.92, 0.3, length((uv - 0.5) * vec2(0.72, 1.0)));
+        color *= 0.82 + vignette * 0.18;
+        gl_FragColor = vec4(color, 1.0);
+      }
+    `;
+
+    const compileShader = (type: number, source: string) => {
+      const shader = gl.createShader(type);
+      if (!shader) {
+        return null;
+      }
+      gl.shaderSource(shader, source);
+      gl.compileShader(shader);
+      if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        gl.deleteShader(shader);
+        return null;
+      }
+      return shader;
+    };
+
+    const vertexShader = compileShader(gl.VERTEX_SHADER, vertexSource);
+    const fragmentShader = compileShader(gl.FRAGMENT_SHADER, fragmentSource);
+    const program = gl.createProgram();
+    if (!vertexShader || !fragmentShader || !program) {
+      return undefined;
+    }
+
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program);
+      return undefined;
+    }
+
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+      gl.STATIC_DRAW,
+    );
+    gl.useProgram(program);
+    const position = gl.getAttribLocation(program, 'aPosition');
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+    const resolution = gl.getUniformLocation(program, 'uResolution');
+    const time = gl.getUniformLocation(program, 'uTime');
+    const deepColor = gl.getUniformLocation(program, 'uDeepColor');
+    const surfaceColor = gl.getUniformLocation(program, 'uSurfaceColor');
+    const accentColor = gl.getUniformLocation(program, 'uAccentColor');
+
+    const readColor = (token: string, fallback: [number, number, number]) => {
+      const value = getComputedStyle(document.documentElement).getPropertyValue(token).trim();
+      const match = value.match(/^#([0-9a-f]{6})$/i);
+      if (!match) {
+        return fallback;
+      }
+      const numeric = Number.parseInt(match[1], 16);
+      return [
+        ((numeric >> 16) & 255) / 255,
+        ((numeric >> 8) & 255) / 255,
+        (numeric & 255) / 255,
+      ] as [number, number, number];
+    };
+
+    const deep = readColor('--geist-color-bg', [0.06, 0.025, 0.12]);
+    const surface = readColor('--geist-color-surface-strong', [0.22, 0.09, 0.43]);
+    const accent = readColor('--geist-color-accent', [0.65, 0.55, 0.98]);
+    gl.uniform3fv(deepColor, deep);
+    gl.uniform3fv(surfaceColor, surface);
+    gl.uniform3fv(accentColor, accent);
+
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+    let animationFrame = 0;
+    const render = (timestamp: number) => {
+      const bounds = canvas.getBoundingClientRect();
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+      const width = Math.max(1, Math.round(bounds.width * pixelRatio));
+      const height = Math.max(1, Math.round(bounds.height * pixelRatio));
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+        gl.viewport(0, 0, width, height);
+      }
+
+      gl.uniform2f(resolution, width, height);
+      gl.uniform1f(time, reduceMotion ? 0 : timestamp / 1000);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      if (!reduceMotion) {
+        animationFrame = window.requestAnimationFrame(render);
+      }
+    };
+    animationFrame = window.requestAnimationFrame(render);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      gl.deleteBuffer(buffer);
+      gl.deleteProgram(program);
+      gl.deleteShader(vertexShader);
+      gl.deleteShader(fragmentShader);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="about-aurora-background" aria-hidden="true" />;
+}
+
+export default function AboutSection(): JSX.Element {
+  const branding = useBranding();
+  const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch('/api/v1/system')
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`System information failed: ${response.statusText}`);
+        }
+        return response.json() as Promise<SystemInfo>;
+      })
+      .then((payload) => {
+        if (!cancelled) {
+          setSystemInfo(payload);
+          setError(null);
+        }
+      })
+      .catch((requestError) => {
+        if (!cancelled) {
+          setError(requestError instanceof Error ? requestError.message : 'System information failed');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const details = useMemo<Detail[]>(() => {
+    if (!systemInfo) {
+      return [];
+    }
+
+    const nextDetails: Detail[] = [];
+    if (systemInfo.platform) {
+      nextDetails.push({
+        label: 'Operating System',
+        value: `${displayValue(systemInfo.platform.system)} ${displayValue(systemInfo.platform.release)}`,
+      });
+      nextDetails.push({ label: 'Architecture', value: displayValue(systemInfo.platform.machine) });
+    }
+
+    if (systemInfo.inference) {
+      const inference = systemInfo.inference;
+      nextDetails.push({ label: 'Inference Engine', value: displayEngine(inference.engine) });
+      if (inference.acceleration) {
+        nextDetails.push({ label: 'Acceleration', value: inference.acceleration });
+      }
+    }
+
+    if (systemInfo.python) {
+      nextDetails.push({ label: 'Python Runtime', value: displayValue(systemInfo.python.version) });
+    }
+    return nextDetails;
+  }, [systemInfo]);
+
+  const productName = branding.productName ?? 'Geist';
+  const productVersion = branding.productVersion ?? systemInfo?.version;
+
+  return (
+    <section className="about-section" aria-labelledby="about-product-name">
+      <header className="about-identity">
+        <AboutAuroraBackground />
+        <div className="about-lockup">
+          {branding.logoUrl && (
+            <img className="about-logo" src={branding.logoUrl} alt={`${productName} logo`} />
+          )}
+          <div className="about-identity-copy">
+            <h2 id="about-product-name">
+              {productName}
+              {productVersion && <span className="about-product-version">v{productVersion}</span>}
+            </h2>
+            <p>
+              Powered by Geist
+              {systemInfo?.version && <span> v{systemInfo.version}</span>}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="about-machine">
+        <header className="settings-section-header">
+          <h3>This Machine</h3>
+          <p>Runtime details reported by the active Geist service.</p>
+        </header>
+
+        {!systemInfo && !error && <div className="empty-state compact">Loading system information...</div>}
+        {error && <div className="notice notice-error">{error}</div>}
+        {systemInfo && (
+          <>
+            {details.length > 1 ? (
+              <dl className="about-details">
+                {details.map((detail) => (
+                  <div className="about-detail" key={detail.label}>
+                    <dt>{detail.label}</dt>
+                    <dd>{detail.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : (
+              <div className="notice">
+                Restart Geist to load detailed machine and inference information.
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -16,6 +16,10 @@
   overflow: hidden;
 }
 
+.settings-page.settings-page-about {
+  --settings-action-clearance: 24px;
+}
+
 .settings-page.settings-page-interactive.settings-scrollbar-visible {
   --settings-scrollbar-lane: 10px;
 }
@@ -461,8 +465,134 @@
   border-radius: var(--geist-radius-md);
 }
 
+.about-section {
+  display: grid;
+  gap: 18px;
+}
+
+.about-identity {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  gap: 8px;
+  padding: 28px;
+  overflow: hidden;
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-lg);
+  box-shadow: var(--geist-shadow-panel);
+}
+
+.about-aurora-background {
+  position: absolute;
+  z-index: -2;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 72% 18%, color-mix(in srgb, var(--geist-color-accent) 28%, transparent), transparent 42%),
+    linear-gradient(to bottom, var(--geist-color-surface-strong), var(--geist-color-bg));
+}
+
+.about-lockup {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.about-logo {
+  flex: 0 0 auto;
+  width: clamp(64px, 9vw, 96px);
+  height: clamp(64px, 9vw, 96px);
+  object-fit: contain;
+  border-radius: var(--geist-radius-lg);
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.22));
+}
+
+.about-identity-copy {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.about-identity h2 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: baseline;
+  margin: 0;
+  color: var(--geist-color-text);
+  font-size: clamp(2.25rem, 6vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.045em;
+}
+
+.about-product-version {
+  color: var(--geist-color-accent-strong);
+  font-size: 0.42em;
+  font-weight: 720;
+  letter-spacing: -0.02em;
+}
+
+.about-identity p {
+  margin: 0;
+  color: var(--geist-color-text-muted);
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.about-machine {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  background: var(--geist-color-surface);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-lg);
+  box-shadow: var(--geist-shadow-panel);
+}
+
+.about-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.about-detail {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 13px;
+  background: var(--geist-color-surface-muted);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
+}
+
+.about-detail dt {
+  color: var(--geist-color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 740;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.about-detail dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--geist-color-text);
+  font-size: 0.92rem;
+  font-weight: 650;
+}
+
 @media (max-width: 720px) {
-  .settings-readonly-grid {
+  .settings-readonly-grid,
+  .about-details {
     grid-template-columns: 1fr;
+  }
+
+  .about-lockup {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import Settings from './Settings';
+import { BrandingProvider } from './branding';
 import { UserSettingsProvider } from './Hooks/useUserSettings';
 import { installResizeObserverMock } from './testUtils/mockResizeObserver';
 
@@ -59,9 +60,18 @@ const renderSettings = () => render(
   </UserSettingsProvider>,
 );
 
+const renderBrandedSettings = () => render(
+  <BrandingProvider>
+    <UserSettingsProvider>
+      <Settings />
+    </UserSettingsProvider>
+  </BrandingProvider>,
+);
+
 describe('Settings page', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    delete window.__GEIST_BRANDING__;
     // @ts-ignore
     global.fetch = jest.fn();
   });
@@ -81,6 +91,92 @@ describe('Settings page', () => {
       expect(screen.getByRole('tab', { name: 'Files and RAG' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Appearance' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Developer' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows host, Geist, machine, and inference details on the About tab', async () => {
+    window.__GEIST_BRANDING__ = {
+      productName: 'Pitchblend',
+      productVersion: '2.3.4',
+      logoUrl: 'data:image/png;base64,cGl0Y2hibGVuZA==',
+    };
+    const systemInfo = {
+      version: '0.4.2',
+      spa: true,
+      platform: {
+        system: 'Windows',
+        release: '11',
+        machine: 'AMD64',
+      },
+      python: {
+        version: '3.11.9',
+      },
+      inference: {
+        mode: 'local',
+        engine: 'llama_server',
+        model: 'Qwen/Qwen3-4B',
+        provider: null,
+        acceleration: 'vulkan',
+      },
+    };
+
+    // @ts-ignore
+    global.fetch = jest.fn((url: string) => {
+      if (url === '/api/v1/system') {
+        return Promise.resolve({ ok: true, json: async () => systemInfo });
+      }
+      return Promise.resolve({ ok: true, json: async () => baseSettings });
+    });
+
+    renderBrandedSettings();
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Pitchblend.*v2\.3\.4/i })).toBeInTheDocument();
+      expect(screen.getByRole('img', { name: 'Pitchblend logo' })).toBeInTheDocument();
+      expect(screen.getByText(/Powered by Geist/i)).toHaveTextContent('v0.4.2');
+      expect(screen.getByText('Windows 11')).toBeInTheDocument();
+      expect(screen.getByText('AMD64')).toBeInTheDocument();
+      expect(screen.getByText('llama.cpp')).toBeInTheDocument();
+      expect(screen.getByText('vulkan')).toBeInTheDocument();
+      expect(screen.queryByText('Geist API')).not.toBeInTheDocument();
+      expect(screen.queryByText('Inference Mode')).not.toBeInTheDocument();
+      expect(screen.queryByText('Model')).not.toBeInTheDocument();
+      expect(screen.queryByText('Provider')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole('contentinfo', { name: 'Settings actions' })).not.toBeInTheDocument();
+  });
+
+  it('keeps About usable when connected to an older Geist system endpoint', async () => {
+    window.__GEIST_BRANDING__ = {
+      productName: 'Pitchblend',
+      productVersion: '2.3.4',
+    };
+
+    // @ts-ignore
+    global.fetch = jest.fn((url: string) => {
+      if (url === '/api/v1/system') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ version: '0.3.0', spa: true }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => baseSettings });
+    });
+
+    renderBrandedSettings();
+    await waitFor(() => screen.getByRole('tab', { name: 'About' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'About' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Pitchblend.*v2\.3\.4/i })).toBeInTheDocument();
+      expect(screen.getByText(/Powered by Geist/i)).toHaveTextContent('v0.3.0');
+      expect(screen.getByText(/Restart Geist to load detailed machine/i)).toBeInTheDocument();
     });
   });
 

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -6,9 +6,10 @@ import GenerationParamsSection from './Components/GenerationParamsSection';
 import RAGSettingsSection from './Components/RAGSettingsSection';
 import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
+import AboutSection from './Components/AboutSection';
 import useOverflowObserver from './Hooks/useOverflowObserver';
 
-type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer';
+type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer' | 'about';
 
 const agentTypeOptions = [
   { value: 'local', label: 'Local Model' },
@@ -119,7 +120,8 @@ const Settings: React.FC = () => {
     { id: 'generation' as Tab, label: 'Generation' },
     { id: 'rag' as Tab, label: 'Files and RAG' },
     { id: 'ui' as Tab, label: 'Appearance' },
-    { id: 'developer' as Tab, label: 'Developer' }
+    { id: 'developer' as Tab, label: 'Developer' },
+    { id: 'about' as Tab, label: 'About' }
   ];
 
   if (loading && !localSettings) {
@@ -146,7 +148,7 @@ const Settings: React.FC = () => {
   }
 
   return (
-    <div className={`settings-page page-surface settings-page-interactive${hasSettingsScrollbar ? ' settings-scrollbar-visible' : ''}`}>
+    <div className={`settings-page page-surface settings-page-interactive${activeTab === 'about' ? ' settings-page-about' : ''}${hasSettingsScrollbar ? ' settings-scrollbar-visible' : ''}`}>
       <div className="settings-scroll-region" ref={settingsScrollRef}>
         <header className="settings-header">
           <div>
@@ -274,20 +276,24 @@ const Settings: React.FC = () => {
               </div>
             </section>
           )}
+
+          {activeTab === 'about' && <AboutSection />}
         </div>
       </div>
 
-      <footer className="settings-actions" aria-label="Settings actions">
-        <button className="button button-danger" onClick={handleReset} disabled={saveStatus === 'saving'}>
-          Reset to Defaults
-        </button>
-        <button className="button button-secondary" onClick={handleCancel} disabled={!hasUnsavedChanges || saveStatus === 'saving'}>
-          Cancel
-        </button>
-        <button className="button" onClick={handleSave} disabled={!hasUnsavedChanges || saveStatus === 'saving'}>
-          {saveStatus === 'saving' ? 'Saving...' : 'Save Changes'}
-        </button>
-      </footer>
+      {activeTab !== 'about' && (
+        <footer className="settings-actions" aria-label="Settings actions">
+          <button className="button button-danger" onClick={handleReset} disabled={saveStatus === 'saving'}>
+            Reset to Defaults
+          </button>
+          <button className="button button-secondary" onClick={handleCancel} disabled={!hasUnsavedChanges || saveStatus === 'saving'}>
+            Cancel
+          </button>
+          <button className="button" onClick={handleSave} disabled={!hasUnsavedChanges || saveStatus === 'saving'}>
+            {saveStatus === 'saving' ? 'Saving...' : 'Save Changes'}
+          </button>
+        </footer>
+      )}
     </div>
   );
 };

--- a/client/geist/src/branding.tsx
+++ b/client/geist/src/branding.tsx
@@ -22,6 +22,7 @@ export type GeistThemeToken =
 
 export interface GeistBranding {
   productName?: string;
+  productVersion?: string;
   logoUrl?: string;
   faviconUrl?: string;
   titleTemplate?: string;

--- a/plans/304-ci-fix-and-review.md
+++ b/plans/304-ci-fix-and-review.md
@@ -1,0 +1,7 @@
+# PR 304 CI Fix and First-Pass Review
+
+1. Reproduce the failing CI type check from the workflow logs.
+2. Apply the smallest type-safe fix without changing runtime behavior.
+3. Run the exact backend and native-host mypy checks plus affected tests.
+4. Review the PR diff for correctness, security, performance, and project conventions.
+5. Commit and push only the CI fix to the PR branch, then verify GitHub Actions.

--- a/tests/test_app_lifecycle.py
+++ b/tests/test_app_lifecycle.py
@@ -38,7 +38,16 @@ def test_app_lifespan_starts_and_stops_the_job_worker(monkeypatch):
             "version": main.application_version(),
             "checks": {"lifespan": "ok", "database": "ok"},
         }
-        assert client.get("/api/v1/system").json()["spa"] is False
+        system = client.get("/api/v1/system").json()
+        assert system["spa"] is False
+        assert system["version"] == main.application_version()
+        assert system["platform"]["system"]
+        assert system["platform"]["release"]
+        assert system["platform"]["machine"]
+        assert system["python"]["version"]
+        assert system["inference"]["mode"] in {"local", "online"}
+        assert system["inference"]["engine"]
+        assert system["inference"]["model"]
         assert client.get("/").json() == {"Version": "1.0"}
 
     assert events == ["start", "stop", "models", "llama"]


### PR DESCRIPTION
## Changes

- Adds an **About** tab to Settings.
- Displays the host application name, logo, and version.
- Displays the active Geist version beneath “Powered by Geist.”
- Reports:
  - Operating system
  - Architecture
  - Inference engine
  - Acceleration mode
  - Python runtime
- Adds compatibility handling for older Geist system responses.
- Hides Settings save/reset actions while viewing About.
- Adds a theme-aware WebGL aurora animation with:
  - Reduced-motion support
  - CSS fallback when WebGL is unavailable
  - Proper animation and resource cleanup
- Extends `/api/v1/system` with machine and runtime metadata.
- Does not display the legacy API version, inference mode, model, or provider.
