### PR TITLE
Add OpenRouter provider with Qwen 3.8 Max hosted model

### DIFF
--- a/agents/model_catalog.py
+++ b/agents/model_catalog.py
@@ -74,6 +74,9 @@ PROVIDERS: dict[str, ProviderSpec] = {
     "deepseek": ProviderSpec(
         "deepseek", "DeepSeek", "https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"
     ),
+    "openrouter": ProviderSpec(
+        "openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"
+    ),
     "self-hosted": ProviderSpec(
         "self-hosted",
         "Self-hosted OpenAI-compatible",
@@ -248,6 +251,14 @@ MODEL_SPECS: tuple[ModelSpec, ...] = (
         performance_note="Hosted alternative to running the 31B Flash checkpoint on your own server.",
     ),
     ModelSpec(
+        "qwen/qwen3.8-max", "Qwen 3.8 Max", "qwen", provider="openrouter",
+        backend="openai_compatible", context_window=1000000, max_output_tokens=131072,
+        supports_vision=True, supports_function_calling=True, supports_reasoning=True,
+        supports_streaming=True, recommended=True, parameter_count="2.4T",
+        activated_parameters="95B", local=False,
+        performance_note="Hosted-only flagship MoE; OpenRouter proxies Alibaba's endpoint until open weights ship.",
+    ),
+    ModelSpec(
         "deepseek-reasoner", "DeepSeek R1", "deepseek", provider="deepseek",
         backend="openai_compatible", context_window=131072, max_output_tokens=32768,
         supports_function_calling=True, supports_reasoning=True, supports_streaming=True,
@@ -275,6 +286,8 @@ def infer_model_spec(model_id: str) -> ModelSpec | None:
     # Map heavyweight Hugging Face repository IDs to their server-backed
     # catalog entries so they can never fall through to an accidental local
     # trillion-parameter load.
+    if "qwen3.8-max" in value:
+        return get_model_spec("qwen/qwen3.8-max")
     if "moonshotai/kimi-k2" in value:
         return get_model_spec("kimi-k2.5")
     if "zai-org/glm-5" in value:

--- a/agents/online_agent.py
+++ b/agents/online_agent.py
@@ -117,7 +117,13 @@ class OnlineAgent(BaseAgent):
         normalized_url = self.base_url.lower()
         return any(
             provider_host in normalized_url
-            for provider_host in ("openai.com", "anthropic.com", "groq.com", "api.x.ai")
+            for provider_host in (
+                "openai.com",
+                "anthropic.com",
+                "groq.com",
+                "api.x.ai",
+                "openrouter.ai",
+            )
         )
 
     def _get_api_key_from_env(self) -> str | None:

--- a/client/geist/src/Components/AgentConfigSection.tsx
+++ b/client/geist/src/Components/AgentConfigSection.tsx
@@ -21,6 +21,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   moonshot: 'Moonshot AI',
   zai: 'Z.AI',
   deepseek: 'DeepSeek',
+  openrouter: 'OpenRouter',
   'self-hosted': 'Self-hosted Server',
   offline: 'Local/Offline',
   custom: 'Custom Provider'

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -198,6 +198,7 @@ User settings control default agent behavior and can be configured via API:
 - `MOONSHOT_API_KEY` - Moonshot API key for Kimi models
 - `ZAI_API_KEY` - Z.AI API key for hosted GLM models
 - `DEEPSEEK_API_KEY` - DeepSeek API key
+- `OPENROUTER_API_KEY` - OpenRouter API key for aggregated hosted models (e.g. Qwen 3.8 Max)
 - `OPENAI_COMPATIBLE_BASE_URL` - Base `/v1` URL for a self-hosted inference server
 - `API_KEY` - Generic fallback API key
 

--- a/tests/agents/test_model_catalog.py
+++ b/tests/agents/test_model_catalog.py
@@ -58,6 +58,23 @@ def test_heavyweight_models_are_server_backed():
     assert hosted_glm.local is False
     assert get_provider_endpoint(hosted_glm.provider) == "https://api.z.ai/api/paas/v4"
 
+    qwen_max = get_model_spec("qwen/qwen3.8-max")
+    assert qwen_max.backend == "openai_compatible"
+    assert qwen_max.local is False
+    assert get_provider_endpoint(qwen_max.provider) == "https://openrouter.ai/api/v1"
+
+
+def test_qwen_max_id_variants_route_to_openrouter_not_local_qwen():
+    from agents.architectures.registry import get_all_models, provider_from_string
+
+    assert provider_from_string("openrouter") == "openrouter"
+    assert "openrouter" in get_all_models()
+
+    for model_id in ("qwen3.8-max", "alibaba/qwen3.8-max", "Qwen/Qwen3.8-Max"):
+        spec = infer_model_spec(model_id)
+        assert spec.provider == "openrouter"
+        assert spec.local is False
+
 
 @pytest.mark.parametrize("model_id", [
     "Qwen/Qwen2.5-3B-Instruct",
@@ -162,6 +179,8 @@ def test_existing_llama_id_preserves_optimized_runner():
     "openai/gpt-oss-120b",
     "zai-org/GLM-5.2",
     "deepseek-ai/DeepSeek-R1",
+    "qwen/qwen3.8-max",
+    "qwen3.8-max",
 ])
 def test_server_model_cannot_be_accidentally_loaded_locally(model_id):
     with pytest.raises(ValueError, match="server-backed"):
@@ -181,6 +200,14 @@ def test_hosted_glm_infers_zai_endpoint():
     with patch("agents.online_agent.OnlineAgent") as online_agent:
         AgentFactory.create_agent("online", context, model="glm-4.7-flash")
     assert online_agent.call_args.kwargs["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+@pytest.mark.parametrize("model_id", ["qwen/qwen3.8-max", "qwen3.8-max"])
+def test_qwen_max_infers_openrouter_endpoint(model_id):
+    context = MagicMock()
+    with patch("agents.online_agent.OnlineAgent") as online_agent:
+        AgentFactory.create_agent("online", context, model=model_id)
+    assert online_agent.call_args.kwargs["base_url"] == "https://openrouter.ai/api/v1"
 
 
 def test_self_hosted_model_requires_endpoint_or_environment():


### PR DESCRIPTION
## Description

Adds OpenRouter as an online inference provider and registers Qwen 3.8 Max (Alibaba's new 2.4T-parameter MoE flagship, GA August 3, 2026) as a hosted model routed through it.

- **`agents/model_catalog.py`**: new `openrouter` `ProviderSpec` (`https://openrouter.ai/api/v1`, `OPENROUTER_API_KEY`) and a `qwen/qwen3.8-max` `ModelSpec` — 1M-token context, 131K max output, vision + function calling + reasoning + streaming, 2.4T total / 95B activated parameters, server-backed via the `openai_compatible` backend. `infer_model_spec` now redirects alternate ids (`qwen3.8-max`, `alibaba/qwen3.8-max`) to the hosted entry so they can never fall through the generic `qwen` prefix map to an accidental local load.
- **`agents/online_agent.py`**: `openrouter.ai` recognized as a native tool-calling endpoint; the existing `PROVIDERS`-based env-key lookup picks up `OPENROUTER_API_KEY` automatically.
- **`client/geist/src/Components/AgentConfigSection.tsx`**: `OpenRouter` display name for the provider dropdown.
- **`docs/agents.md`**: documents `OPENROUTER_API_KEY`.

No new dependencies, enums, or runner changes — the catalog-driven registry merges the provider and model automatically.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Security fix

## Testing

Ran `uv run python -m pytest tests/agents/test_model_catalog.py` — all 47 tests pass. The full `tests/agents` suite shows the same 37 pre-existing failures/6 errors on a clean checkout of `main` (environment-dependent tests), with 5 additional passing tests from this branch.

- [x] Tests pass locally
- [x] Added new tests for new functionality
- [x] Updated existing tests

New coverage in `tests/agents/test_model_catalog.py`:
- OpenRouter endpoint resolution for `qwen/qwen3.8-max`
- Alternate model-id variants route to OpenRouter, not the local Qwen runner
- Server-backed guard: `qwen/qwen3.8-max` and `qwen3.8-max` cannot be loaded locally
- `AgentFactory.create_agent("online", ...)` infers the OpenRouter base URL

## Security Checklist

- [x] No secrets or credentials committed
- [x] Code reviewed for security issues (SQL injection, XSS, etc.)
- [ ] Pre-commit security hooks pass locally
- [ ] Dependencies scanned for vulnerabilities
- [x] Input validation added where necessary
- [ ] Authentication/authorization properly implemented
- [ ] Sensitive data properly encrypted/protected

## Code Quality

- [x] Code follows project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No unnecessary dependencies added

## CI/CD Pipeline

- [ ] All CI checks pass
- [ ] Security scan results reviewed
- [x] No critical vulnerabilities introduced
- [ ] Docker images build successfully (if applicable)

## Additional Notes

Qwen 3.8 Max is currently hosted-only: OpenRouter proxies Alibaba's endpoint (open weights are announced but not yet published), which is reflected in the model's `performance_note`. When the weights land, a self-hosted `ModelSpec` entry can be added alongside, mirroring the GLM 4.7 Flash hosted/self-hosted pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnTByb7uUqrojkQ9P5MdUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnTByb7uUqrojkQ9P5MdUg)_