### PR TITLE
Add generic host plugin runtime

### DIFF
--- a/client/geist/src/App.tsx
+++ b/client/geist/src/App.tsx
@@ -9,6 +9,7 @@ import Models from './Models';
 import Settings from './Settings';
 import { BrandingProvider } from './branding';
 import { UserSettingsProvider } from './Hooks/useUserSettings';
+import { GeistPluginHost } from './plugins/runtime';
 import './Motion.css';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
     <BrandingProvider>
       <UserSettingsProvider>
         <BrowserRouter>
+          <GeistPluginHost />
           <AppShell>
             <Routes>
               <Route path="/" element={<Navigate to="/chat" replace />} />

--- a/client/geist/src/Settings.css
+++ b/client/geist/src/Settings.css
@@ -465,6 +465,56 @@
   border-radius: var(--geist-radius-md);
 }
 
+.plugin-diagnostic-list {
+  display: grid;
+  gap: 10px;
+}
+
+.plugin-diagnostic-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px 14px;
+  padding: 12px;
+  background: var(--geist-color-surface-muted);
+  border: 1px solid var(--geist-color-border);
+  border-radius: var(--geist-radius-md);
+}
+
+.plugin-diagnostic-id {
+  display: block;
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+}
+
+.plugin-diagnostic-summary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.plugin-status {
+  padding: 3px 7px;
+  font-size: 0.7rem;
+  font-weight: 760;
+  text-transform: uppercase;
+  border: 1px solid var(--geist-color-border);
+  border-radius: 999px;
+}
+
+.plugin-status-active {
+  color: var(--geist-color-success);
+}
+
+.plugin-status-error,
+.plugin-diagnostic-error {
+  color: var(--geist-color-danger);
+}
+
+.plugin-diagnostic-error {
+  grid-column: 1 / -1;
+}
+
 .about-section {
   display: grid;
   gap: 18px;

--- a/client/geist/src/Settings.test.tsx
+++ b/client/geist/src/Settings.test.tsx
@@ -4,6 +4,11 @@ import Settings from './Settings';
 import { BrandingProvider } from './branding';
 import { UserSettingsProvider } from './Hooks/useUserSettings';
 import { installResizeObserverMock } from './testUtils/mockResizeObserver';
+import {
+  GEIST_HOST_DEVELOPMENT_UPDATED_EVENT,
+  GEIST_PLUGIN_API_VERSION,
+  geistPluginRuntime,
+} from './plugins/runtime';
 
 const baseSettings = {
   user_settings_id: 1,
@@ -72,6 +77,7 @@ describe('Settings page', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     delete window.__GEIST_BRANDING__;
+    delete window.__GEIST_HOST_DEVELOPMENT__;
     // @ts-ignore
     global.fetch = jest.fn();
   });
@@ -90,9 +96,46 @@ describe('Settings page', () => {
       expect(screen.getByRole('tab', { name: 'Generation' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Files and RAG' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Appearance' })).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: 'Developer' })).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Developer' })).not.toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
     });
