### PR TITLE
Add Kimi K3 online inference

### DIFF
--- a/agents/model_catalog.py
+++ b/agents/model_catalog.py
@@ -233,6 +233,13 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         performance_note="Server-only baseline; the official repository is hundreds of GB.",
     ),
     ModelSpec(
+        "k3", "Kimi K3", "kimi", provider="moonshot",
+        backend="openai_compatible", context_window=1048576,
+        supports_vision=True, supports_function_calling=True, supports_reasoning=True,
+        supports_streaming=True, recommended=True, local=False,
+        performance_note="Hosted through Moonshot AI's OpenAI-compatible API.",
+    ),
+    ModelSpec(
         "glm-5.2", "GLM 5.2", "glm", provider="zai", backend="openai_compatible",
         context_window=1000000, max_output_tokens=131072,
         supports_function_calling=True, supports_reasoning=True, supports_streaming=True,

--- a/plans/157-KIMI-K3-ONLINE-INFERENCE.md
+++ b/plans/157-KIMI-K3-ONLINE-INFERENCE.md
@@ -1,0 +1,27 @@
+# Kimi K3 Online Inference
+
+## Goal
+
+Add Kimi K3 to Geist's online model catalog so it can be selected and routed
+through Moonshot AI's OpenAI-compatible API.
+
+## Scope
+
+- Add the hosted `k3` model to the Moonshot provider catalog.
+- Record the capabilities Geist exposes for K3: one-million-token context,
+  vision, reasoning, function calling, and streaming.
+- Keep the existing `MOONSHOT_API_KEY` and Moonshot endpoint configuration.
+- Add focused catalog and agent-factory coverage for discovery and routing.
+
+No database migration, new provider, frontend-specific model list, or local
+runner implementation is required because the model API and UI are catalog
+driven and K3 is server backed.
+
+## Verification
+
+- Run the focused model-catalog tests.
+- Run Ruff on the changed Python files.
+- Check the patch for whitespace errors.
+- Exercise Docker startup and the model API when the local Docker environment
+  has sufficient capacity; native MLX validation is not applicable to an
+  online-only model.

--- a/tests/agents/test_model_catalog.py
+++ b/tests/agents/test_model_catalog.py
@@ -54,6 +54,16 @@ def test_heavyweight_models_are_server_backed():
     assert provider_from_string("moonshot") == "moonshot"
     assert "moonshot" in get_all_models()
 
+    kimi_k3 = get_model_spec("k3")
+    assert kimi_k3.provider == "moonshot"
+    assert kimi_k3.backend == "openai_compatible"
+    assert kimi_k3.local is False
+    assert kimi_k3.context_window == 1048576
+    assert kimi_k3.supports_vision is True
+    assert kimi_k3.supports_function_calling is True
+    assert kimi_k3.supports_reasoning is True
+    assert kimi_k3.supports_streaming is True
+
     hosted_glm = get_model_spec("glm-4.7-flash")
     assert hosted_glm.local is False
     assert get_provider_endpoint(hosted_glm.provider) == "https://api.z.ai/api/paas/v4"
@@ -152,6 +162,7 @@ def test_existing_llama_id_preserves_optimized_runner():
 
 
 @pytest.mark.parametrize("model_id", [
+    "k3",
     "kimi-k2.5",
     "moonshotai/Kimi-K2.5",
     "glm-4.7-flash",
@@ -168,12 +179,13 @@ def test_server_model_cannot_be_accidentally_loaded_locally(model_id):
         AgentFactory._infer_runner_type(model_id)
 
 
-@pytest.mark.parametrize("model_id", ["kimi-k2.5", "moonshotai/Kimi-K2.5"])
+@pytest.mark.parametrize("model_id", ["k3", "kimi-k2.5", "moonshotai/Kimi-K2.5"])
 def test_server_model_infers_openai_compatible_provider_endpoint(model_id):
     context = MagicMock()
     with patch("agents.online_agent.OnlineAgent") as online_agent:
         AgentFactory.create_agent("online", context, model=model_id)
     assert online_agent.call_args.kwargs["base_url"] == "https://api.moonshot.ai/v1"
+    assert online_agent.call_args.kwargs["model"] == model_id
 
 
 def test_hosted_glm_infers_zai_endpoint():
@@ -241,6 +253,12 @@ def test_model_api_metadata_contains_performance_fields():
 
     gpt_oss = get_model_by_id("openai/gpt-oss-20b")
     assert gpt_oss.optional_dependencies == ("kernels",)
+
+    kimi_k3 = get_model_by_id("k3")
+    assert kimi_k3.provider == "moonshot"
+    assert kimi_k3.context_window == 1048576
+    assert kimi_k3.supports_vision is True
+    assert kimi_k3.supports_reasoning is True
 
     # Mistral also exists in the legacy Hugging Face provider list. Direct
     # lookup should return the catalog-enriched local record.


### PR DESCRIPTION
## Summary

- add Kimi K3 (`k3`) to the Moonshot hosted model catalog
- expose its 1,048,576-token context plus vision, reasoning, function-calling, and streaming capabilities to Geist's catalog-driven API/UI
- verify online-agent routing through the existing Moonshot OpenAI-compatible endpoint and preserve the existing `MOONSHOT_API_KEY` configuration

Implementation reference: [official Kimi provider configuration](https://moonshotai.github.io/kimi-code/en/configuration/config-files.html).

## Validation

- `pytest tests/agents/test_model_catalog.py -k 'heavyweight_models_are_server_backed or server_model_cannot_be_accidentally_loaded_locally or server_model_infers_openai_compatible_provider_endpoint or model_api_metadata_contains_performance_fields'` — 16 passed
- `ruff check agents/model_catalog.py tests/agents/test_model_catalog.py` — passed
- `docker compose config --quiet` — passed
- `git diff --check` — passed

## Validation notes

- The complete catalog test file currently has 10 baseline failures on Apple Silicon: current `AgentFactory` returns `mlx_llama`, while those unchanged tests expect `transformers`.
- Docker startup reaches dependency installation but current `uv.lock` excludes Linux arm64, so application startup and curl/browser smoke could not run from this Apple Silicon Docker host.
- Native MLX validation is not applicable because K3 is online-only.