### PR TITLE
Approval resume loop, persistent sandbox sessions, and scheduled routines

### DIFF
--- a/app/api/v1/endpoints/routines.py
+++ b/app/api/v1/endpoints/routines.py
@@ -1,0 +1,91 @@
+"""API endpoints for scheduled agent routines."""
+import datetime
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.models.database.agent_routine import (
+    create_routine,
+    delete_routine,
+    get_routine,
+    list_routines,
+    update_routine,
+)
+from app.models.database.geist_user import get_default_user
+from app.schemas.routine import RoutineCreate, RoutineResponse, RoutineUpdate
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def get_current_user():
+    """Placeholder auth shim, mirroring the user-settings endpoints."""
+    return get_default_user()
+
+
+def _owned_routine_or_404(routine_id: int, user_id: int):
+    routine = get_routine(routine_id)
+    if routine is None or routine.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Routine not found")
+    return routine
+
+
+@router.get("/", response_model=list[RoutineResponse])
+async def get_routines(current_user=Depends(get_current_user)):
+    try:
+        return list_routines(current_user.user_id)
+    except Exception as error:
+        logger.error(f"Error listing routines: {error}")
+        raise HTTPException(status_code=500, detail="Internal server error") from error
+
+
+@router.post("/", response_model=RoutineResponse)
+async def create_routine_endpoint(
+    params: RoutineCreate, current_user=Depends(get_current_user)
+):
+    try:
+        return create_routine(
+            user_id=current_user.user_id,
+            name=params.name,
+            prompt=params.prompt,
+            interval_minutes=params.interval_minutes,
+            enabled=params.enabled,
+        )
+    except Exception as error:
+        logger.error(f"Error creating routine: {error}")
+        raise HTTPException(status_code=500, detail="Internal server error") from error
+
+
+@router.put("/{routine_id}", response_model=RoutineResponse)
+async def update_routine_endpoint(
+    routine_id: int, params: RoutineUpdate, current_user=Depends(get_current_user)
+):
+    _owned_routine_or_404(routine_id, current_user.user_id)
+    updated = update_routine(routine_id, params.model_dump(exclude_unset=True))
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Routine not found")
+    return updated
+
+
+@router.delete("/{routine_id}")
+async def delete_routine_endpoint(
+    routine_id: int, current_user=Depends(get_current_user)
+):
+    _owned_routine_or_404(routine_id, current_user.user_id)
+    delete_routine(routine_id)
+    return {"deleted": routine_id}
+
+
+@router.post("/{routine_id}/run_now", response_model=RoutineResponse)
+async def run_routine_now(routine_id: int, current_user=Depends(get_current_user)):
+    """Schedule the routine for the scheduler's next poll (within a minute)."""
+    _owned_routine_or_404(routine_id, current_user.user_id)
+    updated = update_routine(
+        routine_id,
+        {"next_run_at": datetime.datetime.utcnow(), "enabled": True},
+    )
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Routine not found")
+    return updated

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,11 @@ from app.api.v1.endpoints.voice import router as voice_router
 from app.api.v1.endpoints.workflows import router as workflow_router
 from app.environment import load_environment_dictionary
 from app.loopback_security import install_loopback_security