+  });
+
+  it('shows active plugins only after an explicit host-development update', async () => {
+    // @ts-ignore
+    global.fetch = createFetchMock([{ ok: true, json: async () => baseSettings }]);
+    const unregister = geistPluginRuntime.register({
+      apiVersion: GEIST_PLUGIN_API_VERSION,
+      id: 'example.host-plugin',
+      name: 'Example Host Plugin',
+      provider: 'Example Host',
+      version: '1.2.3',
+      activate: () => undefined,
+    });
+
+    try {
+      renderSettings();
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('tab', { name: 'Developer' })).not.toBeInTheDocument();
+
+      act(() => {
+        window.__GEIST_HOST_DEVELOPMENT__ = true;
+        window.dispatchEvent(new Event(GEIST_HOST_DEVELOPMENT_UPDATED_EVENT));
+      });
+
+      fireEvent.click(await screen.findByRole('tab', { name: 'Developer' }));
+      expect(screen.getByRole('heading', { name: 'Active Plugins' })).toBeInTheDocument();
+      expect(screen.getByText('Example Host Plugin')).toBeInTheDocument();
+      expect(
+        screen.getByText('Example Host - example.host-plugin v1.2.3 - API 1')
+      ).toBeInTheDocument();
+      expect(screen.getByText('0/0 mounted')).toBeInTheDocument();
+      expect(screen.getByText('Last error: None')).toBeInTheDocument();
+    } finally {
+      act(() => unregister());
+    }
   });
 
   it('shows host, Geist, machine, and inference details on the About tab', async () => {

--- a/client/geist/src/Settings.tsx
+++ b/client/geist/src/Settings.tsx
@@ -8,6 +8,10 @@ import UIPreferencesSection from './Components/UIPreferencesSection';
 import SettingsSelect from './Components/SettingsSelect';
 import AboutSection from './Components/AboutSection';
 import useOverflowObserver from './Hooks/useOverflowObserver';
+import {
+  useGeistPluginDiagnostics,
+  useHostDevelopmentEnabled,
+} from './plugins/runtime';
 
 type Tab = 'general' | 'models' | 'generation' | 'rag' | 'ui' | 'developer' | 'about';
 
@@ -23,6 +27,8 @@ const Settings: React.FC = () => {
   const [localSettings, setLocalSettings] = useState<any>(null);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'success' | 'error'>('idle');
   const [statusMessage, setStatusMessage] = useState<string>('');
+  const hostDevelopmentEnabled = useHostDevelopmentEnabled();
+  const pluginDiagnostics = useGeistPluginDiagnostics();
   const {
     ref: settingsScrollRef,
     hasOverflow: hasSettingsScrollbar,
@@ -33,6 +39,12 @@ const Settings: React.FC = () => {
       setLocalSettings(settings);
     }
   }, [settings]);
+
+  useEffect(() => {
+    if (!hostDevelopmentEnabled && activeTab === 'developer') {
+      setActiveTab('general');
+    }
+  }, [activeTab, hostDevelopmentEnabled]);
 
   const updateLocalSetting = (key: string, value: any) => {
     setLocalSettings((prev: any) => ({
@@ -120,7 +132,9 @@ const Settings: React.FC = () => {
     { id: 'generation' as Tab, label: 'Generation' },
     { id: 'rag' as Tab, label: 'Files and RAG' },
     { id: 'ui' as Tab, label: 'Appearance' },
-    { id: 'developer' as Tab, label: 'Developer' },
+    ...(hostDevelopmentEnabled
+      ? [{ id: 'developer' as Tab, label: 'Developer' }]
+      : []),
     { id: 'about' as Tab, label: 'About' }
   ];
 
@@ -258,11 +272,11 @@ const Settings: React.FC = () => {
             />
           )}
 
-          {activeTab === 'developer' && (
+          {hostDevelopmentEnabled && activeTab === 'developer' && (
             <section className="settings-section">
               <header className="settings-section-header">
                 <h3>Developer</h3>
-                <p>Inspect host branding and runtime integration defaults.</p>
+                <p>Inspect host integration and plugins active in this page.</p>
               </header>
               <div className="settings-readonly-grid">
                 <div className="settings-readonly-item">
@@ -274,6 +288,47 @@ const Settings: React.FC = () => {
                   <span className="settings-description">Semantic CSS variables</span>
                 </div>
               </div>
+              <div className="settings-subsection-header">
+                <div>
+                  <h4>Active Plugins</h4>
+                  <p className="settings-description">
+                    Full-trust host plugins registered with host API 1.
+                  </p>
+                </div>
+                <span className="settings-value-pill">{pluginDiagnostics.length}</span>
+              </div>
+              {pluginDiagnostics.length === 0 ? (
+                <p className="settings-description">No host plugins are active.</p>
+              ) : (
+                <div className="plugin-diagnostic-list">
+                  {pluginDiagnostics.map((plugin) => {
+                    const mountedCount = plugin.contributions.filter(
+                      (contribution) => contribution.mounted
+                    ).length;
+                    return (
+                      <article className="plugin-diagnostic-item" key={plugin.id}>
+                        <div>
+                          <span className="settings-label">{plugin.name}</span>
+                          <span className="settings-description plugin-diagnostic-id">
+                            {plugin.provider} - {plugin.id} v{plugin.version} - API {plugin.apiVersion}
+                          </span>
+                        </div>
+                        <div className="plugin-diagnostic-summary">
+                          <span className={`plugin-status plugin-status-${plugin.status}`}>
+                            {plugin.status}
+                          </span>
+                          <span className="settings-description">
+                            {mountedCount}/{plugin.contributions.length} mounted
+                          </span>
+                        </div>
+                        <p className={`settings-description${plugin.lastError ? ' plugin-diagnostic-error' : ''}`}>
+                          Last error: {plugin.lastError ?? 'None'}
+                        </p>
+                      </article>
+                    );
+                  })}
+                </div>
+              )}
             </section>
           )}
 

--- a/client/geist/src/index.tsx
+++ b/client/geist/src/index.tsx
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { installGeistPluginRuntime } from './plugins/runtime';
+
+installGeistPluginRuntime();
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/client/geist/src/plugins/runtime.test.tsx
+++ b/client/geist/src/plugins/runtime.test.tsx
@@ -1,0 +1,417 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+  createGeistPluginRuntime,
+  GEIST_PLUGIN_API_VERSION,
+  GEIST_PLUGIN_RUNTIME_READY_EVENT,
+  GeistPluginContextV1,
+  GeistPluginV1,
+  useHostDevelopmentEnabled,
+} from './runtime';
+
+/* eslint-disable testing-library/no-node-access -- DOM ownership and cleanup are the API under test. */
+
+function pluginDefinition(
+  overrides: Partial<GeistPluginV1> = {}
+): GeistPluginV1 {
+  return {
+    apiVersion: GEIST_PLUGIN_API_VERSION,
+    id: 'example.plugin',
+    name: 'Example Plugin',
+    provider: 'Example Provider',
+    version: '1.0.0',
+    activate: () => undefined,
+    ...overrides,
+  };
+}
+
+describe('Geist plugin runtime', () => {
+  afterEach(() => {
+    delete window.__GEIST_PLUGIN_RUNTIME_V1__;
+    delete window.__GEIST_HOST_DEVELOPMENT__;
+    delete (window as unknown as { trustedTypes?: unknown }).trustedTypes;
+    jest.restoreAllMocks();
+  });
+
+  it('installs API v1 globally and announces readiness', () => {
+    const installation = createGeistPluginRuntime();
+    const listener = jest.fn();
+    window.addEventListener(GEIST_PLUGIN_RUNTIME_READY_EVENT, listener);
+
+    try {
+      installation.install();
+
+      expect(window.__GEIST_PLUGIN_RUNTIME_V1__).toBe(installation.runtime);
+      expect(installation.runtime.apiVersion).toBe(1);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({ apiVersion: 1 });
+    } finally {
+      window.removeEventListener(GEIST_PLUGIN_RUNTIME_READY_EVENT, listener);
+    }
+  });
+
+  it('exposes the exact approved V1 definition and activation context', () => {
+    const installation = createGeistPluginRuntime();
+    let activationContext: GeistPluginContextV1 | undefined;
+    const definition = pluginDefinition({
+      activate: (context) => {
+        activationContext = context;
+      },
+    });
+
+    expect(Object.keys(definition).sort()).toEqual([
+      'activate',
+      'apiVersion',
+      'id',
+      'name',
+      'provider',
+      'version',
+    ]);
+    installation.runtime.register(definition);
+
+    expect(Object.keys(activationContext ?? {}).sort()).toEqual([
+      'React',
+      'document',
+      'mountDom',
+      'mountReact',
+      'observeTargets',
+    ]);
+    expect(activationContext?.React).toBe(React);
+    expect(activationContext?.document).toBe(document);
+    expect('window' in (activationContext ?? {})).toBe(false);
+  });
+
+  it('mounts shared-React content before the Host boots and owns its cleanup', async () => {
+    const installation = createGeistPluginRuntime();
+    const target = document.createElement('div');
+    target.id = 'plugin-target';
+    document.body.appendChild(target);
+    const deactivate = jest.fn();
+
+    const unregister = installation.runtime.register(pluginDefinition({
+      activate: ({ React: HostReact, mountReact }) => {
+        mountReact(target, HostReact.createElement('button', null, 'Host control'));
+        return deactivate;
+      },
+    }));
+
+    render(<installation.Host />);
+
+    expect(await screen.findByRole('button', { name: 'Host control' })).toBeInTheDocument();
+    expect(target.querySelector(':scope > geist-plugin-surface')).not.toBeNull();
+    expect(installation.runtime.getDiagnostics()).toEqual([
+      expect.objectContaining({
+        id: 'example.plugin',
+        name: 'Example Plugin',
+        provider: 'Example Provider',
+        status: 'active',
+        contributions: [
+          expect.objectContaining({ kind: 'react', mounted: true }),
+        ],
+      }),
+    ]);
+
+    act(() => unregister());
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Host control' })).not.toBeInTheDocument();
+    });
+    expect(target.querySelector('geist-plugin-surface')).toBeNull();
+    expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts Nodes, DocumentFragments, and TrustedHTML while rejecting plain strings', () => {
+    const installation = createGeistPluginRuntime();
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const trustedHtml = {
+      toString: () => '<strong>Trusted host markup</strong>',
+    } as unknown as TrustedHTML;
+    Object.defineProperty(window, 'trustedTypes', {
+      configurable: true,
+      value: { isHTML: (value: unknown) => value === trustedHtml },
+    });
+
+    const unregister = installation.runtime.register(pluginDefinition({
+      activate: ({ document: pluginDocument, mountDom }) => {
+        const node = pluginDocument.createElement('span');
+        node.textContent = 'Node control';
+        mountDom(target, node);
+
+        const fragment = pluginDocument.createDocumentFragment();
+        const fragmentNode = pluginDocument.createElement('em');
+        fragmentNode.textContent = 'Fragment control';
+        fragment.appendChild(fragmentNode);
+        mountDom(target, fragment);
+        mountDom(target, trustedHtml);
+      },
+    }));
+
+    expect(target).toHaveTextContent('Node control');
+    expect(target).toHaveTextContent('Fragment control');
+    expect(target).toHaveTextContent('Trusted host markup');
+
+    act(() => unregister());
+    expect(target).toBeEmptyDOMElement();
+
+    const unsafe = createGeistPluginRuntime();
+    unsafe.runtime.register(pluginDefinition({
+      id: 'unsafe.plugin',
+      activate: ({ mountDom }) => {
+        mountDom(target, '<em>Unsafe string</em>' as unknown as TrustedHTML);
+      },
+    }));
+    expect(unsafe.runtime.getDiagnostics()[0]).toEqual(expect.objectContaining({
+      status: 'error',
+      error: expect.stringMatching(/Node, DocumentFragment, or TrustedHTML/u),
+    }));
+    expect(target).not.toHaveTextContent('Unsafe string');
+  });
+
+  it('mounts both shared-React and DOM content into ShadowRoot targets', async () => {
+    const installation = createGeistPluginRuntime();
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    document.body.appendChild(host);
+
+    const unregister = installation.runtime.register(pluginDefinition({
+      activate: ({ React: HostReact, document: pluginDocument, mountDom, mountReact }) => {
+        mountReact(shadow, HostReact.createElement('span', null, 'Shadow React'));
+        const node = pluginDocument.createElement('span');
+        node.textContent = 'Shadow DOM';
+        mountDom(shadow, node);
+      },
+    }));
+    render(<installation.Host />);
+
+    await waitFor(() => expect(shadow).toHaveTextContent('Shadow React'));
+    expect(shadow).toHaveTextContent('Shadow DOM');
+
+    act(() => unregister());
+    expect(shadow.childNodes).toHaveLength(0);
+  });
+
+  it('observes late and replacement targets and runs per-target cleanup', async () => {
+    const installation = createGeistPluginRuntime();
+    const callback = jest.fn();
+    const targetCleanup = jest.fn();
+
+    const unregister = installation.runtime.register(pluginDefinition({
+      activate: ({ React: HostReact, mountReact, observeTargets }) => {
+        let currentTarget: Element | undefined;
+        let unmount = (): void => undefined;
+        const clearTarget = (): void => {
+          if (currentTarget) {
+            targetCleanup(currentTarget);
+          }
+          currentTarget = undefined;
+          unmount();
+          unmount = () => undefined;
+        };
+        const stopObserving = observeTargets('#late-target', (targets) => {
+          callback(targets);
+          clearTarget();
+          currentTarget = targets[0];
+          if (currentTarget) {
+            unmount = mountReact(
+              currentTarget,
+              HostReact.createElement('span', null, 'Observed control')
+            );
+          }
+        });
+        return () => {
+          stopObserving();
+          clearTarget();
+        };
+      },
+    }));
+
+    render(<installation.Host />);
+    expect(installation.runtime.getDiagnostics()[0].contributions[0]).toEqual(
+      expect.objectContaining({ kind: 'observe', mounted: false })
+    );
+    expect(callback).toHaveBeenCalledWith([]);
+    expect(Object.isFrozen(callback.mock.calls[0][0])).toBe(true);
+
+    const first = document.createElement('div');
+    first.id = 'late-target';
+    act(() => document.body.appendChild(first));
+    expect(await screen.findByText('Observed control')).toBeInTheDocument();
+    expect(callback).toHaveBeenCalledWith([first]);
+
+    const replacement = document.createElement('div');
+    replacement.id = 'late-target';
+    act(() => first.replaceWith(replacement));
+    await waitFor(() => {
+      expect(callback).toHaveBeenCalledWith([replacement]);
+    });
+    expect(targetCleanup).toHaveBeenCalledWith(first);
+    expect(replacement.querySelector('geist-plugin-surface')).not.toBeNull();
+
+    act(() => unregister());
+    expect(targetCleanup).toHaveBeenCalledWith(replacement);
+    expect(replacement.querySelector('geist-plugin-surface')).toBeNull();
+  });
+
+  it('isolates activation, observation, and React render failures', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const installation = createGeistPluginRuntime();
+    const target = document.createElement('div');
+    target.id = 'error-target';
+    document.body.appendChild(target);
+
+    installation.runtime.register(pluginDefinition({
+      id: 'broken.activation',
+      name: 'Broken activation',
+      activate: () => {
+        throw new Error('activation failed');
+      },
+    }));
+    installation.runtime.register(pluginDefinition({
+      id: 'broken.observe',
+      name: 'Broken observer',
+      activate: ({ observeTargets }) => {
+        observeTargets('#error-target', () => {
+          throw new Error('observer failed');
+        });
+      },
+    }));
+    installation.runtime.register(pluginDefinition({
+      id: 'broken.render',
+      name: 'Broken render',
+      activate: ({ React: HostReact, mountReact }) => {
+        const Broken = () => {
+          throw new Error('render failed');
+        };
+        mountReact(target, HostReact.createElement(Broken));
+      },
+    }));
+    installation.runtime.register(pluginDefinition({
+      id: 'healthy.plugin',
+      name: 'Healthy plugin',
+      activate: ({ React: HostReact, mountReact }) => {
+        mountReact(target, HostReact.createElement('span', null, 'Healthy control'));
+      },
+    }));
+
+    render(<installation.Host />);
+    expect(await screen.findByText('Healthy control')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        installation.runtime.getDiagnostics().find((item) => item.id === 'broken.render')
+      ).toEqual(expect.objectContaining({ status: 'error' }));
+    });
+    expect(
+      installation.runtime.getDiagnostics().find((item) => item.id === 'broken.activation')
+    ).toEqual(expect.objectContaining({ status: 'error', error: 'activation failed' }));
+    expect(
+      installation.runtime.getDiagnostics().find((item) => item.id === 'broken.observe')
+    ).toEqual(expect.objectContaining({ status: 'error' }));
+  });
+
+  it('isolates diagnostics subscribers from registration and cleanup', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const installation = createGeistPluginRuntime();
+    const healthyListener = jest.fn();
+    const unsubscribeBroken = installation.runtime.subscribeDiagnostics(() => {
+      throw new Error('subscriber failed');
+    });
+    const unsubscribeHealthy = installation.runtime.subscribeDiagnostics(healthyListener);
+
+    let unregister: (() => void) | undefined;
+    expect(() => {
+      unregister = installation.runtime.register(pluginDefinition());
+    }).not.toThrow();
+    expect(unregister).toEqual(expect.any(Function));
+    expect(healthyListener).toHaveBeenCalledTimes(1);
+    expect(installation.runtime.getDiagnostics()).toHaveLength(1);
+
+    expect(() => unregister?.()).not.toThrow();
+    expect(healthyListener).toHaveBeenCalledTimes(2);
+    expect(installation.runtime.getDiagnostics()).toHaveLength(0);
+    expect(() => installation.runtime.register(pluginDefinition())).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Geist plugin diagnostics listener failed:',
+      expect.any(Error)
+    );
+
+    unsubscribeBroken();
+    unsubscribeHealthy();
+  });
+
+  it('detects a host-development change made before subscription is attached', async () => {
+    const DevelopmentStatus = () => (
+      <span>{useHostDevelopmentEnabled() ? 'Development enabled' : 'Development disabled'}</span>
+    );
+    const EnableBeforePassiveEffects = () => {
+      React.useLayoutEffect(() => {
+        window.__GEIST_HOST_DEVELOPMENT__ = true;
+      }, []);
+      return null;
+    };
+
+    render(
+      <>
+        <DevelopmentStatus />
+        <EnableBeforePassiveEffects />
+      </>
+    );
+
+    expect(await screen.findByText('Development enabled')).toBeInTheDocument();
+  });
+
+  it('retains a read-only last error after an observation recovers', async () => {
+    const installation = createGeistPluginRuntime();
+    const first = document.createElement('div');
+    first.id = 'recover-target';
+    document.body.appendChild(first);
+    let fail = true;
+
+    installation.runtime.register(pluginDefinition({
+      activate: ({ observeTargets }) => {
+        observeTargets('#recover-target', () => {
+          if (fail) {
+            throw new Error('temporary target failure');
+          }
+        });
+      },
+    }));
+    expect(installation.runtime.getDiagnostics()[0]).toEqual(expect.objectContaining({
+      status: 'error',
+      lastError: 'temporary target failure',
+    }));
+
+    fail = false;
+    const replacement = document.createElement('div');
+    replacement.id = 'recover-target';
+    act(() => first.replaceWith(replacement));
+
+    await waitFor(() => {
+      expect(installation.runtime.getDiagnostics()[0]).toEqual(expect.objectContaining({
+        status: 'active',
+        lastError: 'temporary target failure',
+      }));
+    });
+    expect(() => {
+      (installation.runtime.getDiagnostics()[0] as { lastError?: string }).lastError = 'changed';
+    }).toThrow();
+  });
+
+  it('rejects duplicate plugins, the old ABI, and unsupported API versions', () => {
+    const installation = createGeistPluginRuntime();
+    installation.runtime.register(pluginDefinition());
+
+    expect(() => installation.runtime.register(pluginDefinition())).toThrow(/already registered/u);
+    expect(() => installation.runtime.register(pluginDefinition({
+      id: 'future.plugin',
+      apiVersion: 2 as 1,
+    }))).toThrow(/Unsupported Geist plugin API/u);
+    expect(() => installation.runtime.register({
+      protocolVersion: 1,
+      id: 'old.plugin',
+      displayName: 'Old Plugin',
+      provider: 'Old Provider',
+      version: '1.0.0',
+      activate: () => ({ contributions: [] }),
+    } as unknown as GeistPluginV1)).toThrow(/Unsupported Geist plugin API/u);
+  });
+});

