### PR TITLE
Add Claude review when PRs become ready

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,39 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Review pull request with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for:
+            - correctness and potential bugs
+            - security vulnerabilities
+            - performance problems
+            - missing or inadequate tests
+            - violations of AGENTS.md and repository conventions
+
+            Post only actionable findings. Use inline comments for specific
+            problems and a concise top-level summary. Do not modify code.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/plans/151-CLAUDE-READY-FOR-REVIEW.md
+++ b/plans/151-CLAUDE-READY-FOR-REVIEW.md
@@ -1,0 +1,22 @@
+# Claude Ready-for-Review Automation Plan
+
+## Goal
+
+Automatically ask Claude to review a pull request when it transitions from draft
+to ready for review.
+
+## Scope
+
+- Add a dedicated GitHub Actions workflow for the `pull_request` event's
+  `ready_for_review` activity type.
+- Reuse the repository's existing `ANTHROPIC_API_KEY` secret and Claude Code
+  GitHub Action.
+- Grant read-only repository access and write access only for pull-request
+  feedback.
+- Instruct Claude to report actionable findings without modifying the branch.
+
+## Validation
+
+- Parse the workflow as YAML.
+- Confirm the workflow has only the `ready_for_review` pull-request trigger.
+- Inspect the staged diff to ensure no unrelated files are included.


### PR DESCRIPTION
## What changed

- add a dedicated Claude auto-review workflow
- trigger it only on the `pull_request.ready_for_review` event
- limit permissions to repository read access and pull-request feedback
- instruct Claude to report actionable findings without modifying code
- add the required implementation plan

## Why

The existing Claude workflow is mention-driven. This adds one automatic review at the point a draft PR first becomes ready, without rerunning on open, reopen, new commits, or synchronization events.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-auto-review.yml")'`
- `git diff --cached --check`
- inspected the staged diff; only the workflow and plan are included

`pre-commit` was unavailable in the local environment. Docker, browser, and native MLX checks are not applicable to this GitHub-workflow-only change.