-from app.models.completion import CompleteTextParams, InitializeAgentParams
+from app.models.completion import (
+    CompleteTextParams,
+    InitializeAgentParams,
+    ToolApprovalParams,
+)
 from app.models.database.agent_preset import AgentPreset
 from app.models.database.chat_session import (
     get_all_chat_history,
@@ -52,6 +56,7 @@ from app.services.job_queue import start_worker, stop_worker
 from app.services.memory_context import build_memory_context
 from app.services.memory_scheduler import MEMORY_JOB_KIND  # noqa: F401
 from app.services.memory_service import get_chat_memory_settings
+from app.services.tool_approvals import approval_registry as tool_approval_registry
 from app.services.tool_registry import build_default_tool_registry
 from app.services.user_settings_service import UserSettingsService
 from app.static_web import install_spa
@@ -518,6 +523,21 @@ def create_app(
     @agent_router.post("/runs/{run_id}/cancel")
     def cancel_chat_run(run_id: str):
         return {"run_id": run_id, "cancelled": run_controls.cancel(run_id)}
+
+    @agent_router.post("/runs/{run_id}/tool_approval")
+    def resolve_tool_approval(run_id: str, params: ToolApprovalParams):
+        try:
+            resolved = tool_approval_registry.resolve(
+                run_id, params.call_id, params.decision
+            )
+        except ValueError as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+        if not resolved:
+            raise HTTPException(
+                status_code=404,
+                detail="No pending approval for this run and call",
+            )
+        return {"run_id": run_id, "call_id": params.call_id, "decision": params.decision}
 
     @agent_router.get("/chat_history/{session_id}")
     async def get_chat_history_endpoint(session_id: int):

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.api.v1.endpoints.files import router as files_router
 from app.api.v1.endpoints.jobs import router as jobs_router
 from app.api.v1.endpoints.memory import router as memory_router
 from app.api.v1.endpoints.models import router as models_router
+from app.api.v1.endpoints.routines import router as routines_router
 from app.api.v1.endpoints.user_settings import router as user_settings_router
 from app.api.v1.endpoints.voice import router as voice_router
 from app.api.v1.endpoints.workflows import router as workflow_router
@@ -56,6 +57,7 @@ from app.services.job_queue import start_worker, stop_worker
 from app.services.memory_context import build_memory_context
 from app.services.memory_scheduler import MEMORY_JOB_KIND  # noqa: F401
 from app.services.memory_service import get_chat_memory_settings
+from app.services.routine_scheduler import RoutineScheduler
 from app.services.tool_approvals import approval_registry as tool_approval_registry
 from app.services.tool_registry import build_default_tool_registry
 from app.services.user_settings_service import UserSettingsService
@@ -442,6 +444,40 @@ def stream_chat_completion(params: CompleteTextParams, chat_id: int | None = Non
         yield sse_event("done", {"run_id": None, "chat_id": chat_id})
 
 
+def run_routine(routine) -> None:
+    """Execute one scheduled routine through the orchestrator, unattended.
+
+    interactive=False makes the orchestrator deny approval-gated tools
+    immediately instead of waiting for a user who is not present. The run
+    persists as a normal chat session, so results are visible in the UI.
+    """
+    agent = get_active_agent(default_agent_type)
+    if not hasattr(agent, "stream_model_turn"):
+        logger.warning(
+            "Routine %s skipped: active agent has no native tool loop",
+            routine.routine_id,
+        )
+        return
+    user_id = int(get_default_user().user_id)
+    params = CompleteTextParams(
+        prompt=routine.prompt, max_tokens=1024, enable_tools=True
+    )
+    for _ in chat_orchestrator.stream(
+        backend=agent,
+        prompt=routine.prompt,
+        user_id=user_id,
+        chat_id=None,
+        config=model_request_config(params),
+        system_prompt=chat_system_prompt(True, ""),
+        enable_tools=True,
+        interactive=False,
+    ):
+        pass
+
+
+routine_scheduler = RoutineScheduler(run_routine)
+
+
 # App factory function
 def create_app(
     web_dir: str | Path | None = None,
@@ -452,6 +488,7 @@ def create_app(
     async def lifespan(_app: FastAPI):
         try:
             app.state.job_worker = start_worker()
+            routine_scheduler.start()
             app.state.ready = True
             yield
         finally:
@@ -624,6 +661,7 @@ def create_app(
     app.include_router(models_router, prefix="/api/v1/models", tags=["models"])
     app.include_router(jobs_router, prefix="/api/v1/jobs", tags=["jobs"])
     app.include_router(memory_router, prefix="/api/v1/memory", tags=["memory"])
+    app.include_router(routines_router, prefix="/api/v1/routines", tags=["routines"])
 
     @app.get("/health", include_in_schema=False)
     def health():
@@ -872,6 +910,11 @@ def _database_is_ready() -> bool:
 
 
 def _stop_runtime_services() -> None:
+    try:
+        routine_scheduler.stop()
+    except Exception:
+        logger.exception("Failed to stop the routine scheduler")
+
     try:
         stop_worker()
     except Exception:

--- a/app/models/completion.py
+++ b/app/models/completion.py
@@ -29,3 +29,11 @@ class CompleteTextParams(BaseModel):
 class InitializeAgentParams(BaseModel):
     prompt: str
     agent_type: str | None = None
+
+
+class ToolApprovalParams(BaseModel):
+    """Decision for a tool call blocked on user approval."""
+
+    call_id: str
+    # 'approve' (once) | 'session' (this chat) | 'always' (persist) | 'deny'
+    decision: str

--- a/app/models/database/__init__.py
+++ b/app/models/database/__init__.py
@@ -1,5 +1,6 @@
 from app.models.database.agent import Agent
 from app.models.database.agent_preset import AgentPreset
+from app.models.database.agent_routine import AgentRoutine
 from app.models.database.agent_snapshot import AgentSnapshot
 from app.models.database.chat_session import ChatSession
 from app.models.database.file_upload import FileUpload

--- a/app/models/database/agent_routine.py
+++ b/app/models/database/agent_routine.py
@@ -1,0 +1,151 @@
+"""AgentRoutine database model: user-defined recurring agent prompts."""
+import datetime
+from dataclasses import dataclass
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+
+from app.models.database.database import Base, SessionLocal
+
+
+class AgentRoutine(Base):
+    """A prompt the agent runs on a fixed interval without a user present."""
+
+    __tablename__ = 'agent_routine'
+
+    routine_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey('geist_user.user_id'), nullable=False)
+    name = Column(String, nullable=False)
+    prompt = Column(String, nullable=False)
+    interval_minutes = Column(Integer, nullable=False, default=60)
+    enabled = Column(Boolean, nullable=False, default=True)
+    last_run_at = Column(DateTime, nullable=True)
+    next_run_at = Column(DateTime, nullable=True)
+    create_date = Column(DateTime, default=datetime.datetime.utcnow)
+    update_date = Column(
+        DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+    )
+
+
+@dataclass
+class AgentRoutineModel:
+    routine_id: int
+    user_id: int
+    name: str
+    prompt: str
+    interval_minutes: int
+    enabled: bool
+    last_run_at: datetime.datetime | None
+    next_run_at: datetime.datetime | None
+    create_date: datetime.datetime
+    update_date: datetime.datetime
+
+
+def _to_model(routine: AgentRoutine) -> AgentRoutineModel:
+    return AgentRoutineModel(
+        routine_id=routine.routine_id,
+        user_id=routine.user_id,
+        name=routine.name,
+        prompt=routine.prompt,
+        interval_minutes=routine.interval_minutes,
+        enabled=routine.enabled,
+        last_run_at=routine.last_run_at,
+        next_run_at=routine.next_run_at,
+        create_date=routine.create_date,
+        update_date=routine.update_date,
+    )
+
+
+def create_routine(
+    user_id: int,
+    name: str,
+    prompt: str,
+    interval_minutes: int,
+    enabled: bool = True,
+) -> AgentRoutineModel:
+    with SessionLocal() as session:
+        routine = AgentRoutine(
+            user_id=user_id,
+            name=name,
+            prompt=prompt,
+            interval_minutes=interval_minutes,
+            enabled=enabled,
+            # First run happens one interval from creation, not immediately:
+            # creating a routine should not instantly fire an unattended run.
+            next_run_at=datetime.datetime.utcnow()
+            + datetime.timedelta(minutes=interval_minutes),
+        )
+        session.add(routine)
+        session.commit()
+        session.refresh(routine)
+        return _to_model(routine)
+
+
+def list_routines(user_id: int) -> list[AgentRoutineModel]:
+    with SessionLocal() as session:
+        routines = (
+            session.query(AgentRoutine)
+            .filter_by(user_id=user_id)
+            .order_by(AgentRoutine.routine_id)
+            .all()
+        )
+        return [_to_model(routine) for routine in routines]
+
+
+def get_routine(routine_id: int) -> AgentRoutineModel | None:
+    with SessionLocal() as session:
+        routine = session.query(AgentRoutine).filter_by(routine_id=routine_id).first()
+        return _to_model(routine) if routine else None
+
+
+def update_routine(routine_id: int, updates: dict) -> AgentRoutineModel | None:
+    with SessionLocal() as session:
+        routine = session.query(AgentRoutine).filter_by(routine_id=routine_id).first()
+        if not routine:
+            return None
+        for field, value in updates.items():
+            if hasattr(routine, field):
+                setattr(routine, field, value)
+        if "interval_minutes" in updates and routine.last_run_at is not None:
+            routine.next_run_at = routine.last_run_at + datetime.timedelta(
+                minutes=routine.interval_minutes
+            )
+        routine.update_date = datetime.datetime.utcnow()
+        session.commit()
+        session.refresh(routine)
+        return _to_model(routine)
+
+
+def delete_routine(routine_id: int) -> bool:
+    with SessionLocal() as session:
+        routine = session.query(AgentRoutine).filter_by(routine_id=routine_id).first()
+        if not routine:
+            return False
+        session.delete(routine)
+        session.commit()
+        return True
+
+
+def get_due_routines(now: datetime.datetime | None = None) -> list[AgentRoutineModel]:
+    now = now or datetime.datetime.utcnow()
+    with SessionLocal() as session:
+        routines = (
+            session.query(AgentRoutine)
+            .filter(AgentRoutine.enabled.is_(True))
+            .filter(AgentRoutine.next_run_at.isnot(None))
+            .filter(AgentRoutine.next_run_at <= now)
+            .order_by(AgentRoutine.next_run_at)
+            .all()
+        )
+        return [_to_model(routine) for routine in routines]
+
+
+def mark_routine_run(routine_id: int, now: datetime.datetime | None = None) -> None:
+    """Record a completed run and schedule the next one."""
+    now = now or datetime.datetime.utcnow()
+    with SessionLocal() as session:
+        routine = session.query(AgentRoutine).filter_by(routine_id=routine_id).first()
+        if not routine:
+            return
+        routine.last_run_at = now
+        routine.next_run_at = now + datetime.timedelta(minutes=routine.interval_minutes)
+        session.commit()

--- a/app/schemas/routine.py
+++ b/app/schemas/routine.py
@@ -1,0 +1,35 @@
+"""DTO models for agent routines API."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class RoutineCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    prompt: str = Field(min_length=1, max_length=8_000)
+    interval_minutes: int = Field(default=60, ge=5, le=7 * 24 * 60)
+    enabled: bool = True
+
+
+class RoutineUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    prompt: str | None = Field(default=None, min_length=1, max_length=8_000)
+    interval_minutes: int | None = Field(default=None, ge=5, le=7 * 24 * 60)
+    enabled: bool | None = None
+
+
+class RoutineResponse(BaseModel):
+    routine_id: int
+    user_id: int
+    name: str
+    prompt: str
+    interval_minutes: int
+    enabled: bool
+    last_run_at: datetime | None
+    next_run_at: datetime | None
+    create_date: datetime
+    update_date: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/services/chat_orchestrator.py
+++ b/app/services/chat_orchestrator.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import uuid
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from agents.models.agent_completion import AgentCompletion
@@ -19,11 +19,38 @@ from agents.models.tool_calling import (
     ModelRequestConfig,
     ToolCall,
     ToolContext,
+    ToolResult,
     tool_requires_approval,
 )
 from app.models.database.chat_session import get_chat_history, update_chat_history
 from app.services.agent_permissions import AgentPermissions, load_agent_permissions
+from app.services.tool_approvals import (
+    DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+    SessionGrantRegistry,
+    ToolApprovalRegistry,
+    approval_registry,
+    persist_always_allow,
+    session_grants,
+)
 from app.services.tool_registry import ToolRegistry
+
+
+UNATTENDED_DENY_MESSAGE = (
+    "BLOCKED: this tool requires user approval, but the run is unattended "
+    "(no user is present to approve it). Find an approach that avoids this "
+    "tool, and do NOT retry the call."
+)
+
+DENIED_MESSAGE = (
+    "BLOCKED: the user denied this tool call. The user has NOT consented to "
+    "this action. Do NOT retry it, and do NOT attempt the same outcome "
+    "through a different tool."
+)
+
+TIMEOUT_MESSAGE = (
+    "BLOCKED: the approval request timed out without a user response. "
+    "Silence is not consent. Do NOT retry the call."
+)
 
 
 logger = logging.getLogger(__name__)
@@ -113,9 +140,17 @@ class ChatOrchestrator:
         history_loader: Callable[[int], Any] = get_chat_history,
         history_writer: Callable[..., Any] = update_chat_history,
         permissions_loader: Callable[[int], AgentPermissions] = load_agent_permissions,
+        approvals: ToolApprovalRegistry = approval_registry,
+        grants: SessionGrantRegistry = session_grants,
+        approval_timeout_seconds: float = DEFAULT_APPROVAL_TIMEOUT_SECONDS,
+        always_allow_persister: Callable[[int, str], None] = persist_always_allow,
     ) -> None:
         self.registry = registry
         self.permissions_loader = permissions_loader
+        self.approvals = approvals
+        self.grants = grants
+        self.approval_timeout_seconds = approval_timeout_seconds
+        self.always_allow_persister = always_allow_persister
         self.run_controls = run_controls or RunControlRegistry()
         self.max_rounds = max_rounds
         self.max_tool_calls = max_tool_calls
@@ -298,6 +333,7 @@ class ChatOrchestrator:
         memory_enabled: bool = True,
         memory_mode: str = "public",
         folder_id: int | None = None,
+        interactive: bool = True,
     ) -> Iterator[ChatStreamEvent]:
         conversation = ConversationState(chat_id=chat_id, user_id=user_id)
         conversation.add_system_prompt(system_prompt)
@@ -308,6 +344,7 @@ class ChatOrchestrator:
                 logger.warning("Could not hydrate chat %s: %s", chat_id, error)
         run = conversation.begin_run(prompt)
         permissions = self.permissions_loader(user_id)
+        approved_call_ids: set[str] = set()
         context = ToolContext(
             user_id=user_id,
             chat_id=chat_id,
@@ -412,8 +449,16 @@ class ChatOrchestrator:
 
                 for call in completed_turn.tool_calls:
                     definition = self.registry.get(call.name)
+                    grant_scope = (
+                        f"chat:{conversation.chat_id}"
+                        if conversation.chat_id is not None
+                        else f"run:{run.run_id}"
+                    )
                     requires_approval = bool(
-                        definition and tool_requires_approval(definition, context)
+                        definition
+                        and tool_requires_approval(definition, context)
+                        and call.name not in self.grants.granted(grant_scope)
+                        and call.id not in approved_call_ids
                     )
                     proposed = self._tool_state(
                         call,
@@ -429,10 +474,69 @@ class ChatOrchestrator:
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
 
-                    if not requires_approval:
-                        yield ChatStreamEvent("tool_call", self._tool_state(call, "running"))
+                    denial_message: str | None = None
+                    if requires_approval:
+                        if not interactive:
+                            denial_message = UNATTENDED_DENY_MESSAGE
+                        else:
+                            yield ChatStreamEvent(
+                                "tool_call",
+                                self._tool_state(
+                                    call, "awaiting_approval", requires_approval=True
+                                ),
+                            )
+                            pending = self.approvals.request(
+                                run.run_id, call.id, call.name
+                            )
+                            decision = self.approvals.wait(
+                                pending,
+                                self.approval_timeout_seconds,
+                                cancellation=cancellation,
+                            )
+                            if cancellation.is_set():
+                                cancelled = self._tool_state(call, "cancelled")
+                                run.record_tool_call(cancelled)
+                                yield ChatStreamEvent("tool_call", cancelled)
+                                yield ChatStreamEvent("cancelled", cancelled_payload())
+                                return
+                            if decision == "deny":
+                                denial_message = (
+                                    DENIED_MESSAGE
+                                    if pending.decision is not None
+                                    else TIMEOUT_MESSAGE
+                                )
+                            else:
+                                approved_call_ids.add(call.id)
+                                if decision == "session":
+                                    self.grants.grant(grant_scope, call.name)
+                                elif decision == "always":
+                                    try:
+                                        self.always_allow_persister(user_id, call.name)
+                                    except Exception:
+                                        logger.exception(
+                                            "Could not persist always-allow for %s",
+                                            call.name,
+                                        )
 
-                    result = self.registry.execute(call, context)
+                    if denial_message is not None:
+                        result = ToolResult(
+                            call=call,
+                            status="failed",
+                            content=denial_message,
+                            summary="Tool call denied",
+                            error="approval_denied",
+                        )
+                    else:
+                        yield ChatStreamEvent("tool_call", self._tool_state(call, "running"))
+                        result = self.registry.execute(
+                            call,
+                            replace(
+                                context,
+                                approved_call_ids=frozenset(approved_call_ids),
+                                always_allow_tools=context.always_allow_tools
+                                | self.grants.granted(grant_scope),
+                            ),
+                        )
                     if cancellation.is_set():
                         yield ChatStreamEvent("cancelled", cancelled_payload())
                         return
@@ -517,6 +621,7 @@ class ChatOrchestrator:
                 {"run_id": run.run_id, "chat_id": persisted_chat_id},
             )
         finally:
+            self.approvals.cancel_run(run.run_id)
             self.run_controls.finish(run.run_id)
 
     def complete(self, **kwargs: Any) -> AgentCompletion:

--- a/app/services/execution/__init__.py
+++ b/app/services/execution/__init__.py
@@ -13,7 +13,10 @@ runs without per-call approval, while a backend that can reach host files
 
 from app.services.execution.base import ExecutionEnvironment, ExecutionResult
 from app.services.execution.docker import DockerExecutionEnvironment
-from app.services.execution.factory import create_execution_environment
+from app.services.execution.factory import (
+    create_execution_environment,
+    create_session_manager,
+)
 from app.services.execution.local import LocalExecutionEnvironment
 
 
@@ -23,4 +26,5 @@ __all__ = [
     "ExecutionResult",
     "LocalExecutionEnvironment",
     "create_execution_environment",
+    "create_session_manager",
 ]

--- a/app/services/execution/factory.py
+++ b/app/services/execution/factory.py
@@ -17,6 +17,11 @@ Environment variables (all optional; unset backend disables execution):
   bind-mounted at /workspace and makes the environment host-reaching (the
   tool then requires approval); for the local backend it is the working
   directory.
+- ``GEIST_EXEC_PERSISTENT``: ``1``/``true`` to keep one long-lived sandbox
+  container per chat session (docker backend only), so filesystem state
+  survives between terminal.run calls.
+- ``GEIST_EXEC_SESSION_TTL_SECONDS``: idle lifetime for persistent session
+  containers (default 1800).
 """
 
 from __future__ import annotations
@@ -62,3 +67,26 @@ def create_execution_environment() -> ExecutionEnvironment | None:
             backend,
         )
     return None
+
+
+def create_session_manager(environment: ExecutionEnvironment | None):
+    """Build the persistent-session manager when configured (docker only)."""
+    if not _env_flag("GEIST_EXEC_PERSISTENT"):
+        return None
+    if not isinstance(environment, DockerExecutionEnvironment):
+        if environment is not None:
+            logger.warning(
+                "GEIST_EXEC_PERSISTENT requires the docker backend; "
+                "persistent sessions disabled"
+            )
+        return None
+    from app.services.execution.session import (
+        DEFAULT_SESSION_TTL_SECONDS,
+        DockerSessionManager,
+    )
+
+    try:
+        ttl = float(os.getenv("GEIST_EXEC_SESSION_TTL_SECONDS", ""))
+    except ValueError:
+        ttl = DEFAULT_SESSION_TTL_SECONDS
+    return DockerSessionManager(environment, ttl_seconds=ttl)

--- a/app/services/execution/session.py
+++ b/app/services/execution/session.py
@@ -1,0 +1,213 @@
+"""Persistent per-chat Docker sandbox sessions.
+
+The one-shot sandbox gives every ``terminal.run`` call a fresh container, so
+multi-step workflows (install a package, then use it) cannot work. When
+``GEIST_EXEC_PERSISTENT`` is enabled, each chat session gets a named
+long-lived container (``sleep infinity``) with the same hardening posture as
+the one-shot runner, and commands run via ``docker exec``. Filesystem state
+in /workspace and /tmp survives between calls for the container's lifetime.
+
+Idle containers are reaped opportunistically: every ``run_in_session`` call
+also removes sessions that have been unused longer than the TTL, so no
+background thread is needed (the same write-time pruning pattern used for
+agent snapshots).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import threading
+import time
+
+from app.services.execution.base import (
+    DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ExecutionResult,
+    clamp_timeout,
+    truncate_output,
+)
+from app.services.execution.docker import (
+    _BASE_SECURITY_ARGS,
+    _DOCKER_OVERHEAD_SECONDS,
+    DockerExecutionEnvironment,
+    _shell_quote,
+)
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SESSION_TTL_SECONDS = 1800.0
+_NAME_SAFE_RE = re.compile(r"[^a-zA-Z0-9_.-]")
+
+
+def session_container_name(scope_key: str) -> str:
+    """Deterministic, docker-safe container name for one session scope."""
+    return f"geist-exec-{_NAME_SAFE_RE.sub('-', str(scope_key))}"
+
+
+def build_session_create_args(
+    *,
+    name: str,
+    image: str,
+    network: bool = False,
+    workspace: str | None = None,
+) -> list[str]:
+    """argv (after the runtime executable) that starts one session container."""
+    args = ["run", "--detach", "--name", name, *_BASE_SECURITY_ARGS]
+    if not network:
+        args += ["--network", "none"]
+    if workspace:
+        args += ["--volume", f"{workspace}:/workspace"]
+    else:
+        args += ["--tmpfs", "/workspace:rw,nosuid,size=256m,mode=0777"]
+    args += ["--workdir", "/workspace", image, "sleep", "infinity"]
+    return args
+
+
+def build_session_exec_args(*, name: str, command: str, timeout: int) -> list[str]:
+    """argv (after the runtime executable) that runs one command in a session."""
+    bounded = f"timeout {timeout} bash -c {_shell_quote(command)}"
+    return ["exec", "--workdir", "/workspace", name, "bash", "-c", bounded]
+
+
+class DockerSessionManager:
+    """Lazily creates, reuses, and reaps per-scope sandbox containers."""
+
+    def __init__(
+        self,
+        environment: DockerExecutionEnvironment,
+        *,
+        ttl_seconds: float = DEFAULT_SESSION_TTL_SECONDS,
+        clock=time.monotonic,
+    ):
+        self.environment = environment
+        self.ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._last_used: dict[str, float] = {}
+
+    def run_in_session(
+        self,
+        scope_key: str,
+        command: str,
+        timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    ) -> ExecutionResult:
+        runtime = self.environment.runtime()
+        if runtime is None:
+            return ExecutionResult(
+                exit_code=127,
+                stdout="",
+                stderr="No container runtime (docker/podman) is available on this host",
+                duration_seconds=0.0,
+            )
+
+        self._reap_idle(runtime, exclude=scope_key)
+
+        name = session_container_name(scope_key)
+        timeout = clamp_timeout(timeout_seconds)
+        started = self._clock()
+
+        create_error = self._ensure_container(runtime, name)
+        if create_error is not None:
+            return ExecutionResult(
+                exit_code=125,
+                stdout="",
+                stderr=f"Could not start sandbox session: {create_error}",
+                duration_seconds=self._clock() - started,
+            )
+
+        try:
+            completed = subprocess.run(
+                [
+                    runtime,
+                    *build_session_exec_args(name=name, command=command, timeout=timeout),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout + _DOCKER_OVERHEAD_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return ExecutionResult(
+                exit_code=124,
+                stdout="",
+                stderr=f"Sandbox session did not respond within {timeout} seconds",
+                duration_seconds=self._clock() - started,
+                timed_out=True,
+            )
+        finally:
+            with self._lock:
+                self._last_used[scope_key] = self._clock()
+
+        stdout, stdout_truncated = truncate_output(completed.stdout)
+        stderr, stderr_truncated = truncate_output(completed.stderr)
+        return ExecutionResult(
+            exit_code=completed.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=self._clock() - started,
+            timed_out=completed.returncode == 124,
+            truncated=stdout_truncated or stderr_truncated,
+        )
+
+    def _ensure_container(self, runtime: str, name: str) -> str | None:
+        """Start the session container if it isn't already running."""
+        inspect = subprocess.run(
+            [runtime, "inspect", "--format", "{{.State.Running}}", name],
+            capture_output=True,
+            text=True,
+        )
+        if inspect.returncode == 0 and inspect.stdout.strip() == "true":
+            return None
+        if inspect.returncode == 0:
+            # Exists but stopped (host restart, OOM-kill): replace it.
+            subprocess.run([runtime, "rm", "-f", name], capture_output=True, text=True)
+
+        created = subprocess.run(
+            [
+                runtime,
+                *build_session_create_args(
+                    name=name,
+                    image=self.environment.image,
+                    network=self.environment.network,
+                    workspace=self.environment.workspace,
+                ),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if created.returncode != 0:
+            return created.stderr.strip() or f"exit {created.returncode}"
+        return None
+
+    def _reap_idle(self, runtime: str, exclude: str | None = None) -> None:
+        now = self._clock()
+        with self._lock:
+            expired = [
+                scope
+                for scope, last_used in self._last_used.items()
+                if scope != exclude and now - last_used > self.ttl_seconds
+            ]
+            for scope in expired:
+                self._last_used.pop(scope, None)
+        for scope in expired:
+            self._remove(runtime, scope)
+
+    def _remove(self, runtime: str, scope_key: str) -> None:
+        name = session_container_name(scope_key)
+        try:
+            subprocess.run([runtime, "rm", "-f", name], capture_output=True, text=True)
+            logger.info("Reaped idle sandbox session %s", name)
+        except Exception:
+            logger.warning("Could not remove sandbox session %s", name, exc_info=True)
+
+    def shutdown(self) -> None:
+        """Remove every tracked session container (app shutdown)."""
+        runtime = self.environment.runtime()
+        with self._lock:
+            scopes = list(self._last_used)
+            self._last_used.clear()
+        if runtime is None:
+            return
+        for scope in scopes:
+            self._remove(runtime, scope)

--- a/app/services/routine_scheduler.py
+++ b/app/services/routine_scheduler.py
@@ -1,0 +1,106 @@
+"""Background scheduler that runs due agent routines.
+
+A routine is a stored prompt run through the chat orchestrator on a fixed
+interval with nobody watching. Runs are therefore non-interactive: the
+orchestrator is invoked with ``interactive=False``, so any tool call that
+would normally wait for user approval is denied immediately (the Hermes
+``cron_mode: deny`` posture) instead of blocking on a user who is not there.
+
+The scheduler is a single daemon thread polling for due routines, mirroring
+the JobWorker pattern. The actual run is delegated to an injected runner
+callable so the scheduler itself stays free of model/agent wiring.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+from collections.abc import Callable
+
+from app.models.database.agent_routine import (
+    AgentRoutineModel,
+    get_due_routines,
+    mark_routine_run,
+)
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLL_INTERVAL_SECONDS = 60.0
+
+RoutineRunner = Callable[[AgentRoutineModel], None]
+
+
+class RoutineScheduler:
+    def __init__(
+        self,
+        runner: RoutineRunner,
+        *,
+        poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        due_loader: Callable[[], list[AgentRoutineModel]] | None = None,
+        run_marker: Callable[[int], None] | None = None,
+    ):
+        self.runner = runner
+        self.poll_interval_seconds = poll_interval_seconds
+        self.due_loader = due_loader or (
+            lambda: get_due_routines(datetime.datetime.utcnow())
+        )
+        self.run_marker = run_marker or mark_routine_run
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def run_due_once(self) -> int:
+        """Run everything currently due; returns how many routines ran.
+
+        A routine is marked as run BEFORE the runner executes, so a crash or
+        restart mid-run delays the next occurrence instead of re-firing the
+        same routine in a loop.
+        """
+        try:
+            due = self.due_loader()
+        except Exception:
+            logger.exception("Could not load due routines")
+            return 0
+
+        ran = 0
+        for routine in due:
+            if self._stop_event.is_set():
+                break
+            try:
+                self.run_marker(routine.routine_id)
+            except Exception:
+                logger.exception(
+                    "Could not mark routine %s as run; skipping this cycle",
+                    routine.routine_id,
+                )
+                continue
+            try:
+                logger.info(
+                    "Running routine %s (%r)", routine.routine_id, routine.name
+                )
+                self.runner(routine)
+                ran += 1
+            except Exception:
+                logger.exception("Routine %s failed", routine.routine_id)
+        return ran
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self.run_due_once()
+            self._stop_event.wait(self.poll_interval_seconds)
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop, name="geist-routine-scheduler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None

--- a/app/services/tool_approvals.py
+++ b/app/services/tool_approvals.py
@@ -1,0 +1,148 @@
+"""In-flight tool approval decisions and session-scoped grants.
+
+The chat orchestrator blocks a run when a tool call needs approval; the
+client answers through the approval endpoint with one of four decisions
+(Hermes/OpenCode tiers):
+
+- ``approve``: run this one call.
+- ``session``: run it and stop asking for this tool in this chat session.
+- ``always``: run it and persist the tool onto the user's always-allow list.
+- ``deny``: refuse the call; the model is told not to retry.
+
+Waiting fails closed: no decision within the timeout counts as a deny
+("silence is not consent").
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+
+
+logger = logging.getLogger(__name__)
+
+APPROVAL_DECISIONS = frozenset({"approve", "session", "always", "deny"})
+DEFAULT_APPROVAL_TIMEOUT_SECONDS = 300.0
+
+
+@dataclass
+class PendingApproval:
+    run_id: str
+    call_id: str
+    tool_name: str
+    event: threading.Event = field(default_factory=threading.Event)
+    decision: str | None = None
+
+
+class ToolApprovalRegistry:
+    """Bridges the blocked orchestrator thread and the approval endpoint."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: dict[tuple[str, str], PendingApproval] = {}
+
+    def request(self, run_id: str, call_id: str, tool_name: str) -> PendingApproval:
+        pending = PendingApproval(run_id=run_id, call_id=call_id, tool_name=tool_name)
+        with self._lock:
+            self._pending[(run_id, call_id)] = pending
+        return pending
+
+    def resolve(self, run_id: str, call_id: str, decision: str) -> bool:
+        """Record a decision; False when nothing is waiting for this call."""
+        if decision not in APPROVAL_DECISIONS:
+            raise ValueError(
+                f"decision must be one of {sorted(APPROVAL_DECISIONS)}"
+            )
+        with self._lock:
+            pending = self._pending.pop((run_id, call_id), None)
+        if pending is None:
+            return False
+        pending.decision = decision
+        pending.event.set()
+        return True
+
+    def wait(
+        self,
+        pending: PendingApproval,
+        timeout_seconds: float,
+        cancellation: threading.Event | None = None,
+    ) -> str:
+        """Block until a decision, cancellation, or timeout (both deny)."""
+        remaining = timeout_seconds
+        interval = 0.25
+        while remaining > 0:
+            if pending.event.wait(min(interval, remaining)):
+                return pending.decision or "deny"
+            if cancellation is not None and cancellation.is_set():
+                break
+            remaining -= interval
+        with self._lock:
+            self._pending.pop((pending.run_id, pending.call_id), None)
+        return "deny"
+
+    def cancel_run(self, run_id: str) -> None:
+        """Deny everything still pending for a finished/cancelled run."""
+        with self._lock:
+            entries = [
+                self._pending.pop(key)
+                for key in [key for key in self._pending if key[0] == run_id]
+            ]
+        for pending in entries:
+            pending.decision = "deny"
+            pending.event.set()
+
+    def has_pending(self, run_id: str) -> bool:
+        with self._lock:
+            return any(key[0] == run_id for key in self._pending)
+
+    def pending(self) -> list[PendingApproval]:
+        """Snapshot of everything currently awaiting a decision."""
+        with self._lock:
+            return list(self._pending.values())
+
+
+class SessionGrantRegistry:
+    """'Allow for this session' grants, scoped to a chat session (in-memory)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._grants: dict[str, set[str]] = {}
+
+    def grant(self, scope_key: str, tool_name: str) -> None:
+        with self._lock:
+            self._grants.setdefault(scope_key, set()).add(tool_name)
+
+    def granted(self, scope_key: str) -> frozenset[str]:
+        with self._lock:
+            return frozenset(self._grants.get(scope_key, set()))
+
+    def clear(self, scope_key: str) -> None:
+        with self._lock:
+            self._grants.pop(scope_key, None)
+
+
+# Shared singletons: the orchestrator waits on these, the API resolves them.
+approval_registry = ToolApprovalRegistry()
+session_grants = SessionGrantRegistry()
+
+
+def persist_always_allow(user_id: int, tool_name: str) -> None:
+    """Append a tool to the user's stored always-allow list ("always" tier)."""
+    from app.models.database.user_settings import get_user_settings, update_user_settings
+    from app.services.agent_permissions import normalize_agent_permissions
+
+    settings = get_user_settings(user_id)
+    if settings is None:
+        logger.warning(
+            "Cannot persist always-allow for unknown user %s", user_id
+        )
+        return
+    try:
+        current = normalize_agent_permissions(settings.agent_permissions or {})
+    except ValueError:
+        current = {"mode": "default", "always_allow": []}
+    if tool_name in current["always_allow"]:
+        return
+    current["always_allow"] = sorted({*current["always_allow"], tool_name})
+    update_user_settings(user_id, {"agent_permissions": current})

--- a/app/services/tool_registry.py
+++ b/app/services/tool_registry.py
@@ -23,7 +23,10 @@ from agents.models.tool_calling import (
     tool_requires_approval,
 )
 from app.services.document_search import DocumentSearchService
-from app.services.execution import create_execution_environment
+from app.services.execution import (
+    create_execution_environment,
+    create_session_manager,
+)
 from app.services.execution.base import (
     DEFAULT_COMMAND_TIMEOUT_SECONDS,
     MAX_COMMAND_TIMEOUT_SECONDS,
@@ -402,13 +405,21 @@ def build_default_tool_registry() -> ToolRegistry:
     # budget, so a backend must hold at least one of them.
     execution_environment = create_execution_environment()
     if execution_environment is not None:
+        session_manager = create_session_manager(execution_environment)
 
         def terminal_run(
             context: ToolContext, arguments: TerminalRunArguments
         ) -> ToolExecutionOutput:
-            result = execution_environment.run(
-                arguments.command, timeout_seconds=arguments.timeout_seconds
-            )
+            if session_manager is not None and context.chat_id is not None:
+                result = session_manager.run_in_session(
+                    f"chat-{context.chat_id}",
+                    arguments.command,
+                    timeout_seconds=arguments.timeout_seconds,
+                )
+            else:
+                result = execution_environment.run(
+                    arguments.command, timeout_seconds=arguments.timeout_seconds
+                )
             summary = (
                 f"exit {result.exit_code}"
                 + (" (timed out)" if result.timed_out else "")

--- a/client/geist/src/Chat.tsx
+++ b/client/geist/src/Chat.tsx
@@ -10,7 +10,7 @@ import EnhancedChatInput from './Components/EnhancedChatInput';
 import ChatMemoryControls from './Components/ChatMemoryControls';
 import MemoryExplorer from './Components/MemoryExplorer';
 import StagePanelIcon from './Components/StagePanelIcon';
-import { ChatPair, ChatHistory, ChatTurnResult } from './chatTypes';
+import { ChatPair, ChatHistory, ChatTurnResult, ToolApprovalDecision } from './chatTypes';
 import { NavLink, useNavigate, useParams } from 'react-router-dom';
 
 const PAGE_SIZE = 20;
@@ -377,6 +377,24 @@ const Chat = () => {
     }
   };
 
+  const handleToolApproval = useCallback(
+    async (runId: string, callId: string, decision: ToolApprovalDecision) => {
+      try {
+        const response = await fetch(`/agent/runs/${runId}/tool_approval`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ call_id: callId, decision })
+        });
+        if (!response.ok) {
+          console.error(`Tool approval failed: ${response.statusText}`);
+        }
+      } catch (err) {
+        console.error('Tool approval failed:', err);
+      }
+    },
+    []
+  );
+
   const handleNewChat = () => {
     const newChatScope: MemoryScope = folderFilter === 'all'
       ? { kind: 'public' }
@@ -585,6 +603,7 @@ const Chat = () => {
               <ChatTextArea
                 chatHistory={displayedHistory}
                 isLoading={isLoading}
+                onToolApproval={handleToolApproval}
               />
             </div>
           </div>

--- a/client/geist/src/Components/ChatTextArea.tsx
+++ b/client/geist/src/Components/ChatTextArea.tsx
@@ -1,5 +1,5 @@
-import React, { forwardRef } from 'react';
-import { ChatHistory, ToolCallStatus } from '../chatTypes';
+import React, { forwardRef, useState } from 'react';
+import { ChatHistory, ToolApprovalDecision, ToolCallStatus } from '../chatTypes';
 
 
 const statusLabel = (status: ToolCallStatus | string): string =>
@@ -12,12 +12,26 @@ const statusTone = (status: ToolCallStatus): string => {
   return '';
 };
 
+const approvalChoices: { decision: ToolApprovalDecision; label: string }[] = [
+  { decision: 'approve', label: 'Approve once' },
+  { decision: 'session', label: 'Allow for session' },
+  { decision: 'always', label: 'Always allow' },
+  { decision: 'deny', label: 'Deny' }
+];
+
 interface ChatTextAreaProps extends ChatHistory {
   isLoading?: boolean;
+  onToolApproval?: (runId: string, callId: string, decision: ToolApprovalDecision) => void;
 }
 
 const ChatTextArea = forwardRef<HTMLDivElement, ChatTextAreaProps>((props, ref) => {
   const isEmpty = props.chatHistory.length === 0 && !props.isLoading;
+  const [answeredCallIds, setAnsweredCallIds] = useState<Set<string>>(new Set());
+
+  const answerApproval = (runId: string, callId: string, decision: ToolApprovalDecision) => {
+    setAnsweredCallIds((prev) => new Set(prev).add(callId));
+    props.onToolApproval?.(runId, callId, decision);
+  };
 
   return (
     <div ref={ref} className={`chat-history${isEmpty ? ' chat-history-empty' : ''}`}>
@@ -93,6 +107,28 @@ const ChatTextArea = forwardRef<HTMLDivElement, ChatTextAreaProps>((props, ref) 
                 {needsApproval && (
                   <div role="status" className="status-badge warning" style={{ marginTop: 8 }}>
                     Approval required
+                  </div>
+                )}
+                {toolCall.status === 'awaiting_approval'
+                  && element.run_id
+                  && props.onToolApproval
+                  && (
+                  <div
+                    role="group"
+                    aria-label={`Approve ${toolCall.name}`}
+                    style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 8 }}
+                  >
+                    {approvalChoices.map((choice) => (
+                      <button
+                        key={choice.decision}
+                        type="button"
+                        className={`button button-small ${choice.decision === 'deny' ? 'button-danger' : 'button-secondary'}`}
+                        disabled={answeredCallIds.has(toolCall.id)}
+                        onClick={() => answerApproval(element.run_id as string, toolCall.id, choice.decision)}
+                      >
+                        {choice.label}
+                      </button>
+                    ))}
                   </div>
                 )}
                 {toolCall.result_summary && <div style={{ marginTop: 8 }}>{toolCall.result_summary}</div>}

--- a/client/geist/src/Components/RoutinesSection.tsx
+++ b/client/geist/src/Components/RoutinesSection.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import SettingsToggle from './SettingsToggle';
+
+export interface Routine {
+  routine_id: number;
+  name: string;
+  prompt: string;
+  interval_minutes: number;
+  enabled: boolean;
+  last_run_at: string | null;
+  next_run_at: string | null;
+}
+
+const RoutinesSection: React.FC = () => {
+  const [routines, setRoutines] = useState<Routine[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [intervalMinutes, setIntervalMinutes] = useState(60);
+  const [saving, setSaving] = useState(false);
+
+  const fetchRoutines = useCallback(async () => {
+    try {
+      setError(null);
+      const response = await fetch('/api/v1/routines/');
+      if (!response.ok) throw new Error(response.statusText);
+      setRoutines(await response.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load routines');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchRoutines();
+  }, [fetchRoutines]);
+
+  const createRoutine = async () => {
+    if (!name.trim() || !prompt.trim()) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await fetch('/api/v1/routines/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          prompt: prompt.trim(),
+          interval_minutes: intervalMinutes
+        })
+      });
+      if (!response.ok) throw new Error(response.statusText);
+      setName('');
+      setPrompt('');
+      await fetchRoutines();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create routine');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleRoutine = async (routine: Routine, enabled: boolean) => {
+    try {
+      const response = await fetch(`/api/v1/routines/${routine.routine_id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled })
+      });
+      if (!response.ok) throw new Error(response.statusText);
+      await fetchRoutines();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update routine');
+    }
+  };
+
+  const removeRoutine = async (routine: Routine) => {
+    if (!window.confirm(`Delete routine "${routine.name}"?`)) return;
+    try {
+      const response = await fetch(`/api/v1/routines/${routine.routine_id}`, {
+        method: 'DELETE'
+      });
+      if (!response.ok) throw new Error(response.statusText);
+      await fetchRoutines();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete routine');
+    }
+  };
+
+  const runNow = async (routine: Routine) => {
+    try {
+      const response = await fetch(`/api/v1/routines/${routine.routine_id}/run_now`, {
+        method: 'POST'
+      });
+      if (!response.ok) throw new Error(response.statusText);
+      await fetchRoutines();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to schedule routine');
+    }
+  };
+
+  return (
+    <section className="settings-section">
+      <header className="settings-section-header">
+        <h3>Scheduled Routines</h3>
+        <p>
+          Recurring prompts the agent runs unattended. Tools that require approval are
+          denied during routine runs; results appear as chat sessions.
+        </p>
+      </header>
+
+      {error && <div className="notice notice-error">{error}</div>}
+
+      <div className="settings-subsection">
+        <span className="settings-label">New Routine</span>
+        <div className="settings-field">
+          <label className="settings-label" htmlFor="routine-name">Name</label>
+          <input
+            id="routine-name"
+            className="form-control"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Morning digest"
+          />
+        </div>
+        <div className="settings-field">
+          <label className="settings-label" htmlFor="routine-prompt">Prompt</label>
+          <textarea
+            id="routine-prompt"
+            className="form-control"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Summarize my uploaded documents that changed this week."
+            rows={3}
+          />
+        </div>
+        <div className="settings-field">
+          <label className="settings-label" htmlFor="routine-interval">Interval (minutes)</label>
+          <input
+            id="routine-interval"
+            className="form-control"
+            type="number"
+            min={5}
+            value={intervalMinutes}
+            onChange={(e) => setIntervalMinutes(Number(e.target.value) || 60)}
+          />
+        </div>
+        <button
+          className="button"
+          onClick={createRoutine}
+          disabled={saving || !name.trim() || !prompt.trim()}
+        >
+          {saving ? 'Creating...' : 'Create Routine'}
+        </button>
+      </div>
+
+      <div className="settings-subsection">
+        <span className="settings-label">Your Routines</span>
+        {loading ? (
+          <div className="empty-state compact">Loading routines...</div>
+        ) : routines.length === 0 ? (
+          <div className="empty-state compact">No routines yet.</div>
+        ) : (
+          routines.map((routine) => (
+            <div
+              key={routine.routine_id}
+              data-testid={`routine-${routine.routine_id}`}
+              className="settings-field"
+              style={{
+                border: '1px solid var(--geist-color-border)',
+                borderRadius: 'var(--geist-radius-lg)',
+                padding: '10px 12px'
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <strong>{routine.name}</strong>
+                <span className="settings-description">every {routine.interval_minutes} min</span>
+              </div>
+              <p className="settings-description" style={{ marginTop: 4 }}>{routine.prompt}</p>
+              {routine.next_run_at && (
+                <p className="settings-description">Next run: {routine.next_run_at}</p>
+              )}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 8 }}>
+                <SettingsToggle
+                  label="Enabled"
+                  checked={routine.enabled}
+                  onChange={(value) => toggleRoutine(routine, value)}
+                />
+                <button className="button button-secondary button-small" onClick={() => runNow(routine)}>
+                  Run Now
+                </button>
+                <button className="button button-danger button-small" onClick={() => removeRoutine(routine)}>
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default RoutinesSection;

--- a/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
+++ b/client/geist/src/Components/__tests__/ChatTextArea.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ChatTextArea from '../ChatTextArea';
 import { ChatPair } from '../../chatTypes';
 
@@ -129,5 +129,42 @@ describe('ChatTextArea tool activity', () => {
       'href',
       'https://example.com/notes.txt',
     );
+  });
+});
+
+describe('ChatTextArea approval decisions', () => {
+  const awaitingTurn = (): ChatPair => ({
+    run_id: 'run_9',
+    user: 'Write the file',
+    ai: '',
+    status: 'awaiting_approval',
+    tool_calls: [
+      {
+        id: 'call_gated',
+        name: 'workspace.write_markdown',
+        arguments: { path: 'notes.md' },
+        status: 'awaiting_approval',
+        requires_approval: true,
+      },
+    ],
+  });
+
+  it('offers the four decision tiers and reports the choice', () => {
+    const onToolApproval = jest.fn();
+    render(<ChatTextArea chatHistory={[awaitingTurn()]} onToolApproval={onToolApproval} />);
+
+    const group = screen.getByRole('group', { name: 'Approve workspace.write_markdown' });
+    expect(group).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow for session' }));
+    expect(onToolApproval).toHaveBeenCalledWith('run_9', 'call_gated', 'session');
+
+    // Buttons disable after a decision to prevent double submission.
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeDisabled();
+  });
+
+  it('renders no decision buttons without a handler', () => {
+    render(<ChatTextArea chatHistory={[awaitingTurn()]} />);
+    expect(screen.queryByRole('button', { name: 'Approve once' })).not.toBeInTheDocument();
   });
 });

--- a/client/geist/src/Components/__tests__/RoutinesSection.test.tsx
+++ b/client/geist/src/Components/__tests__/RoutinesSection.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import RoutinesSection from '../RoutinesSection';
+
+const routinesResponse = [
+  {
+    routine_id: 1,
+    name: 'Morning digest',
+    prompt: 'Summarize my documents',
+    interval_minutes: 60,
+    enabled: true,
+    last_run_at: null,
+    next_run_at: '2026-08-02T13:00:00Z',
+  },
+];
+
+describe('RoutinesSection', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  it('lists routines from the API', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => routinesResponse,
+    });
+
+    render(<RoutinesSection />);
+
+    expect(screen.getByText(/Loading routines/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Morning digest')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/every 60 min/i)).toBeInTheDocument();
+  });
+
+  it('creates a routine and refreshes the list', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] }) // initial list
+      .mockResolvedValueOnce({ ok: true, json: async () => routinesResponse[0] }) // create
+      .mockResolvedValueOnce({ ok: true, json: async () => routinesResponse }); // refresh
+
+    render(<RoutinesSection />);
+    await waitFor(() => screen.getByText(/No routines yet/i));
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Morning digest' },
+    });
+    fireEvent.change(screen.getByLabelText('Prompt'), {
+      target: { value: 'Summarize my documents' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Routine' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Morning digest')).toBeInTheDocument();
+    });
+
+    const createCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(createCall[0]).toBe('/api/v1/routines/');
+    expect(JSON.parse(createCall[1].body)).toEqual({
+      name: 'Morning digest',
+      prompt: 'Summarize my documents',
+      interval_minutes: 60,
+    });
+  });
+
+  it('deletes a routine after confirmation', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: async () => routinesResponse })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ deleted: 1 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<RoutinesSection />);
+    await waitFor(() => screen.getByText('Morning digest'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No routines yet/i)).toBeInTheDocument();
+    });
+    const deleteCall = (global.fetch as jest.Mock).mock.calls[1];
+    expect(deleteCall[0]).toBe('/api/v1/routines/1');
+    expect(deleteCall[1].method).toBe('DELETE');
+  });
+});

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -5,12 +5,13 @@ import AgentConfigSection from './Components/AgentConfigSection';
 import GenerationParamsSection from './Components/GenerationParamsSection';
 import RAGSettingsSection from './Components/RAGSettingsSection';
 import AgentPermissionsSection from './Components/AgentPermissionsSection';
+import RoutinesSection from './Components/RoutinesSection';
 import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
 import AboutSection from './Components/AboutSection';
 import useOverflowObserver from './Hooks/useOverflowObserver';
 
-type Tab = 'general' | 'models' | 'generation' | 'rag' | 'permissions' | 'ui' | 'developer' | 'about';
+type Tab = 'general' | 'models' | 'generation' | 'rag' | 'permissions' | 'routines' | 'ui' | 'developer' | 'about';
 
 const agentTypeOptions = [
   { value: 'local', label: 'Local Model' },
@@ -122,6 +123,7 @@ const Settings: React.FC = () => {
     { id: 'generation' as Tab, label: 'Generation' },
     { id: 'rag' as Tab, label: 'Files and RAG' },
     { id: 'permissions' as Tab, label: 'Permissions' },
+    { id: 'routines' as Tab, label: 'Routines' },
     { id: 'ui' as Tab, label: 'Appearance' },
     { id: 'developer' as Tab, label: 'Developer' },
     { id: 'about' as Tab, label: 'About' }
@@ -260,6 +262,8 @@ const Settings: React.FC = () => {
               onChange={(value) => updateLocalSetting('agent_permissions', value)}
             />
           )}
+
+          {activeTab === 'routines' && <RoutinesSection />}
 
           {activeTab === 'ui' && (
             <UIPreferencesSection

--- a/client/geist/src/chatTypes.ts
+++ b/client/geist/src/chatTypes.ts
@@ -84,3 +84,5 @@ export interface ChatPair {
 export interface ChatHistory {
   chatHistory: ChatPair[];
 }
+
+export type ToolApprovalDecision = 'approve' | 'session' | 'always' | 'deny';

--- a/migrations/versions/c7d9e1f3a5b7_add_agent_routine_table.py
+++ b/migrations/versions/c7d9e1f3a5b7_add_agent_routine_table.py
@@ -1,0 +1,46 @@
+"""add agent routine table
+
+Revision ID: c7d9e1f3a5b7
+Revises: b2e5f7a9c3d1
+Create Date: 2026-08-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "c7d9e1f3a5b7"
+down_revision: str | None = "b2e5f7a9c3d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_routine",
+        sa.Column("routine_id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("geist_user.user_id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("prompt", sa.String(), nullable=False),
+        sa.Column("interval_minutes", sa.Integer(), nullable=False, server_default="60"),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("last_run_at", sa.DateTime(), nullable=True),
+        sa.Column("next_run_at", sa.DateTime(), nullable=True),
+        sa.Column("create_date", sa.DateTime(), nullable=True),
+        sa.Column("update_date", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_agent_routine_next_run", "agent_routine", ["enabled", "next_run_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_routine_next_run", table_name="agent_routine")
+    op.drop_table("agent_routine")

--- a/tests/services/test_chat_orchestrator.py
+++ b/tests/services/test_chat_orchestrator.py
@@ -14,6 +14,7 @@ from agents.models.tool_calling import (
 )
 from app.services.agent_permissions import AgentPermissions
 from app.services.chat_orchestrator import ChatOrchestrator, RunControlRegistry
+from app.services.tool_approvals import SessionGrantRegistry, ToolApprovalRegistry
 from app.services.tool_registry import ToolRegistry
 
 
@@ -511,6 +512,9 @@ def test_require_approval_permissions_gate_read_only_tool():
         history_loader=lambda chat_id: [],
         history_writer=lambda **kwargs: SimpleNamespace(chat_session_id=1),
         permissions_loader=lambda user_id: AgentPermissions(mode="require_approval"),
+        approvals=ToolApprovalRegistry(),
+        grants=SessionGrantRegistry(),
+        approval_timeout_seconds=0.05,
     )
 
     events = list(
@@ -524,9 +528,14 @@ def test_require_approval_permissions_gate_read_only_tool():
         )
     )
 
+    # No decision arrives, so the approval times out and fails closed.
     tool_states = [event.payload for event in events if event.event == "tool_call"]
-    assert [state.status for state in tool_states] == ["proposed", "awaiting_approval"]
-    assert all(state.requires_approval is True for state in tool_states)
+    assert [state.status for state in tool_states] == [
+        "proposed",
+        "awaiting_approval",
+        "failed",
+    ]
+    assert tool_states[-1].error == "approval_denied"
 
 
 def test_always_allow_permissions_skip_approval_for_listed_tool():
@@ -574,3 +583,260 @@ def test_always_allow_permissions_skip_approval_for_listed_tool():
 
     tool_states = [event.payload for event in events if event.event == "tool_call"]
     assert [state.status for state in tool_states] == ["proposed", "running", "succeeded"]
+
+
+def _resolver(approvals: ToolApprovalRegistry, decision: str, decisions_made: list):
+    """Background thread: resolve each pending approval with `decision`."""
+    import threading
+    import time
+
+    def resolve_loop():
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            for pending in approvals.pending():
+                approvals.resolve(pending.run_id, pending.call_id, decision)
+                decisions_made.append((pending.tool_name, decision))
+                return
+            time.sleep(0.01)
+
+    thread = threading.Thread(target=resolve_loop, daemon=True)
+    thread.start()
+    return thread
+
+
+def _approval_orchestrator(registry, *, approvals, grants=None, persister=None):
+    return ChatOrchestrator(
+        registry,
+        history_loader=lambda chat_id: [],
+        history_writer=lambda **kwargs: SimpleNamespace(chat_session_id=1),
+        permissions_loader=lambda user_id: AgentPermissions(mode="require_approval"),
+        approvals=approvals,
+        grants=grants or SessionGrantRegistry(),
+        approval_timeout_seconds=5.0,
+        always_allow_persister=persister or (lambda user_id, tool_name: None),
+    )
+
+
+def _gated_registry(calls):
+    registry = ToolRegistry()
+    registry.register(
+        ToolDefinition(
+            name="documents.search",
+            description="Search documents",
+            arguments_model=LookupArguments,
+            handler=lambda context, arguments: (
+                calls.append(arguments.query),
+                ToolExecutionOutput(content="found"),
+            )[1],
+        )
+    )
+    return registry
+
+
+def test_approval_approve_resumes_and_executes():
+    calls = []
+    approvals = ToolApprovalRegistry()
+    registry = _gated_registry(calls)
+    backend = ScriptedBackend(
+        [
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_1", name="documents.search", arguments={"query": "q"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(text="Found it.", finish_reason="stop"),
+        ]
+    )
+    orchestrator = _approval_orchestrator(registry, approvals=approvals)
+    decisions = []
+    _resolver(approvals, "approve", decisions)
+
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="search",
+            user_id=1,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    tool_states = [event.payload for event in events if event.event == "tool_call"]
+    assert [state.status for state in tool_states] == [
+        "proposed",
+        "awaiting_approval",
+        "running",
+        "succeeded",
+    ]
+    assert calls == ["q"]
+    assert decisions == [("documents.search", "approve")]
+
+
+def test_approval_deny_blocks_and_tells_model():
+    calls = []
+    approvals = ToolApprovalRegistry()
+    registry = _gated_registry(calls)
+    backend = ScriptedBackend(
+        [
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_1", name="documents.search", arguments={"query": "q"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(text="Understood.", finish_reason="stop"),
+        ]
+    )
+    orchestrator = _approval_orchestrator(registry, approvals=approvals)
+    _resolver(approvals, "deny", [])
+
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="search",
+            user_id=1,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    tool_states = [event.payload for event in events if event.event == "tool_call"]
+    assert [state.status for state in tool_states] == [
+        "proposed",
+        "awaiting_approval",
+        "failed",
+    ]
+    assert calls == []
+    tool_message = backend.requests[1]["messages"][-1]
+    assert tool_message["role"] == "tool"
+    assert "denied" in tool_message["content"]
+    assert "Do NOT retry" in tool_message["content"]
+
+
+def test_approval_session_grant_skips_second_ask():
+    calls = []
+    approvals = ToolApprovalRegistry()
+    grants = SessionGrantRegistry()
+    registry = _gated_registry(calls)
+    backend = ScriptedBackend(
+        [
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_1", name="documents.search", arguments={"query": "a"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_2", name="documents.search", arguments={"query": "b"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(text="Both done.", finish_reason="stop"),
+        ]
+    )
+    orchestrator = _approval_orchestrator(registry, approvals=approvals, grants=grants)
+    _resolver(approvals, "session", [])
+
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="search twice",
+            user_id=1,
+            chat_id=7,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    tool_states = [event.payload for event in events if event.event == "tool_call"]
+    assert [state.status for state in tool_states] == [
+        "proposed",
+        "awaiting_approval",
+        "running",
+        "succeeded",
+        # second call: session grant, no awaiting_approval round-trip
+        "proposed",
+        "running",
+        "succeeded",
+    ]
+    assert calls == ["a", "b"]
+    assert "documents.search" in grants.granted("chat:7")
+
+
+def test_approval_always_persists_to_settings():
+    calls = []
+    persisted = []
+    approvals = ToolApprovalRegistry()
+    registry = _gated_registry(calls)
+    backend = ScriptedBackend(
+        [
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_1", name="documents.search", arguments={"query": "q"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(text="Done.", finish_reason="stop"),
+        ]
+    )
+    orchestrator = _approval_orchestrator(
+        registry,
+        approvals=approvals,
+        persister=lambda user_id, tool_name: persisted.append((user_id, tool_name)),
+    )
+    _resolver(approvals, "always", [])
+
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="search",
+            user_id=9,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+        )
+    )
+
+    tool_states = [event.payload for event in events if event.event == "tool_call"]
+    assert tool_states[-1].status == "succeeded"
+    assert calls == ["q"]
+    assert persisted == [(9, "documents.search")]
+
+
+def test_non_interactive_runs_deny_gated_tools_immediately():
+    calls = []
+    registry = _gated_registry(calls)
+    backend = ScriptedBackend(
+        [
+            ModelTurn(
+                tool_calls=[
+                    ToolCall(id="call_1", name="documents.search", arguments={"query": "q"})
+                ],
+                finish_reason="tool_calls",
+            ),
+            ModelTurn(text="Skipped.", finish_reason="stop"),
+        ]
+    )
+    orchestrator = _approval_orchestrator(registry, approvals=ToolApprovalRegistry())
+
+    events = list(
+        orchestrator.stream(
+            backend=backend,
+            prompt="search",
+            user_id=1,
+            chat_id=None,
+            config=ModelRequestConfig(),
+            system_prompt=None,
+            interactive=False,
+        )
+    )
+
+    tool_states = [event.payload for event in events if event.event == "tool_call"]
+    assert [state.status for state in tool_states] == ["proposed", "failed"]
+    assert calls == []
+    tool_message = backend.requests[1]["messages"][-1]
+    assert "unattended" in tool_message["content"]

--- a/tests/services/test_execution_sessions.py
+++ b/tests/services/test_execution_sessions.py
@@ -1,0 +1,173 @@
+import subprocess
+from unittest.mock import call, patch
+
+from app.services.execution.docker import DockerExecutionEnvironment
+from app.services.execution.factory import create_session_manager
+from app.services.execution.session import (
+    DockerSessionManager,
+    build_session_create_args,
+    build_session_exec_args,
+    session_container_name,
+)
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_session_container_name_is_sanitized():
+    assert session_container_name("chat-7") == "geist-exec-chat-7"
+    assert session_container_name("a b/c$") == "geist-exec-a-b-c-"
+
+
+def test_session_create_args_keep_hardening_posture():
+    args = build_session_create_args(name="geist-exec-chat-7", image="python:3.11-slim")
+    joined = " ".join(args)
+    assert args[:4] == ["run", "--detach", "--name", "geist-exec-chat-7"]
+    assert "--cap-drop ALL" in joined
+    assert "no-new-privileges" in joined
+    assert "--user 65534:65534" in joined
+    assert "--network none" in joined
+    assert args[-2:] == ["sleep", "infinity"]
+
+
+def test_session_exec_args_bound_the_command():
+    args = build_session_exec_args(name="geist-exec-chat-7", command="echo hi", timeout=10)
+    assert args[:4] == ["exec", "--workdir", "/workspace", "geist-exec-chat-7"]
+    assert args[-1].startswith("timeout 10 bash -c ")
+
+
+def _manager(clock=None):
+    env = DockerExecutionEnvironment(runtime_path="/usr/bin/docker")
+    ticks = iter(range(0, 10_000))
+    return DockerSessionManager(
+        env, ttl_seconds=100.0, clock=clock or (lambda: next(ticks))
+    )
+
+
+def test_run_in_session_reuses_running_container():
+    manager = _manager()
+    responses = [
+        _completed(0, stdout="true\n"),  # inspect: running
+        _completed(0, stdout="hi\n"),  # exec
+    ]
+    with patch("subprocess.run", side_effect=responses) as mock_run:
+        result = manager.run_in_session("chat-7", "echo hi")
+
+    assert result.exit_code == 0
+    assert result.stdout == "hi\n"
+    first_argv = mock_run.call_args_list[0].args[0]
+    assert first_argv[:2] == ["/usr/bin/docker", "inspect"]
+    second_argv = mock_run.call_args_list[1].args[0]
+    assert second_argv[1] == "exec"
+
+
+def test_run_in_session_creates_container_when_missing():
+    manager = _manager()
+    responses = [
+        _completed(1, stderr="No such object"),  # inspect: absent
+        _completed(0, stdout="containerid\n"),  # run -d
+        _completed(0, stdout="done\n"),  # exec
+    ]
+    with patch("subprocess.run", side_effect=responses) as mock_run:
+        result = manager.run_in_session("chat-7", "echo done")
+
+    assert result.exit_code == 0
+    create_argv = mock_run.call_args_list[1].args[0]
+    assert create_argv[1] == "run"
+    assert "--detach" in create_argv
+    assert "geist-exec-chat-7" in create_argv
+
+
+def test_run_in_session_replaces_stopped_container():
+    manager = _manager()
+    responses = [
+        _completed(0, stdout="false\n"),  # inspect: exists, stopped
+        _completed(0),  # rm -f
+        _completed(0, stdout="containerid\n"),  # run -d
+        _completed(0, stdout="ok\n"),  # exec
+    ]
+    with patch("subprocess.run", side_effect=responses) as mock_run:
+        result = manager.run_in_session("chat-7", "echo ok")
+
+    assert result.exit_code == 0
+    rm_argv = mock_run.call_args_list[1].args[0]
+    assert rm_argv[1:3] == ["rm", "-f"]
+
+
+def test_create_failure_surfaces_as_error_result():
+    manager = _manager()
+    responses = [
+        _completed(1, stderr="No such object"),
+        _completed(125, stderr="image not found"),
+    ]
+    with patch("subprocess.run", side_effect=responses):
+        result = manager.run_in_session("chat-7", "echo hi")
+
+    assert result.exit_code == 125
+    assert "image not found" in result.stderr
+
+
+def test_idle_sessions_are_reaped_on_next_run():
+    now = {"value": 0.0}
+    manager = _manager(clock=lambda: now["value"])
+    exec_ok = [
+        _completed(0, stdout="true\n"),
+        _completed(0, stdout="a\n"),
+    ]
+    with patch("subprocess.run", side_effect=exec_ok):
+        manager.run_in_session("chat-1", "echo a")
+
+    # 500s later (ttl=100): running for chat-2 must reap chat-1's container.
+    now["value"] = 500.0
+    second = [
+        _completed(0),  # rm -f geist-exec-chat-1 (reap)
+        _completed(0, stdout="true\n"),  # inspect chat-2
+        _completed(0, stdout="b\n"),  # exec chat-2
+    ]
+    with patch("subprocess.run", side_effect=second) as mock_run:
+        manager.run_in_session("chat-2", "echo b")
+
+    reap_argv = mock_run.call_args_list[0].args[0]
+    assert reap_argv[1:3] == ["rm", "-f"]
+    assert "geist-exec-chat-1" in reap_argv
+
+
+def test_shutdown_removes_all_tracked_sessions():
+    manager = _manager()
+    with patch("subprocess.run", side_effect=[
+        _completed(0, stdout="true\n"),
+        _completed(0, stdout="a\n"),
+    ]):
+        manager.run_in_session("chat-1", "echo a")
+
+    with patch("subprocess.run", return_value=_completed(0)) as mock_run:
+        manager.shutdown()
+
+    assert mock_run.call_args_list == [
+        call(
+            ["/usr/bin/docker", "rm", "-f", "geist-exec-chat-1"],
+            capture_output=True,
+            text=True,
+        )
+    ]
+
+
+def test_factory_persistent_flag_gates_manager(monkeypatch):
+    docker_env = DockerExecutionEnvironment(runtime_path="/usr/bin/docker")
+
+    monkeypatch.delenv("GEIST_EXEC_PERSISTENT", raising=False)
+    assert create_session_manager(docker_env) is None
+
+    monkeypatch.setenv("GEIST_EXEC_PERSISTENT", "1")
+    manager = create_session_manager(docker_env)
+    assert isinstance(manager, DockerSessionManager)
+
+    monkeypatch.setenv("GEIST_EXEC_SESSION_TTL_SECONDS", "60")
+    assert create_session_manager(docker_env).ttl_seconds == 60.0
+
+    # Local backend never gets persistence.
+    from app.services.execution.local import LocalExecutionEnvironment
+
+    assert create_session_manager(LocalExecutionEnvironment()) is None
+    assert create_session_manager(None) is None

--- a/tests/services/test_routine_scheduler.py
+++ b/tests/services/test_routine_scheduler.py
@@ -1,0 +1,96 @@
+import datetime
+
+from app.models.database.agent_routine import AgentRoutineModel
+from app.services.routine_scheduler import RoutineScheduler
+
+
+def _routine(routine_id=1, name="digest") -> AgentRoutineModel:
+    now = datetime.datetime(2026, 8, 2, 12, 0, 0)
+    return AgentRoutineModel(
+        routine_id=routine_id,
+        user_id=1,
+        name=name,
+        prompt="Summarize the week",
+        interval_minutes=60,
+        enabled=True,
+        last_run_at=None,
+        next_run_at=now,
+        create_date=now,
+        update_date=now,
+    )
+
+
+def test_run_due_once_marks_before_running():
+    order = []
+    scheduler = RoutineScheduler(
+        runner=lambda routine: order.append(("run", routine.routine_id)),
+        due_loader=lambda: [_routine(1), _routine(2)],
+        run_marker=lambda routine_id: order.append(("mark", routine_id)),
+    )
+
+    ran = scheduler.run_due_once()
+
+    assert ran == 2
+    # mark-before-run: a crash mid-run delays the next occurrence instead of
+    # re-firing the same routine forever.
+    assert order == [("mark", 1), ("run", 1), ("mark", 2), ("run", 2)]
+
+
+def test_runner_failure_does_not_stop_other_routines():
+    ran = []
+
+    def flaky_runner(routine):
+        if routine.routine_id == 1:
+            raise RuntimeError("model unavailable")
+        ran.append(routine.routine_id)
+
+    scheduler = RoutineScheduler(
+        runner=flaky_runner,
+        due_loader=lambda: [_routine(1), _routine(2)],
+        run_marker=lambda routine_id: None,
+    )
+
+    assert scheduler.run_due_once() == 1
+    assert ran == [2]
+
+
+def test_mark_failure_skips_that_routine():
+    ran = []
+
+    def failing_marker(routine_id):
+        if routine_id == 1:
+            raise RuntimeError("db down")
+
+    scheduler = RoutineScheduler(
+        runner=lambda routine: ran.append(routine.routine_id),
+        due_loader=lambda: [_routine(1), _routine(2)],
+        run_marker=failing_marker,
+    )
+
+    assert scheduler.run_due_once() == 1
+    assert ran == [2]
+
+
+def test_due_loader_failure_is_contained():
+    def broken_loader():
+        raise RuntimeError("db down")
+
+    scheduler = RoutineScheduler(
+        runner=lambda routine: None,
+        due_loader=broken_loader,
+        run_marker=lambda routine_id: None,
+    )
+    assert scheduler.run_due_once() == 0
+
+
+def test_start_stop_lifecycle():
+    scheduler = RoutineScheduler(
+        runner=lambda routine: None,
+        poll_interval_seconds=3600,
+        due_loader=lambda: [],
+        run_marker=lambda routine_id: None,
+    )
+    scheduler.start()
+    assert scheduler._thread is not None and scheduler._thread.is_alive()
+    scheduler.stop(timeout=2)
+    assert scheduler._thread is None

--- a/tests/services/test_tool_approvals.py
+++ b/tests/services/test_tool_approvals.py
@@ -1,0 +1,99 @@
+import threading
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.services.tool_approvals import (
+    SessionGrantRegistry,
+    ToolApprovalRegistry,
+    persist_always_allow,
+)
+
+
+def test_resolve_unblocks_waiter_with_decision():
+    registry = ToolApprovalRegistry()
+    pending = registry.request("run_1", "call_1", "web.search")
+
+    resolver = threading.Timer(
+        0.05, lambda: registry.resolve("run_1", "call_1", "session")
+    )
+    resolver.start()
+    decision = registry.wait(pending, timeout_seconds=2.0)
+    assert decision == "session"
+    assert registry.has_pending("run_1") is False
+
+
+def test_wait_times_out_to_deny():
+    registry = ToolApprovalRegistry()
+    pending = registry.request("run_1", "call_1", "web.search")
+    assert registry.wait(pending, timeout_seconds=0.05) == "deny"
+    assert registry.has_pending("run_1") is False
+
+
+def test_wait_cancellation_denies():
+    registry = ToolApprovalRegistry()
+    pending = registry.request("run_1", "call_1", "web.search")
+    cancellation = threading.Event()
+    cancellation.set()
+    assert registry.wait(pending, timeout_seconds=5.0, cancellation=cancellation) == "deny"
+
+
+def test_resolve_unknown_call_returns_false_and_bad_decision_raises():
+    registry = ToolApprovalRegistry()
+    assert registry.resolve("run_x", "call_x", "approve") is False
+    registry.request("run_1", "call_1", "web.search")
+    with pytest.raises(ValueError):
+        registry.resolve("run_1", "call_1", "yolo")
+
+
+def test_cancel_run_denies_all_pending():
+    registry = ToolApprovalRegistry()
+    first = registry.request("run_1", "call_1", "a")
+    second = registry.request("run_1", "call_2", "b")
+    other = registry.request("run_2", "call_1", "c")
+
+    registry.cancel_run("run_1")
+    assert first.decision == "deny" and first.event.is_set()
+    assert second.decision == "deny" and second.event.is_set()
+    assert other.decision is None
+    assert registry.has_pending("run_2") is True
+
+
+def test_session_grants_are_scoped():
+    grants = SessionGrantRegistry()
+    grants.grant("chat:1", "web.search")
+    assert grants.granted("chat:1") == frozenset({"web.search"})
+    assert grants.granted("chat:2") == frozenset()
+    grants.clear("chat:1")
+    assert grants.granted("chat:1") == frozenset()
+
+
+def test_persist_always_allow_merges_into_settings():
+    stored = Mock(agent_permissions={"mode": "default", "always_allow": ["a.tool"]})
+    with (
+        patch(
+            "app.models.database.user_settings.get_user_settings", return_value=stored
+        ),
+        patch(
+            "app.models.database.user_settings.update_user_settings"
+        ) as mock_update,
+    ):
+        persist_always_allow(1, "web.search")
+
+    mock_update.assert_called_once_with(
+        1, {"agent_permissions": {"mode": "default", "always_allow": ["a.tool", "web.search"]}}
+    )
+
+
+def test_persist_always_allow_noop_when_already_listed():
+    stored = Mock(agent_permissions={"mode": "default", "always_allow": ["web.search"]})
+    with (
+        patch(
+            "app.models.database.user_settings.get_user_settings", return_value=stored
+        ),
+        patch(
+            "app.models.database.user_settings.update_user_settings"
+        ) as mock_update,
+    ):
+        persist_always_allow(1, "web.search")
+    mock_update.assert_not_called()


### PR DESCRIPTION
## Description

Third PR in the stack (**base: `claude/native-tool-execution-backend-ls4bxk`**, which sits on `claude/agent-permissions-auto-approve-ls4bxk`). Three features referenced from Hermes-agent, OpenClaw, and OpenCode, one commit each:

**1. Interactive tool approval resume loop** (`234e86a`) — `awaiting_approval` is no longer terminal. The orchestrator blocks the run on a gated tool call; the chat UI shows **Approve once / Allow for session / Always allow / Deny** buttons (OpenCode's permission→question→resume pattern, Hermes' decision tiers); `POST /agent/runs/{run_id}/tool_approval` resolves the wait and the run resumes and executes. "Session" records an in-memory per-chat grant, "always" persists onto `agent_permissions.always_allow`, deny/timeout feed the model a do-not-retry BLOCKED result. Waiting fails closed after a timeout — silence is not consent. `stream(interactive=False)` lets unattended callers deny gated tools immediately.

**2. Persistent per-chat sandbox sessions** (`3ab4ce5`) — `GEIST_EXEC_PERSISTENT` keeps one long-lived hardened container per chat (`docker exec` into a `sleep infinity` container with the same cap-drop/no-new-privileges/tmpfs/no-network posture), so `terminal.run` state survives between calls and install-then-use workflows work (Hermes `file_sync`/persistent-environment pattern). Stopped containers are replaced; idle sessions are reaped opportunistically after `GEIST_EXEC_SESSION_TTL_SECONDS` (default 1800).

**3. Scheduled agent routines** (`c6bacd5`) — `agent_routine` table + migration, a polling scheduler thread mirroring the JobWorker pattern, CRUD + `run_now` API under `/api/v1/routines`, and a Routines tab in Settings. Runs are non-interactive: approval-gated tools are denied (Hermes `cron_mode: deny` posture) and results persist as ordinary chat sessions. Routines are marked-before-run so a crash delays rather than re-fires.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Tests pass locally
- [x] Added new tests for new functionality
- [x] Updated existing tests

New backend tests: approval registry (8), orchestrator approve/deny/session/always/timeout/non-interactive flows (6), session manager container lifecycle + reaping (9), scheduler ordering and failure containment (5). New frontend tests: approval decision buttons, Routines section CRUD. Full backend suite: 502 passed, failure set byte-identical to base branch (pre-existing, require live Postgres). Frontend: 111 passed across 20 suites, `tsc --noEmit` clean.

## Security Checklist

- [x] Pre-commit security hooks pass locally
- [x] No secrets or credentials committed
- [x] Dependencies scanned for vulnerabilities (no dependencies added)
- [x] Code reviewed for security issues (SQL injection, XSS, etc.)
- [x] Input validation added where necessary (decision enum 422s; routine name/prompt/interval bounds via Pydantic)
- [x] Authentication/authorization properly implemented (routines are owner-scoped via the same default-user shim as user settings; approval decisions fail closed)
- [x] Sensitive data properly encrypted/protected (persistent sandboxes keep the empty-environment posture)

## Code Quality

- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable) — config documented in module docstrings
- [x] No unnecessary dependencies added

## CI/CD Pipeline

- [ ] All CI checks pass (pending)
- [x] Security scan results reviewed
- [x] No critical vulnerabilities introduced
- [x] Docker images build successfully (if applicable) — no image changes

## Additional Notes

Merge order: permissions PR → execution backend PR (#307) → this PR. Known limits worth flagging for review: session grants are in-memory (lost on restart — by design, matching Hermes' session tier); routine runs use the default user and active agent; a live Docker daemon wasn't available in the dev container, so persistent-session container lifecycle is verified against mocked runtime invocations, not a real daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2s3kephNqkwckrsebSrMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2s3kephNqkwckrsebSrMF)_