--- a/client/geist/src/plugins/runtime.tsx
+++ b/client/geist/src/plugins/runtime.tsx
@@ -1,0 +1,657 @@
+import React, {
+  Component,
+  ErrorInfo,
+  ReactNode,
+  useSyncExternalStore,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+export const GEIST_PLUGIN_API_VERSION = 1 as const;
+export const GEIST_PLUGIN_RUNTIME_READY_EVENT = 'geist-plugin-runtime-ready';
+export const GEIST_HOST_DEVELOPMENT_UPDATED_EVENT = 'geist-host-development-updated';
+
+export interface GeistPluginContextV1 {
+  React: typeof React;
+  document: Document;
+  mountReact: (target: Element | ShadowRoot, content: ReactNode) => () => void;
+  mountDom: (
+    target: Element | ShadowRoot,
+    content: Node | DocumentFragment | TrustedHTML
+  ) => () => void;
+  observeTargets: (
+    selector: string,
+    callback: (targets: readonly Element[]) => void
+  ) => () => void;
+}
+
+export type GeistPluginActivationContextV1 = GeistPluginContextV1;
+
+export interface GeistPluginV1 {
+  apiVersion: typeof GEIST_PLUGIN_API_VERSION;
+  id: string;
+  name: string;
+  provider: string;
+  version: string;
+  activate: (context: GeistPluginContextV1) => void | (() => void);
+}
+
+export type GeistPluginDefinitionV1 = GeistPluginV1;
+
+export type GeistPluginDiagnosticStatusV1 = 'active' | 'error';
+export type GeistPluginContributionKindV1 = 'react' | 'dom' | 'observe';
+
+export interface GeistPluginContributionDiagnosticV1 {
+  readonly id: string;
+  readonly kind: GeistPluginContributionKindV1;
+  readonly mounted: boolean;
+  readonly error?: string;
+}
+
+export interface GeistPluginDiagnosticV1 {
+  readonly apiVersion: typeof GEIST_PLUGIN_API_VERSION;
+  readonly id: string;
+  readonly name: string;
+  readonly provider: string;
+  readonly version: string;
+  readonly status: GeistPluginDiagnosticStatusV1;
+  readonly error?: string;
+  readonly lastError?: string;
+  readonly contributions: readonly GeistPluginContributionDiagnosticV1[];
+}
+
+export interface GeistPluginRuntimeV1 {
+  readonly apiVersion: typeof GEIST_PLUGIN_API_VERSION;
+  register: (definition: GeistPluginDefinitionV1) => () => void;
+  getDiagnostics: () => readonly GeistPluginDiagnosticV1[];
+  subscribeDiagnostics: (listener: () => void) => () => void;
+}
+
+interface PluginRuntimeEnvironment {
+  window: Window & typeof globalThis;
+  document: Document;
+}
+
+interface PluginOperation {
+  id: string;
+  kind: GeistPluginContributionKindV1;
+  isMounted: () => boolean;
+  error?: string;
+}
+
+interface ReactMount {
+  id: string;
+  pluginId: string;
+  content: ReactNode;
+  surface: HTMLElement;
+}
+
+interface RegisteredPlugin {
+  definition: GeistPluginDefinitionV1;
+  activationCleanup?: () => void;
+  activationError?: string;
+  lastError?: string;
+  operationSequence: number;
+  operations: Map<string, PluginOperation>;
+  reactMounts: Map<string, ReactMount>;
+  resources: Set<() => void>;
+  active: boolean;
+}
+
+export interface GeistPluginRuntimeInstallation {
+  runtime: GeistPluginRuntimeV1;
+  Host: React.FC;
+  install: () => void;
+}
+
+declare global {
+  interface Window {
+    __GEIST_PLUGIN_RUNTIME_V1__?: GeistPluginRuntimeV1;
+    __GEIST_HOST_DEVELOPMENT__?: boolean;
+  }
+}
+
+class PluginRuntimeStore {
+  private readonly plugins = new Map<string, RegisteredPlugin>();
+  private readonly listeners = new Set<() => void>();
+  private revision = 0;
+  private diagnosticsSnapshot: readonly GeistPluginDiagnosticV1[] = Object.freeze([]);
+
+  constructor(private readonly environment: PluginRuntimeEnvironment) {}
+
+  register = (definition: GeistPluginDefinitionV1): (() => void) => {
+    validateDefinition(definition);
+    const stableDefinition: GeistPluginDefinitionV1 = Object.freeze({
+      apiVersion: definition.apiVersion,
+      id: definition.id,
+      name: definition.name,
+      provider: definition.provider,
+      version: definition.version,
+      activate: definition.activate,
+    });
+    if (this.plugins.has(stableDefinition.id)) {
+      throw new Error(`Geist plugin "${stableDefinition.id}" is already registered.`);
+    }
+
+    const plugin: RegisteredPlugin = {
+      definition: stableDefinition,
+      operationSequence: 0,
+      operations: new Map(),
+      reactMounts: new Map(),
+      resources: new Set(),
+      active: true,
+    };
+    this.plugins.set(stableDefinition.id, plugin);
+
+    try {
+      const cleanup = stableDefinition.activate(this.createActivationContext(plugin));
+      if (cleanup !== undefined && typeof cleanup !== 'function') {
+        throw new Error(
+          `Geist plugin "${stableDefinition.id}" must return void or a cleanup function from activate.`
+        );
+      }
+      plugin.activationCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+    } catch (error) {
+      plugin.activationError = getErrorMessage(error);
+      plugin.lastError = plugin.activationError;
+      plugin.active = false;
+      this.disposeResources(plugin);
+    }
+
+    this.emit();
+    let unregistered = false;
+    return () => {
+      if (unregistered) {
+        return;
+      }
+      unregistered = true;
+
+      const current = this.plugins.get(stableDefinition.id);
+      if (current !== plugin) {
+        return;
+      }
+
+      plugin.active = false;
+      this.plugins.delete(stableDefinition.id);
+      try {
+        plugin.activationCleanup?.();
+      } catch (error) {
+        console.error(`Failed to deactivate Geist plugin "${stableDefinition.id}":`, error);
+      }
+      this.disposeResources(plugin);
+      this.emit();
+    };
+  };
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getRevision = (): number => this.revision;
+
+  getDiagnostics = (): readonly GeistPluginDiagnosticV1[] => this.diagnosticsSnapshot;
+
+  getReactMounts(): readonly ReactMount[] {
+    const mounts: ReactMount[] = [];
+    this.plugins.forEach((plugin) => {
+      plugin.reactMounts.forEach((mount) => mounts.push(mount));
+    });
+    return mounts;
+  }
+
+  reportReactError(pluginId: string, operationId: string, error: unknown): void {
+    const plugin = this.plugins.get(pluginId);
+    const operation = plugin?.operations.get(operationId);
+    if (!plugin || !operation) {
+      return;
+    }
+    this.setOperationError(plugin, operation, error);
+    this.emit();
+  }
+
+  private createActivationContext(plugin: RegisteredPlugin): GeistPluginContextV1 {
+    return Object.freeze({
+      React,
+      document: this.environment.document,
+      mountReact: (target: Element | ShadowRoot, content: ReactNode) =>
+        this.mountReact(plugin, target, content),
+      mountDom: (
+        target: Element | ShadowRoot,
+        content: Node | DocumentFragment | TrustedHTML
+      ) => this.mountDom(plugin, target, content),
+      observeTargets: (
+        selector: string,
+        callback: (targets: readonly Element[]) => void
+      ) => this.observeTargets(plugin, selector, callback),
+    });
+  }
+
+  private mountReact(
+    plugin: RegisteredPlugin,
+    target: Element | ShadowRoot,
+    content: ReactNode
+  ): () => void {
+    this.assertPluginActive(plugin);
+    this.assertTarget(target);
+
+    const surface = this.environment.document.createElement('geist-plugin-surface');
+    const operation = this.createOperation(plugin, 'react', () => surface.isConnected);
+    surface.dataset.geistPluginId = plugin.definition.id;
+    surface.dataset.geistPluginOperationId = operation.id;
+
+    try {
+      target.appendChild(surface);
+    } catch (error) {
+      plugin.operations.delete(operation.id);
+      throw error;
+    }
+
+    plugin.reactMounts.set(operation.id, {
+      id: operation.id,
+      pluginId: plugin.definition.id,
+      content,
+      surface,
+    });
+    this.emit();
+
+    return this.trackResource(plugin, () => {
+      plugin.reactMounts.delete(operation.id);
+      plugin.operations.delete(operation.id);
+      surface.remove();
+      this.emit();
+    });
+  }
+
+  private mountDom(
+    plugin: RegisteredPlugin,
+    target: Element | ShadowRoot,
+    content: Node | DocumentFragment | TrustedHTML
+  ): () => void {
+    this.assertPluginActive(plugin);
+    this.assertTarget(target);
+
+    if (typeof content === 'string') {
+      throw new Error('mountDom requires a Node, DocumentFragment, or TrustedHTML object.');
+    }
+
+    let mountedNodes: Node[] = [];
+    const operation = this.createOperation(
+      plugin,
+      'dom',
+      () => mountedNodes.some((node) => node.isConnected)
+    );
+
+    try {
+      if (content instanceof this.environment.window.Node) {
+        mountedNodes = content instanceof this.environment.window.DocumentFragment
+          ? Array.from(content.childNodes)
+          : [content];
+        target.appendChild(content);
+      } else if (isTrustedHtml(this.environment, content)) {
+        const surface = this.environment.document.createElement('geist-plugin-surface');
+        surface.dataset.geistPluginId = plugin.definition.id;
+        surface.dataset.geistPluginOperationId = operation.id;
+        surface.innerHTML = content as unknown as string;
+        target.appendChild(surface);
+        mountedNodes = [surface];
+      } else {
+        throw new Error('mountDom requires a Node, DocumentFragment, or TrustedHTML object.');
+      }
+    } catch (error) {
+      plugin.operations.delete(operation.id);
+      mountedNodes.forEach(removeNode);
+      throw error;
+    }
+
+    this.emit();
+    return this.trackResource(plugin, () => {
+      plugin.operations.delete(operation.id);
+      mountedNodes.forEach(removeNode);
+      this.emit();
+    });
+  }
+
+  private observeTargets(
+    plugin: RegisteredPlugin,
+    selector: string,
+    callback: (targets: readonly Element[]) => void
+  ): () => void {
+    this.assertPluginActive(plugin);
+    validateNonEmptyString(selector, 'Target selector');
+    if (typeof callback !== 'function') {
+      throw new Error('observeTargets requires a callback function.');
+    }
+
+    // Validate the selector synchronously so registration fails deterministically.
+    this.environment.document.querySelectorAll(selector);
+
+    let currentTargets: readonly Element[] = Object.freeze([]);
+    let initialized = false;
+    const operation = this.createOperation(
+      plugin,
+      'observe',
+      () => currentTargets.length > 0
+    );
+
+    const scan = (): void => {
+      if (!plugin.active) {
+        return;
+      }
+
+      const nextTargets = Array.from(
+        this.environment.document.querySelectorAll(selector)
+      );
+      if (initialized && sameTargets(currentTargets, nextTargets)) {
+        return;
+      }
+      initialized = true;
+      currentTargets = Object.freeze(nextTargets);
+
+      try {
+        const result = callback(currentTargets);
+        if (result !== undefined) {
+          throw new Error('observeTargets callbacks must return void.');
+        }
+        this.setOperationError(plugin, operation, undefined);
+      } catch (error) {
+        this.setOperationError(plugin, operation, error);
+      }
+      this.emit();
+    };
+
+    const observer = new this.environment.window.MutationObserver(scan);
+    const observationRoot = this.environment.document.documentElement ?? this.environment.document;
+    observer.observe(observationRoot, { attributes: true, childList: true, subtree: true });
+    scan();
+
+    return this.trackResource(plugin, () => {
+      observer.disconnect();
+      currentTargets = Object.freeze([]);
+      plugin.operations.delete(operation.id);
+      this.emit();
+    });
+  }
+
+  private createOperation(
+    plugin: RegisteredPlugin,
+    kind: GeistPluginContributionKindV1,
+    isMounted: () => boolean
+  ): PluginOperation {
+    plugin.operationSequence += 1;
+    const operation: PluginOperation = {
+      id: `${kind}-${plugin.operationSequence}`,
+      kind,
+      isMounted,
+    };
+    plugin.operations.set(operation.id, operation);
+    return operation;
+  }
+
+  private trackResource(plugin: RegisteredPlugin, cleanup: () => void): () => void {
+    let active = true;
+    const trackedCleanup = (): void => {
+      if (!active) {
+        return;
+      }
+      active = false;
+      plugin.resources.delete(trackedCleanup);
+      cleanup();
+    };
+    plugin.resources.add(trackedCleanup);
+    return trackedCleanup;
+  }
+
+  private disposeResources(plugin: RegisteredPlugin): void {
+    Array.from(plugin.resources).reverse().forEach((cleanup) => {
+      try {
+        cleanup();
+      } catch (error) {
+        console.error(`Failed to clean up Geist plugin "${plugin.definition.id}":`, error);
+      }
+    });
+  }
+
+  private assertPluginActive(plugin: RegisteredPlugin): void {
+    if (!plugin.active || this.plugins.get(plugin.definition.id) !== plugin) {
+      throw new Error(`Geist plugin "${plugin.definition.id}" is not active.`);
+    }
+  }
+
+  private assertTarget(target: Element | ShadowRoot): void {
+    const isElement = target instanceof this.environment.window.Element;
+    const isShadowRoot =
+      typeof this.environment.window.ShadowRoot !== 'undefined' &&
+      target instanceof this.environment.window.ShadowRoot;
+    if (!isElement && !isShadowRoot) {
+      throw new Error(
+        'Plugin mount targets must be Element or ShadowRoot objects from the host document.'
+      );
+    }
+    if (target.ownerDocument !== this.environment.document) {
+      throw new Error('Plugin mount targets must belong to the host document.');
+    }
+  }
+
+  private setOperationError(
+    plugin: RegisteredPlugin,
+    operation: PluginOperation,
+    error: unknown
+  ): void {
+    const nextError = error === undefined ? undefined : getErrorMessage(error);
+    if (operation.error === nextError) {
+      return;
+    }
+    operation.error = nextError;
+    if (nextError) {
+      plugin.lastError = nextError;
+    }
+  }
+
+  private emit(): void {
+    this.revision += 1;
+    this.diagnosticsSnapshot = Object.freeze(
+      Array.from(this.plugins.values(), (plugin): GeistPluginDiagnosticV1 => {
+        const contributions = Object.freeze(
+          Array.from(plugin.operations.values(), (operation) => Object.freeze({
+            id: operation.id,
+            kind: operation.kind,
+            mounted: safelyReadMounted(operation),
+            ...(operation.error ? { error: operation.error } : {}),
+          }))
+        );
+        return Object.freeze({
+          apiVersion: GEIST_PLUGIN_API_VERSION,
+          id: plugin.definition.id,
+          name: plugin.definition.name,
+          provider: plugin.definition.provider,
+          version: plugin.definition.version,
+          status:
+            plugin.activationError || contributions.some((item) => item.error)
+              ? 'error'
+              : 'active',
+          ...(plugin.activationError ? { error: plugin.activationError } : {}),
+          ...(plugin.lastError ? { lastError: plugin.lastError } : {}),
+          contributions,
+        });
+      })
+    );
+    Array.from(this.listeners).forEach((listener) => {
+      try {
+        listener();
+      } catch (error) {
+        console.error('Geist plugin diagnostics listener failed:', error);
+      }
+    });
+  }
+}
+
+class PluginMountErrorBoundary extends Component<
+  { children: ReactNode; onError: (error: unknown) => void },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, _info: ErrorInfo): void {
+    this.props.onError(error);
+  }
+
+  render(): ReactNode {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+function validateDefinition(definition: GeistPluginDefinitionV1): void {
+  if (!definition || definition.apiVersion !== GEIST_PLUGIN_API_VERSION) {
+    throw new Error(
+      `Unsupported Geist plugin API. Expected ${GEIST_PLUGIN_API_VERSION}.`
+    );
+  }
+  const expectedKeys = ['activate', 'apiVersion', 'id', 'name', 'provider', 'version'];
+  const actualKeys = Object.keys(definition).sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    throw new Error('Geist plugin definitions must contain exactly the V1 fields.');
+  }
+  validateNonEmptyString(definition.id, 'Plugin id');
+  validateNonEmptyString(definition.name, 'Plugin name');
+  validateNonEmptyString(definition.provider, 'Plugin provider');
+  validateNonEmptyString(definition.version, 'Plugin version');
+  if (typeof definition.activate !== 'function') {
+    throw new Error(`Geist plugin "${definition.id}" must provide an activate function.`);
+  }
+}
+
+function validateNonEmptyString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+}
+
+function isTrustedHtml(
+  environment: PluginRuntimeEnvironment,
+  content: unknown
+): content is TrustedHTML {
+  if (!content || typeof content !== 'object') {
+    return false;
+  }
+
+  const trustedTypes = (environment.window as unknown as {
+    trustedTypes?: { isHTML?: (value: unknown) => boolean };
+  }).trustedTypes;
+  return trustedTypes?.isHTML?.(content) === true;
+}
+
+function safelyReadMounted(operation: PluginOperation): boolean {
+  try {
+    return operation.isMounted();
+  } catch {
+    return false;
+  }
+}
+
+function sameTargets(
+  current: readonly Element[],
+  next: readonly Element[]
+): boolean {
+  return current.length === next.length && current.every((target, index) => target === next[index]);
+}
+
+function removeNode(node: Node): void {
+  node.parentNode?.removeChild(node);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createGeistPluginRuntime(
+  environment: PluginRuntimeEnvironment = { window, document }
+): GeistPluginRuntimeInstallation {
+  const store = new PluginRuntimeStore(environment);
+  const runtime: GeistPluginRuntimeV1 = Object.freeze({
+    apiVersion: GEIST_PLUGIN_API_VERSION,
+    register: store.register,
+    getDiagnostics: store.getDiagnostics,
+    subscribeDiagnostics: store.subscribe,
+  });
+
+  const Host: React.FC = () => {
+    useSyncExternalStore(store.subscribe, store.getRevision, store.getRevision);
+
+    return (
+      <>
+        {store.getReactMounts().map((mount) =>
+          createPortal(
+            <PluginMountErrorBoundary
+              key={mount.id}
+              onError={(error) => store.reportReactError(mount.pluginId, mount.id, error)}
+            >
+              {mount.content}
+            </PluginMountErrorBoundary>,
+            mount.surface,
+            `${mount.pluginId}:${mount.id}`
+          )
+        )}
+      </>
+    );
+  };
+
+  const install = () => {
+    const existing = environment.window.__GEIST_PLUGIN_RUNTIME_V1__;
+    if (existing && existing !== runtime) {
+      throw new Error('A different Geist plugin runtime v1 is already installed.');
+    }
+    if (!existing) {
+      Object.defineProperty(environment.window, '__GEIST_PLUGIN_RUNTIME_V1__', {
+        configurable: true,
+        enumerable: false,
+        value: runtime,
+        writable: false,
+      });
+    }
+    environment.window.dispatchEvent(
+      new environment.window.CustomEvent(GEIST_PLUGIN_RUNTIME_READY_EVENT, {
+        detail: { apiVersion: GEIST_PLUGIN_API_VERSION },
+      })
+    );
+  };
+
+  return { runtime, Host, install };
+}
+
+const defaultInstallation = createGeistPluginRuntime();
+
+export const geistPluginRuntime = defaultInstallation.runtime;
+export const GeistPluginHost = defaultInstallation.Host;
+export const installGeistPluginRuntime = defaultInstallation.install;
+
+export function isHostDevelopmentEnabled(): boolean {
+  return window.__GEIST_HOST_DEVELOPMENT__ === true;
+}
+
+function subscribeHostDevelopment(listener: () => void): () => void {
+  window.addEventListener(GEIST_HOST_DEVELOPMENT_UPDATED_EVENT, listener);
+  return () => window.removeEventListener(GEIST_HOST_DEVELOPMENT_UPDATED_EVENT, listener);
+}
+
+export function useHostDevelopmentEnabled(): boolean {
+  return useSyncExternalStore(
+    subscribeHostDevelopment,
+    isHostDevelopmentEnabled,
+    () => false
+  );
+}
+
+export function useGeistPluginDiagnostics(): readonly GeistPluginDiagnosticV1[] {
+  return useSyncExternalStore(
+    geistPluginRuntime.subscribeDiagnostics,
+    geistPluginRuntime.getDiagnostics,
+    geistPluginRuntime.getDiagnostics
+  );
+}


### PR DESCRIPTION
## Summary

- add a product-neutral, versioned host plugin runtime at the Geist React root
- support React portals, DOM and TrustedHTML contributions, target observation, cleanup, diagnostics, and error isolation
- hide Developer settings unless the host explicitly enables development mode, and show active-plugin diagnostics there
- add focused runtime and settings coverage, including the two lifecycle races found during independent review

## Testing

- npx tsc --noEmit
- npx eslint src/plugins/runtime.tsx src/plugins/runtime.test.tsx src/App.tsx src/index.tsx src/Settings.tsx
- CI=true npm test -- --watchAll=false --runInBand src/plugins/runtime.test.tsx src/Settings.test.tsx
- CI=true npm run build